### PR TITLE
Use warnings-as-errors and high warning levels

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,10 @@ option(BUILD_DEMO "Build demo" OFF)
 
 set(CMAKE_CXX_STANDARD 11)
 
+if(MSVC)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /W4 /WX")
+endif(MSVC)
+
 set(SOURCES
     src/meshoptimizer.hpp
     src/indexgenerator.cpp

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ OBJECTS=$(SOURCES:%=$(BUILD)/%.o)
 
 EXECUTABLE=$(BUILD)/meshoptimizer
 
-CXXFLAGS=-g -Wall -Wextra -Werror -std=c++11 -O3 -DNDEBUG
+CXXFLAGS=-g -Wall -Wextra -Wno-missing-field-initializers -Werror -std=c++11 -O3 -DNDEBUG
 LDFLAGS=
 
 all: $(EXECUTABLE)

--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,8 @@ OBJECTS=$(SOURCES:%=$(BUILD)/%.o)
 
 EXECUTABLE=$(BUILD)/meshoptimizer
 
-CXXFLAGS=-g -Wall -std=c++11 -O3 -DNDEBUG
-LDFLAGS=-pthread
+CXXFLAGS=-g -Wall -Wextra -Werror -std=c++11 -O3 -DNDEBUG
+LDFLAGS=
 
 all: $(EXECUTABLE)
 

--- a/demo/main.cpp
+++ b/demo/main.cpp
@@ -31,7 +31,7 @@ Mesh generatePlane(unsigned int N)
 	for (unsigned int y = 0; y <= N; ++y)
 		for (unsigned int x = 0; x <= N; ++x)
 		{
-			Vertex v = {float(x), float(y), 0, 0, 0, 1};
+			Vertex v = {float(x), float(y), 0, 0, 0, 1, float(x) / float(N), float(y) / float(N)};
 
 			result.vertices.push_back(v);
 		}


### PR DESCRIPTION
This will make sure codebase stays warning-clean.