### PR TITLE
Add support for custom allocators

### DIFF
--- a/src/allocator.cpp
+++ b/src/allocator.cpp
@@ -1,0 +1,7 @@
+#include "meshoptimizer.h"
+
+void meshopt_setAllocator(void* (*allocate)(size_t), void (*deallocate)(void*))
+{
+	meshopt_Allocator::Storage::allocate = allocate;
+	meshopt_Allocator::Storage::deallocate = deallocate;
+}


### PR DESCRIPTION
meshopt_setAllocator can be used to override default allocation
callbacks (new/delete) with arbitrary functions with matching signature.

The callbacks are stored in global statics; to maintain independence
between individual translation units, the statics are declared in the
header file as templated class statics. They are instantiated in each
translation unit that uses meshopt_Allocator, and merged by linker into
a single symbol.

Note, this change also switches to stack order for deallocating blocks in
meshopt_Allocator to make it easier to implement custom allocators.