### PR TITLE
 simplify: Introduce a second simplifier, simplifySloppy

### DIFF
--- a/demo/main.cpp
+++ b/demo/main.cpp
@@ -368,7 +368,7 @@ void simplify(const Mesh& mesh)
 	float target_error = 1e-3f;
 
 	lod.indices.resize(mesh.indices.size());
-	lod.indices.resize(meshopt_simplifySloppy(&lod.indices[0], &mesh.indices[0], mesh.indices.size(), &mesh.vertices[0].px, mesh.vertices.size(), sizeof(Vertex), target_index_count, target_error));
+	lod.indices.resize(meshopt_simplify(&lod.indices[0], &mesh.indices[0], mesh.indices.size(), &mesh.vertices[0].px, mesh.vertices.size(), sizeof(Vertex), target_index_count, target_error));
 
 	lod.vertices.resize(mesh.vertices.size());
 	lod.vertices.resize(meshopt_optimizeVertexFetch(&lod.vertices[0], &lod.indices[0], lod.indices.size(), &mesh.vertices[0], mesh.vertices.size(), sizeof(Vertex)));

--- a/demo/main.cpp
+++ b/demo/main.cpp
@@ -366,7 +366,7 @@ void simplify(const Mesh& mesh, float threshold = 0.2f)
 	size_t target_index_count = size_t(mesh.indices.size() * threshold);
 	float target_error = 1e-3f;
 
-	lod.indices.resize(mesh.indices.size());
+	lod.indices.resize(mesh.indices.size()); // note: simplify needs space for index_count elements in the destination array, not target_index_count
 	lod.indices.resize(meshopt_simplify(&lod.indices[0], &mesh.indices[0], mesh.indices.size(), &mesh.vertices[0].px, mesh.vertices.size(), sizeof(Vertex), target_index_count, target_error));
 
 	lod.vertices.resize(mesh.vertices.size());
@@ -387,7 +387,7 @@ void simplifySloppy(const Mesh& mesh, float threshold = 0.2f)
 
 	size_t target_index_count = size_t(mesh.indices.size() * threshold);
 
-	lod.indices.resize(mesh.indices.size());
+	lod.indices.resize(target_index_count);
 	lod.indices.resize(meshopt_simplifySloppy(&lod.indices[0], &mesh.indices[0], mesh.indices.size(), &mesh.vertices[0].px, mesh.vertices.size(), sizeof(Vertex), target_index_count));
 
 	lod.vertices.resize(mesh.vertices.size());

--- a/demo/main.cpp
+++ b/demo/main.cpp
@@ -357,13 +357,12 @@ void packMesh(std::vector<PackedVertexOct>& pv, const std::vector<Vertex>& verti
 	}
 }
 
-void simplify(const Mesh& mesh)
+void simplify(const Mesh& mesh, float threshold = 0.2f)
 {
 	Mesh lod;
 
 	double start = timestamp();
 
-	float threshold = 0.2f;
 	size_t target_index_count = size_t(mesh.indices.size() * threshold);
 	float target_error = 1e-3f;
 
@@ -380,13 +379,12 @@ void simplify(const Mesh& mesh)
 	       int(mesh.indices.size() / 3), int(lod.indices.size() / 3), (end - start) * 1000);
 }
 
