### PR TITLE
Optimize meshopt_computeMeshletBounds

### DIFF
--- a/demo/main.cpp
+++ b/demo/main.cpp
@@ -679,7 +679,7 @@ void meshlets(const Mesh& mesh)
 	double startc = timestamp();
 	for (size_t i = 0; i < meshlets.size(); ++i)
 	{
-		meshopt_Bounds bounds = meshopt_computeMeshletBounds(meshlets[i], &mesh.vertices[0].px, mesh.vertices.size(), sizeof(Vertex));
+		meshopt_Bounds bounds = meshopt_computeMeshletBounds(&meshlets[i], &mesh.vertices[0].px, mesh.vertices.size(), sizeof(Vertex));
 
 		// trivial accept: we can't ever backface cull this meshlet
 		accepted += (bounds.cone_cutoff >= 1);

--- a/src/clusterizer.cpp
+++ b/src/clusterizer.cpp
@@ -327,10 +327,11 @@ meshopt_Bounds meshopt_computeClusterBounds(const unsigned int* indices, size_t 
 	return bounds;
 }
 
-meshopt_Bounds meshopt_computeMeshletBounds(meshopt_Meshlet meshlet, const float* vertex_positions, size_t vertex_count, size_t vertex_positions_stride)
+meshopt_Bounds meshopt_computeMeshletBounds(const meshopt_Meshlet* meshlet_ptr, const float* vertex_positions, size_t vertex_count, size_t vertex_positions_stride)
 {
 	assert(vertex_positions_stride > 0 && vertex_positions_stride <= 256);
 	assert(vertex_positions_stride % sizeof(float) == 0);
+	const meshopt_Meshlet& meshlet = *meshlet_ptr;
 
 	unsigned int indices[sizeof(meshlet.indices) / sizeof(meshlet.indices[0][0])];
 

--- a/src/meshoptimizer.h
+++ b/src/meshoptimizer.h
@@ -323,7 +323,7 @@ struct meshopt_Bounds
  * index_count should be less than or equal to 256*3 (the function assumes clusters of limited size)
  */
 MESHOPTIMIZER_EXPERIMENTAL struct meshopt_Bounds meshopt_computeClusterBounds(const unsigned int* indices, size_t index_count, const float* vertex_positions, size_t vertex_count, size_t vertex_positions_stride);
-MESHOPTIMIZER_EXPERIMENTAL struct meshopt_Bounds meshopt_computeMeshletBounds(struct meshopt_Meshlet meshlet, const float* vertex_positions, size_t vertex_count, size_t vertex_positions_stride);
+MESHOPTIMIZER_EXPERIMENTAL struct meshopt_Bounds meshopt_computeMeshletBounds(const struct meshopt_Meshlet* meshlet, const float* vertex_positions, size_t vertex_count, size_t vertex_positions_stride);
 
 #ifdef __cplusplus
 } /* extern "C" */


### PR DESCRIPTION
Optimize meshopt_computeMeshletBounds by passing in pointer to meshlet instead of by value (636 bytes)