### PR TITLE
Add armv7/aarch64 iOS builds to Travis OSX

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ script:
   - if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then ./Debug/demo.exe demo/pirate.obj; fi
   - if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then cmake --build . -- -property:Configuration=Release -verbosity:minimal; fi
   - if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then ./Release/demo.exe demo/pirate.obj; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then make config=iphone; fi
 
 after_script:
   - if [[ "$TRAVIS_OS_NAME" != "windows" ]]; then bash <(curl -s https://codecov.io/bash); fi

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,12 @@ CFLAGS=-g -Wall -Wextra -Werror -std=c89
 CXXFLAGS=-g -Wall -Wextra -Wno-missing-field-initializers -Werror -std=c++98
 LDFLAGS=
 
+ifeq ($(config),iphone)
+	CFLAGS+=-arch armv7 -arch arm64 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk
+	CXXFLAGS+=-arch armv7 -arch arm64 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk -stdlib=libc++
+	LDFLAGS+=-arch armv7 -arch arm64 -L /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk/usr/lib -mios-version-min=7.0
+endif
+
 ifeq ($(config),release)
 	CXXFLAGS+=-O3 -DNDEBUG
 endif

--- a/Makefile
+++ b/Makefile
@@ -25,9 +25,10 @@ CXXFLAGS=-g -Wall -Wextra -Wno-missing-field-initializers -Werror -std=c++98
 LDFLAGS=
 
 ifeq ($(config),iphone)
-	CFLAGS+=-arch armv7 -arch arm64 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk
-	CXXFLAGS+=-arch armv7 -arch arm64 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk -stdlib=libc++
-	LDFLAGS+=-arch armv7 -arch arm64 -L /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk/usr/lib -mios-version-min=7.0
+	IPHONESDK=/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk
+	CFLAGS+=-arch armv7 -arch arm64 -isysroot $(IPHONESDK)
+	CXXFLAGS+=-arch armv7 -arch arm64 -isysroot $(IPHONESDK) -stdlib=libc++
+	LDFLAGS+=-arch armv7 -arch arm64 -L $(IPHONESDK)/usr/lib -mios-version-min=7.0
 endif
 
 ifeq ($(config),release)


### PR DESCRIPTION
That way we can have both ARM and ARM64 code compiled in CI even if we
can't test it.