### PR TITLE
simplifySloppy: Use three point interpolation search

### DIFF
--- a/demo/main.cpp
+++ b/demo/main.cpp
@@ -907,7 +907,8 @@ void processDev(const char* path)
 	if (!loadMesh(mesh, path))
 		return;
 
-	simplify(mesh, 0.01f);
+	simplifySloppy(mesh, 0.5f);
+	simplifySloppy(mesh, 0.1f);
 	simplifySloppy(mesh, 0.01f);
 }
 


### PR DESCRIPTION
Instead of linear interpolation, we now use three point interpolation
search. On many meshes it performs roughly the same, but on some meshes
it does fewer passes by being able to adapt to the actual curve better.

On a full test mesh collection (5 GB of .obj files), running three
simplification attempts for each mesh with factors 0.5, 0.1 and 0.01
requires 2400 passes (14 seconds) with old method and 2000 passes (13
seconds) with new method.