### PR TITLE
Enable sanitize configuration for clang builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ matrix:
 
 script:
   - if [[ "$TRAVIS_OS_NAME" != "windows" ]]; then make config=coverage test; fi
-  - if [[ "CXX" == "clang++" ]]; then make config=sanitize test; fi
+  - if [[ "$CXX" == "clang++" ]]; then make config=sanitize test; fi
   - if [[ "$TRAVIS_OS_NAME" != "windows" ]]; then make config=release test; fi
   - if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then cmake -G "$TARGET" -DBUILD_DEMO=ON; fi
   - if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then cmake --build . -- -property:Configuration=Debug -verbosity:minimal; fi

--- a/src/vertexcodec.cpp
+++ b/src/vertexcodec.cpp
@@ -398,6 +398,11 @@ static __m128i unzigzag8(__m128i v)
 }
 
 static const unsigned char* decodeBytesGroupSimd(const unsigned char* data, unsigned char* buffer, int bitslog2)
+#if defined(__has_attribute)
+#if __has_attribute(no_sanitize)
+    __attribute__((no_sanitize("undefined"))) // ubsan treats the use of _mm_cvtsi32_si128 below as UB because the load address isn't aligned to 4b
+#endif
+#endif
 {
 	switch (bitslog2)
 	{


### PR DESCRIPTION
Travis config had a typo that was causing sanitize builds to be
disabled.