### PR TITLE
Rework coverage reporting to run gcov manually

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,15 +9,18 @@ matrix:
     - os: osx
       compiler: clang
     - os: windows
+      compiler: cl
       env:
         - TARGET="Visual Studio 15 2017"
     - os: windows
+      compiler: cl
       env:
         - TARGET="Visual Studio 15 2017 Win64"
 
 script:
-  - if [[ "$TRAVIS_OS_NAME" != "windows" ]]; then make config=coverage test; fi
-  - if [[ "$CXX" == "clang++" ]]; then make config=sanitize test; fi
+  - if [[ "$TRAVIS_COMPILER" == "gcc" ]]; then make config=coverage test; fi
+  - if [[ "$TRAVIS_COMPILER" == "clang" ]]; then make config=sanitize test; fi
+  - if [[ "$TRAVIS_OS_NAME" != "windows" ]]; then make config=debug test; fi
   - if [[ "$TRAVIS_OS_NAME" != "windows" ]]; then make config=release test; fi
   - if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then cmake -G "$TARGET" -DBUILD_DEMO=ON; fi
   - if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then cmake --build . -- -property:Configuration=Debug -verbosity:minimal; fi
@@ -27,4 +30,8 @@ script:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then make config=iphone; fi
 
 after_script:
-  - if [[ "$TRAVIS_OS_NAME" != "windows" ]]; then bash <(curl -s https://codecov.io/bash); fi
+  - if [[ "$TRAVIS_COMPILER" == "gcc" ]]; then
+    find . -type f -name '*.gcno' -exec gcov -p {} +;
+    sed -i -e "s/#####\(.*\)\(\/\/ unreachable.*\)/    -\1\2/" *.gcov;
+    bash <(curl -s https://codecov.io/bash) -f 'src#*.gcov' -X search;
+    fi

--- a/src/indexgenerator.cpp
+++ b/src/indexgenerator.cpp
@@ -115,7 +115,7 @@ static T* hashLookup(T* table, size_t buckets, const Hash& hash, const T& key, c
 		bucket = (bucket + probe + 1) & hashmod;
 	}
 
-	assert(false && "Hash table is full");
+	assert(false && "Hash table is full"); // unreachable
 	return 0;
 }
 

--- a/src/simplifier.cpp
+++ b/src/simplifier.cpp
@@ -145,7 +145,7 @@ static T* hashLookup2(T* table, size_t buckets, const Hash& hash, const T& key, 
 		bucket = (bucket + probe + 1) & hashmod;
 	}
 
-	assert(false && "Hash table is full");
+	assert(false && "Hash table is full"); // unreachable
 	return 0;
 }
 


### PR DESCRIPTION
codecov script is doing something incredibly weird that results in
meshoptimizer.h being split between src/meshoptimizer.h and
demo/../src/meshoptimizer.h. This results in misleading coverage
information.

Additionally, running gcov ourselves gives us an opportunity to fix
unreachable coverage lines using a simple sed script.

We also now limit coverage run to gcc since clang on Linux doesn't work
and gcov on OSX has somewhat different behavior.