-void simplifySloppy(const Mesh& mesh)
+void simplifySloppy(const Mesh& mesh, float threshold = 0.2f)
 {
 	Mesh lod;
 
 	double start = timestamp();
 
-	float threshold = 0.2f;
 	size_t target_index_count = size_t(mesh.indices.size() * threshold);
 
 	lod.indices.resize(mesh.indices.size());

--- a/demo/main.cpp
+++ b/demo/main.cpp
@@ -388,10 +388,9 @@ void simplifySloppy(const Mesh& mesh)
 
 	float threshold = 0.2f;
 	size_t target_index_count = size_t(mesh.indices.size() * threshold);
-	float target_error = 1e-3f;
 
 	lod.indices.resize(mesh.indices.size());
-	lod.indices.resize(meshopt_simplifySloppy(&lod.indices[0], &mesh.indices[0], mesh.indices.size(), &mesh.vertices[0].px, mesh.vertices.size(), sizeof(Vertex), target_index_count, target_error));
+	lod.indices.resize(meshopt_simplifySloppy(&lod.indices[0], &mesh.indices[0], mesh.indices.size(), &mesh.vertices[0].px, mesh.vertices.size(), sizeof(Vertex), target_index_count));
 
 	lod.vertices.resize(mesh.vertices.size());
 	lod.vertices.resize(meshopt_optimizeVertexFetch(&lod.vertices[0], &lod.indices[0], lod.indices.size(), &mesh.vertices[0], mesh.vertices.size(), sizeof(Vertex)));

--- a/src/meshoptimizer.h
+++ b/src/meshoptimizer.h
@@ -200,6 +200,8 @@ MESHOPTIMIZER_API int meshopt_decodeVertexBuffer(void* destination, size_t verte
  */
 MESHOPTIMIZER_EXPERIMENTAL size_t meshopt_simplify(unsigned int* destination, const unsigned int* indices, size_t index_count, const float* vertex_positions, size_t vertex_count, size_t vertex_positions_stride, size_t target_index_count, float target_error);
 
+MESHOPTIMIZER_EXPERIMENTAL size_t meshopt_simplifySloppy(unsigned int* destination, const unsigned int* indices, size_t index_count, const float* vertex_positions, size_t vertex_count, size_t vertex_positions_stride, size_t target_index_count, float target_error);
+
 /**
  * Mesh stripifier
  * Converts a previously vertex cache optimized triangle list to triangle strip, stitching strips using restart index
@@ -527,6 +529,15 @@ inline size_t meshopt_simplify(T* destination, const T* indices, size_t index_co
 	meshopt_IndexAdapter<T> out(destination, 0, index_count);
 
 	return meshopt_simplify(out.data, in.data, index_count, vertex_positions, vertex_count, vertex_positions_stride, target_index_count, target_error);
+}
+
+template <typename T>
+inline size_t meshopt_simplifySloppy(T* destination, const T* indices, size_t index_count, const float* vertex_positions, size_t vertex_count, size_t vertex_positions_stride, size_t target_index_count, float target_error)
+{
+	meshopt_IndexAdapter<T> in(0, indices, index_count);
+	meshopt_IndexAdapter<T> out(destination, 0, index_count);
+
+	return meshopt_simplifySloppy(out.data, in.data, index_count, vertex_positions, vertex_count, vertex_positions_stride, target_index_count, target_error);
 }
 
 template <typename T>

--- a/src/meshoptimizer.h
+++ b/src/meshoptimizer.h
@@ -191,6 +191,8 @@ MESHOPTIMIZER_API int meshopt_decodeVertexBuffer(void* destination, size_t verte
 /**
  * Experimental: Mesh simplifier
  * Reduces the number of triangles in the mesh, attempting to preserve mesh appearance as much as possible
+ * The algorithm tries to preserve mesh topology and can stop short of the target goal based on topology constraints or target error.
+ * If not all attributes from the input mesh are required, it's recommended to reindex the mesh using meshopt_generateShadowIndexBuffer prior to simplification.
  * Returns the number of indices after simplification, with destination containing new index data
  * The resulting index buffer references vertices from the original vertex buffer.
  * If the original vertex data isn't required, creating a compact vertex buffer using meshopt_optimizeVertexFetch is recommended.
@@ -200,7 +202,18 @@ MESHOPTIMIZER_API int meshopt_decodeVertexBuffer(void* destination, size_t verte
  */
 MESHOPTIMIZER_EXPERIMENTAL size_t meshopt_simplify(unsigned int* destination, const unsigned int* indices, size_t index_count, const float* vertex_positions, size_t vertex_count, size_t vertex_positions_stride, size_t target_index_count, float target_error);
 
-MESHOPTIMIZER_EXPERIMENTAL size_t meshopt_simplifySloppy(unsigned int* destination, const unsigned int* indices, size_t index_count, const float* vertex_positions, size_t vertex_count, size_t vertex_positions_stride, size_t target_index_count, float target_error);
+/**
+ * Experimental: Mesh simplifier (sloppy)
+ * Reduces the number of triangles in the mesh, sacrificing mesh apperance for simplification performance
+ * The algorithm doesn't preserve mesh topology but is always able to reach target triangle count.
+ * Returns the number of indices after simplification, with destination containing new index data
+ * The resulting index buffer references vertices from the original vertex buffer.
+ * If the original vertex data isn't required, creating a compact vertex buffer using meshopt_optimizeVertexFetch is recommended.
+ *
+ * destination must contain enough space for the target index buffer
+ * vertex_positions should have float3 position in the first 12 bytes of each vertex - similar to glVertexPointer
+ */
+MESHOPTIMIZER_EXPERIMENTAL size_t meshopt_simplifySloppy(unsigned int* destination, const unsigned int* indices, size_t index_count, const float* vertex_positions, size_t vertex_count, size_t vertex_positions_stride, size_t target_index_count);
 
 /**
  * Mesh stripifier
@@ -532,12 +545,12 @@ inline size_t meshopt_simplify(T* destination, const T* indices, size_t index_co
 }
 
 template <typename T>
-inline size_t meshopt_simplifySloppy(T* destination, const T* indices, size_t index_count, const float* vertex_positions, size_t vertex_count, size_t vertex_positions_stride, size_t target_index_count, float target_error)
+inline size_t meshopt_simplifySloppy(T* destination, const T* indices, size_t index_count, const float* vertex_positions, size_t vertex_count, size_t vertex_positions_stride, size_t target_index_count)
 {
 	meshopt_IndexAdapter<T> in(0, indices, index_count);
 	meshopt_IndexAdapter<T> out(destination, 0, index_count);
 
-	return meshopt_simplifySloppy(out.data, in.data, index_count, vertex_positions, vertex_count, vertex_positions_stride, target_index_count, target_error);
+	return meshopt_simplifySloppy(out.data, in.data, index_count, vertex_positions, vertex_count, vertex_positions_stride, target_index_count);
 }
 
 template <typename T>

--- a/src/meshoptimizer.h
+++ b/src/meshoptimizer.h
@@ -548,7 +548,7 @@ template <typename T>
 inline size_t meshopt_simplifySloppy(T* destination, const T* indices, size_t index_count, const float* vertex_positions, size_t vertex_count, size_t vertex_positions_stride, size_t target_index_count)
 {
 	meshopt_IndexAdapter<T> in(0, indices, index_count);
-	meshopt_IndexAdapter<T> out(destination, 0, index_count);
+	meshopt_IndexAdapter<T> out(destination, 0, target_index_count);
 
 	return meshopt_simplifySloppy(out.data, in.data, index_count, vertex_positions, vertex_count, vertex_positions_stride, target_index_count);
 }

--- a/src/simplifier.cpp
+++ b/src/simplifier.cpp
@@ -905,6 +905,19 @@ struct TriangleHasher
 	}
 };
 
+struct CoarseCell
+{
+	union {
+		float error;
+		unsigned int errorui;
+	};
+	unsigned int degenerate_triangles;
+	unsigned int best_vertex;
+	// TODO: it simplifies the algorithm to have this, but it's a lot of memory; can we do better?
+	unsigned int fine_cells[8];
+	unsigned int fine_cell_count;
+};
+
 } // namespace meshopt
 
 #if TRACE
@@ -1409,19 +1422,6 @@ size_t meshopt_simplifySloppy(unsigned int* destination, const unsigned int* ind
 	}
 
 	// let's create an array of coarse cells
-	struct CoarseCell
-	{
-		union {
-			float error;
-			unsigned int errorui;
-		};
-		unsigned int degenerate_triangles;
-		unsigned int best_vertex;
-		// TODO: it simplifies the algorithm to have this, but it's a lot of memory; can we do better?
-		unsigned int fine_cells[8];
-		unsigned int fine_cell_count;
-	};
-
 	CoarseCell* coarse_cells = allocator.allocate<CoarseCell>(cell_count);
 	size_t coarse_cell_count = 0;
 

--- a/src/simplifier.cpp
+++ b/src/simplifier.cpp
@@ -1208,10 +1208,12 @@ size_t meshopt_simplifySloppy(unsigned int* destination, const unsigned int* ind
 	printf("result: cell count %d\n", int(cell_count));
 #endif
 #else
+	int mask = 0;
+
 	for (int pass = 0; pass < 10; ++pass)
 	{
 		int maskc = 1023 & ~((1 << (9 - pass)) - 1);
-		int mask = (maskc << 20) | (maskc << 10) | maskc;
+		mask = (maskc << 20) | (maskc << 10) | maskc;
 
 		cell_count = 0;
 		memset(table, -1, table_size * sizeof(HashCell));
@@ -1232,7 +1234,7 @@ size_t meshopt_simplifySloppy(unsigned int* destination, const unsigned int* ind
 		}
 
 #if TRACE
-		printf("pass %d: cell count %d, cell size %.4f\n", pass, int(cell_count), powf(2.f, -pass));
+		printf("pass %d: cell count %d, cell size %.4f\n", pass, int(cell_count), powf(2.f, -float(pass)));
 #endif
 
 		if (cell_count >= target_cell_count)
@@ -1241,6 +1243,7 @@ size_t meshopt_simplifySloppy(unsigned int* destination, const unsigned int* ind
 #endif
 #else
 	int mask = 0x3FFFFFFF; // all 10-bit components set
+	(void)mask;
 
 #if SLOP_TARGET_CELLS_APPROX
 	size_t count_table_size = hashBuckets2(target_cell_count * 4);

--- a/src/simplifier.cpp
+++ b/src/simplifier.cpp
@@ -17,6 +17,7 @@
 // This work is based on:
 // Michael Garland and Paul S. Heckbert. Surface simplification using quadric error metrics. 1997
 // Michael Garland. Quadric-based polygonal surface simplification. 1999
+// Matthias Teschner, Bruno Heidelberger, Matthias Mueller, Danat Pomeranets, Markus Gross. Optimized Spatial Hashing for Collision Detection of Deformable Objects. 2003
 namespace meshopt
 {
 
@@ -866,13 +867,12 @@ struct HashCellHasher
 {
 	size_t hash(const HashCell& cell) const
 	{
-		unsigned int a = cell.id;
-		a = (a ^ 61) ^ (a >> 16);
-		a = a + (a << 3);
-		a = a ^ (a >> 4);
-		a = a * 0x27d4eb2d;
-		a = a ^ (a >> 15);
-		return a;
+		// MurmurHash2 finalizer
+		unsigned int h = cell.id;
+		h ^= h >> 13;
+		h *= 0x5bd1e995;
+		h ^= h >> 15;
+		return h;
 	}
 
 	bool equal(const HashCell& lhs, const HashCell& rhs) const
@@ -895,8 +895,7 @@ struct TriangleHasher
 {
 	size_t hash(const Triangle& tri) const
 	{
-		// TODO: WE NEED TO SCRAMBLE THIS
-		return tri.a ^ tri.b ^ tri.c;
+		return (tri.a * 73856093) ^ (tri.b * 19349663) ^ (tri.c * 83492791);
 	}
 
 	bool equal(const Triangle& lhs, const Triangle& rhs) const

--- a/src/simplifier.cpp
+++ b/src/simplifier.cpp
@@ -914,7 +914,7 @@ struct TriangleHasher
 static size_t fillVertexCells(HashCell* table, size_t table_size, unsigned int* vertex_cells, const Vector3* vertex_positions, size_t vertex_count, int grid_size)
 {
 	HashCellHasher hasher;
-	HashCell dummy = { ~0u, 0 };
+	HashCell dummy = {~0u, 0};
 
 	memset(table, -1, table_size * sizeof(HashCell));
 
@@ -932,8 +932,8 @@ static size_t fillVertexCells(HashCell* table, size_t table_size, unsigned int* 
 
 		unsigned int id = (xi << 20) | (yi << 10) | zi;
 
-		HashCell cell = { id, 0 };
-		HashCell * entry = hashLookup2(table, table_size, hasher, cell, dummy);
+		HashCell cell = {id, 0};
+		HashCell* entry = hashLookup2(table, table_size, hasher, cell, dummy);
 
 		if (entry->id == ~0u)
 		{
@@ -1278,9 +1278,9 @@ size_t meshopt_simplifySloppy(unsigned int* destination, const unsigned int* ind
 
 #if TRACE
 		printf("pass %d (%s): cell count %d, grid size %d, cell size %.4f, triangles %d, %s\n",
-				pass, (pass == 0) ? "guess" : (pass <= SLOP_INTERPOLATION) ? "lerp" : "binary",
-				int(cells), grid_size, 1.f / float(grid_size), int(triangles),
-				(triangles <= target_index_count / 3) ? "under" : "over");
+		       pass, (pass == 0) ? "guess" : (pass <= SLOP_INTERPOLATION) ? "lerp" : "binary",
+		       int(cells), grid_size, 1.f / float(grid_size), int(triangles),
+		       (triangles <= target_index_count / 3) ? "under" : "over");
 #endif
 
 		if (triangles <= target_index_count / 3)
@@ -1317,14 +1317,14 @@ size_t meshopt_simplifySloppy(unsigned int* destination, const unsigned int* ind
 	// fourth pass: collapse triangles!
 	// note that we need to filter out triangles that we've already output because we very frequently generate redundant triangles between cells :(
 #if SLOP_FILTER_DUPLICATES
-	size_t tritable_size = hashBuckets2(target_index_count / 3);
+	size_t tritable_size = hashBuckets2(min_triangles);
 	Triangle* tritable = allocator.allocate<Triangle>(tritable_size);
 
 	size_t write = filterTriangles(destination, tritable, tritable_size, indices, index_count, vertex_cells, cell_remap);
 	assert(write <= target_index_count);
 
 #if TRACE
-	printf("duplicates: %d triangles => %d unique\n", unsigned(countTriangles(vertex_cells, indices, index_count)), int(write / 3));
+	printf("duplicates: %d triangles => %d unique\n", unsigned(min_triangles), int(write / 3));
 #endif
 #else
 	size_t write = filterTriangles(destination, indices, index_count, vertex_cells, cell_remap);

--- a/src/simplifier.cpp
+++ b/src/simplifier.cpp
@@ -1426,14 +1426,14 @@ size_t meshopt_simplifySloppy(unsigned int* destination, const unsigned int* ind
 	Triangle* tritable = allocator.allocate<Triangle>(tritable_size);
 
 	size_t write = filterTriangles(destination, tritable, tritable_size, indices, index_count, vertex_cells, cell_remap);
-	assert(write <= target_index_count / 3);
+	assert(write <= target_index_count);
 
 #if TRACE
 	printf("duplicates: %d triangles => %d unique\n", unsigned(countTriangles(vertex_cells, indices, index_count)), int(write / 3));
 #endif
 #else
 	size_t write = filterTriangles(destination, indices, index_count, vertex_cells, cell_remap);
-	assert(write <= target_index_count / 3);
+	assert(write <= target_index_count);
 #endif
 
 #if TRACE

--- a/src/simplifier.cpp
+++ b/src/simplifier.cpp
@@ -1063,11 +1063,17 @@ size_t meshopt_simplify(unsigned int* destination, const unsigned int* indices, 
 // Should we target cell count vs index count? targeting cell count is faster, but targeting index count gets us more precise results
 #define SLOP_TARGET_CELLS 1
 
+// Should we target cell count precisely or approximately? Approximate counting is much faster but it's approximate (duh).
+#define SLOP_TARGET_CELLS_APPROX 1
+
 // Should we filter duplicate triangles? Normally there's few of them, but in some meshes there's a lot. Filtering is done after targeting...
 #define SLOP_FILTER_DUPLICATES 0
 
 // Should we cache quadric errors?
 #define SLOP_CACHE_ERRORS 1
+
+// How many binary search passes do we perform? We currently run a fixed number for simplicity/robustness
+#define SLOP_PASSES 10
 
 size_t meshopt_simplifySloppy(unsigned int* destination, const unsigned int* indices, size_t index_count, const float* vertex_positions_data, size_t vertex_count, size_t vertex_positions_stride, size_t target_index_count, float target_error)
 {
@@ -1109,19 +1115,22 @@ size_t meshopt_simplifySloppy(unsigned int* destination, const unsigned int* ind
 	printf("target: %d cells, %d triangles\n", int(target_cell_count), int(target_index_count / 3));
 #endif
 
+#if SLOP_TARGET_CELLS_APPROX
+	size_t count_table_size = hashBuckets2(target_cell_count * 4);
+	unsigned char* count_table = allocator.allocate<unsigned char>(count_table_size);
+#endif
+
 	float cell_min_size = 1.f / 1024.f;
 	size_t cell_min_count = vertex_count;
 	float cell_max_size = 1.f;
 	size_t cell_max_count = 1;
 
-	for (int pass = 0; pass <= 10; ++pass)
+	for (int pass = 0; pass <= SLOP_PASSES; ++pass)
 	{
-		memset(table, -1, table_size * sizeof(HashCell));
-
 		float cell_size = (cell_min_size + cell_max_size) * 0.5f;
 		cell_count = 0;
 
-		if (pass == 10)
+		if (pass == SLOP_PASSES)
 			cell_size = cell_max_size;
 
 		// TODO: ROUNDING/BOUNDARY CONDITIONS?
@@ -1129,26 +1138,54 @@ size_t meshopt_simplifySloppy(unsigned int* destination, const unsigned int* ind
 		cell_scale = cell_scale > 1023.5f ? 1023.5f : cell_scale;
 		cell_scale = cell_scale < 0.5f ? 0 : cell_scale;
 
-		for (size_t i = 0; i < vertex_count; ++i)
+#if SLOP_TARGET_CELLS_APPROX
+		if (pass < SLOP_PASSES)
 		{
-			const Vector3& v = vertex_positions[i];
+			memset(count_table, 0, count_table_size);
 
-			int xi = int(v.x * cell_scale + 0.5f);
-			int yi = int(v.y * cell_scale + 0.5f);
-			int zi = int(v.z * cell_scale + 0.5f);
-
-			unsigned int id = (xi << 20) | (yi << 10) | zi;
-
-			HashCell cell = { id, 0 };
-			HashCell* entry = hashLookup2(table, table_size, hasher, cell, dummy);
-
-			if (entry->id == ~0u)
+			for (size_t i = 0; i < vertex_count; ++i)
 			{
-				entry->id = cell.id;
-				entry->cell = unsigned(cell_count++);
-			}
+				const Vector3& v = vertex_positions[i];
 
-			vertex_cells[i] = entry->cell;
+				int xi = int(v.x * cell_scale + 0.5f);
+				int yi = int(v.y * cell_scale + 0.5f);
+				int zi = int(v.z * cell_scale + 0.5f);
+
+				unsigned int id = (xi << 20) | (yi << 10) | zi;
+
+				HashCell cell = { id, 0 };
+				size_t hash = hasher.hash(cell) & (count_table_size - 1);
+
+				cell_count += 1 - count_table[hash];
+				count_table[hash] = 1;
+			}
+		}
+		else
+#endif
+		{
+			memset(table, -1, table_size * sizeof(HashCell));
+
+			for (size_t i = 0; i < vertex_count; ++i)
+			{
+				const Vector3& v = vertex_positions[i];
+
+				int xi = int(v.x * cell_scale + 0.5f);
+				int yi = int(v.y * cell_scale + 0.5f);
+				int zi = int(v.z * cell_scale + 0.5f);
+
+				unsigned int id = (xi << 20) | (yi << 10) | zi;
+
+				HashCell cell = { id, 0 };
+				HashCell* entry = hashLookup2(table, table_size, hasher, cell, dummy);
+
+				if (entry->id == ~0u)
+				{
+					entry->id = cell.id;
+					entry->cell = unsigned(cell_count++);
+				}
+
+				vertex_cells[i] = entry->cell;
+			}
 		}
 
 #if TRACE

--- a/src/simplifier.cpp
+++ b/src/simplifier.cpp
@@ -859,8 +859,9 @@ struct CellHasher
 
 	size_t hash(unsigned int i) const
 	{
-		// MurmurHash2 finalizer
 		unsigned int h = vertex_ids[i];
+
+		// MurmurHash2 finalizer
 		h ^= h >> 13;
 		h *= 0x5bd1e995;
 		h ^= h >> 15;
@@ -881,6 +882,7 @@ struct TriangleHasher
 	{
 		const unsigned int* tri = indices + i * 3;
 
+		// Optimized Spatial Hashing for Collision Detection of Deformable Objects
 		return (tri[0] * 73856093) ^ (tri[1] * 19349663) ^ (tri[2] * 83492791);
 	}
 

--- a/src/simplifier.cpp
+++ b/src/simplifier.cpp
@@ -1348,7 +1348,8 @@ size_t meshopt_simplifySloppy(unsigned int* destination, const unsigned int* ind
 		if (pass == 0)
 		{
 			// instead of starting in the middle, let's guess as to what the answer might be! triangle count usually grows as a square of grid size...
-			grid_size = sqrt(target_cell_count);
+			grid_size = int(sqrtf(float(target_cell_count)));
+			grid_size = (grid_size < 1) ? 1 : (grid_size > 1024) ? 1024 : grid_size;
 		}
 		else
 	#endif
@@ -1358,13 +1359,15 @@ size_t meshopt_simplifySloppy(unsigned int* destination, const unsigned int* ind
 			float kl = 0.1f;
 			k = (k < kl) ? kl : (k > 1 - kl) ? 1 - kl : k;
 			grid_size = int(float(min_grid) * (1 - k) + float(max_grid) * k);
+			grid_size = (grid_size < 1) ? 1 : (grid_size > 1024) ? 1024 : grid_size;
 		}
 	#else
 	#if SLOP_GUESS
 		if (pass == 0)
 		{
 			// instead of starting in the middle, let's guess as to what the answer might be! triangle count usually grows as a square of grid size...
-			grid_size = sqrt(target_cell_count);
+			grid_size = int(sqrtf(float(target_cell_count)));
+			grid_size = (grid_size < 1) ? 1 : (grid_size > 1024) ? 1024 : grid_size;
 		}
 		else
 	#endif

--- a/src/simplifier.cpp
+++ b/src/simplifier.cpp
@@ -1238,8 +1238,6 @@ size_t meshopt_simplifySloppy(unsigned int* destination, const unsigned int* ind
 	unsigned int* vertex_cells = allocator.allocate<unsigned int>(vertex_count);
 	unsigned int* vertex_cells_temp = allocator.allocate<unsigned int>(vertex_count);
 
-	// TODO: we don't need a table this large if we're limiting the number of unique elements we're adding to the table
-	// Especially if we can alloc this *after* the counting pass, with an approx *2 size or whatever?
 	size_t table_size = hashBuckets2(vertex_count);
 	HashCell* table = allocator.allocate<HashCell>(table_size);
 
@@ -1259,15 +1257,13 @@ size_t meshopt_simplifySloppy(unsigned int* destination, const unsigned int* ind
 		{
 			// instead of starting in the middle, let's guess as to what the answer might be! triangle count usually grows as a square of grid size...
 			grid_size = int(sqrtf(float(target_cell_count)));
-			grid_size = (grid_size < 1) ? 1 : (grid_size > 1024) ? 1024 : grid_size;
+			grid_size = (grid_size < min_grid) ? min_grid : (grid_size > max_grid) ? max_grid : grid_size;
 		}
 		else if (pass <= SLOP_INTERPOLATION)
 		{
 			float k = (float(target_index_count / 3) - float(min_triangles)) / (float(max_triangles) - float(min_triangles));
-			float kl = 0.0f; // TODO: should we even clamp since we fall back to binary? to what?
-			k = (k < kl) ? kl : (k > 1 - kl) ? 1 - kl : k;
 			grid_size = int(float(min_grid) * (1 - k) + float(max_grid) * k);
-			grid_size = (grid_size < 1) ? 1 : (grid_size > 1024) ? 1024 : grid_size;
+			grid_size = (grid_size < min_grid) ? min_grid : (grid_size > max_grid) ? max_grid : grid_size;
 		}
 		else
 		{

--- a/tools/lodviewer.cpp
+++ b/tools/lodviewer.cpp
@@ -11,8 +11,10 @@
 
 #include <GLFW/glfw3.h>
 
+#ifdef GLTF
 #define CGLTF_IMPLEMENTATION
 #include "cgltf.h"
+#endif
 
 #ifdef _WIN32
 #pragma comment(lib, "opengl32.lib")
@@ -107,6 +109,7 @@ Mesh parseObj(const char* path)
 	return result;
 }
 
+#ifdef GLTF
 cgltf_accessor* getAccessor(const cgltf_attribute* attributes, size_t attribute_count, cgltf_attribute_type type, int index = 0)
 {
 	for (size_t i = 0; i < attribute_count; ++i)
@@ -125,7 +128,7 @@ const T* getComponentPtr(const cgltf_accessor* a)
 	return reinterpret_cast<const T*>(&buffer[offset]);
 }
 
-Mesh parseGltfC(const char* path)
+Mesh parseGltf(const char* path)
 {
 	cgltf_options options = {};
 	cgltf_data* data = 0;
@@ -271,14 +274,17 @@ Mesh parseGltfC(const char* path)
 
 	return result;
 }
+#endif
 
 Mesh loadMesh(const char* path)
 {
 	if (strstr(path, ".obj"))
 		return parseObj(path);
 
+#ifdef GLTF
 	if (strstr(path, ".gltf") || strstr(path, ".glb"))
-		return parseGltfC(path);
+		return parseGltf(path);
+#endif
 
 	return Mesh();
 }


### PR DESCRIPTION
The default simplifier faithfully follows the topology and doesn't like
collapsing vertices in ways that violate topological consistency. It is
likely that we'll try to unlock some of the collapse options in the
future somehow, and/or recommend discarding and regenerating some
attributes via shadow IB, but that fundamentally limits the algorithm.

Additionally, the simplifier doesn't know how to collapse small regions
of the mesh other than faithfully following topology - which in some
cases is great but isn't always appropriate. It doesn't merge features
that are topologically disjoint because, again, it's topology-driven.

The new simplifier instead completely disregards topology, using an
out-of-core simplification foundation where the space is divided into
cells, and all vertices in a cell are merged together. We currently pick
the vertex with the minimum quadric error. To determine the grid size,
a fast binary search augmented with an initial guess and interpolation
search is ran.

The sloppy simplifier is ~6x faster than baseline simplifier when targeting
10x reduction in triangle count.