### PR TITLE
stripify: Add support for degenerate triangles

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,10 +170,12 @@ This library provides an algorithm for converting a vertex cache optimized trian
 
 ```c++
 std::vector<unsigned int> strip(meshopt_stripifyBound(index_count));
-size_t strip_size = meshopt_stripify(&strip[0], indices, index_count, vertex_count);
+bool use_restart = true;
+size_t strip_size = meshopt_stripify(&strip[0], indices, index_count, vertex_count, use_restart);
 ```
 
-Typically you should expect triangle strips to have ~50-60% of indices compared to triangle lists (~1.5-1.8 indices per triangle) and have ~5% worse ACMR. Note that triangle strips require restart index support for rendering; using degenerate triangles to connect strips is not supported.
+Typically you should expect triangle strips to have ~50-60% of indices compared to triangle lists (~1.5-1.8 indices per triangle) and have ~5% worse ACMR.
+Note that triangle strips can be stitched with or without restart index support. Using restart indices can result in ~10% smaller index buffers, but on some GPUs restart indices may result in decreased performance.
 
 ## Deinterleaved geometry
 

--- a/README.md
+++ b/README.md
@@ -170,8 +170,8 @@ This library provides an algorithm for converting a vertex cache optimized trian
 
 ```c++
 std::vector<unsigned int> strip(meshopt_stripifyBound(index_count));
-bool use_restart = true;
-size_t strip_size = meshopt_stripify(&strip[0], indices, index_count, vertex_count, use_restart);
+unsigned int restart_index = ~0u;
+size_t strip_size = meshopt_stripify(&strip[0], indices, index_count, vertex_count, restart_index);
 ```
 
 Typically you should expect triangle strips to have ~50-60% of indices compared to triangle lists (~1.5-1.8 indices per triangle) and have ~5% worse ACMR.

--- a/demo/main.cpp
+++ b/demo/main.cpp
@@ -644,7 +644,7 @@ void stripify(const Mesh& mesh, bool use_restart)
 	meshopt_VertexCacheStatistics vcs_intel = meshopt_analyzeVertexCache(&copy.indices[0], mesh.indices.size(), mesh.vertices.size(), 128, 0, 0);
 
 	printf("Stripify%c: ACMR %f ATVR %f (NV %f AMD %f Intel %f); %d strip indices (%.1f%%) in %.2f msec\n",
-		   use_restart ? 'R' : ' ',
+	       use_restart ? 'R' : ' ',
 	       vcs.acmr, vcs.atvr, vcs_nv.atvr, vcs_amd.atvr, vcs_intel.atvr,
 	       int(strip.size()), double(strip.size()) / double(mesh.indices.size()) * 100,
 	       (end - start) * 1000);

--- a/demo/main.cpp
+++ b/demo/main.cpp
@@ -623,14 +623,16 @@ void encodeVertex(const Mesh& mesh, const char* pvn)
 
 void stripify(const Mesh& mesh, bool use_restart)
 {
+	unsigned int restart_index = use_restart ? ~0u : 0;
+
 	// note: input mesh is assumed to be optimized for vertex cache and vertex fetch
 	double start = timestamp();
 	std::vector<unsigned int> strip(meshopt_stripifyBound(mesh.indices.size()));
-	strip.resize(meshopt_stripify(&strip[0], &mesh.indices[0], mesh.indices.size(), mesh.vertices.size(), use_restart));
+	strip.resize(meshopt_stripify(&strip[0], &mesh.indices[0], mesh.indices.size(), mesh.vertices.size(), restart_index));
 	double end = timestamp();
 
 	Mesh copy = mesh;
-	copy.indices.resize(meshopt_unstripify(&copy.indices[0], &strip[0], strip.size()));
+	copy.indices.resize(meshopt_unstripify(&copy.indices[0], &strip[0], strip.size(), restart_index));
 	assert(copy.indices.size() <= meshopt_unstripifyBound(strip.size()));
 
 	assert(isMeshValid(copy));

--- a/src/indexcodec.cpp
+++ b/src/indexcodec.cpp
@@ -162,7 +162,7 @@ static void writeTriangle(void* destination, size_t offset, size_t index_size, u
 	}
 	else
 #ifdef __EMSCRIPTEN__
-	if (index_size == 4) // work around Edge (ChakraCore) bug - without this compiler assumes index_size==2
+	    if (index_size == 4) // work around Edge (ChakraCore) bug - without this compiler assumes index_size==2
 #endif
 	{
 		static_cast<unsigned int*>(destination)[offset + 0] = a;

--- a/src/meshoptimizer.h
+++ b/src/meshoptimizer.h
@@ -223,6 +223,7 @@ MESHOPTIMIZER_EXPERIMENTAL size_t meshopt_simplifySloppy(unsigned int* destinati
  * Using restart indices can result in ~10% smaller index buffers, but on some GPUs restart indices may result in decreased performance.
  *
  * destination must contain enough space for the target index buffer, worst case can be computed with meshopt_stripifyBound
+ * restart_index should be 0xffff or 0xffffffff depending on index size, or 0 to use degenerate triangles
  */
 MESHOPTIMIZER_API size_t meshopt_stripify(unsigned int* destination, const unsigned int* indices, size_t index_count, size_t vertex_count, unsigned int restart_index);
 MESHOPTIMIZER_API size_t meshopt_stripifyBound(size_t index_count);

--- a/src/meshoptimizer.h
+++ b/src/meshoptimizer.h
@@ -224,7 +224,7 @@ MESHOPTIMIZER_EXPERIMENTAL size_t meshopt_simplifySloppy(unsigned int* destinati
  *
  * destination must contain enough space for the target index buffer, worst case can be computed with meshopt_stripifyBound
  */
-MESHOPTIMIZER_API size_t meshopt_stripify(unsigned int* destination, const unsigned int* indices, size_t index_count, size_t vertex_count, int use_restart);
+MESHOPTIMIZER_API size_t meshopt_stripify(unsigned int* destination, const unsigned int* indices, size_t index_count, size_t vertex_count, unsigned int restart_index);
 MESHOPTIMIZER_API size_t meshopt_stripifyBound(size_t index_count);
 
 /**
@@ -234,7 +234,7 @@ MESHOPTIMIZER_API size_t meshopt_stripifyBound(size_t index_count);
  *
  * destination must contain enough space for the target index buffer, worst case can be computed with meshopt_unstripifyBound
  */
-MESHOPTIMIZER_API size_t meshopt_unstripify(unsigned int* destination, const unsigned int* indices, size_t index_count);
+MESHOPTIMIZER_API size_t meshopt_unstripify(unsigned int* destination, const unsigned int* indices, size_t index_count, unsigned int restart_index);
 MESHOPTIMIZER_API size_t meshopt_unstripifyBound(size_t index_count);
 
 struct meshopt_VertexCacheStatistics
@@ -563,21 +563,21 @@ inline size_t meshopt_simplifySloppy(T* destination, const T* indices, size_t in
 }
 
 template <typename T>
-inline size_t meshopt_stripify(T* destination, const T* indices, size_t index_count, size_t vertex_count, int use_restart)
+inline size_t meshopt_stripify(T* destination, const T* indices, size_t index_count, size_t vertex_count, T restart_index)
 {
 	meshopt_IndexAdapter<T> in(0, indices, index_count);
 	meshopt_IndexAdapter<T> out(destination, 0, (index_count / 3) * 5);
 
-	return meshopt_stripify(out.data, in.data, index_count, vertex_count, use_restart);
+	return meshopt_stripify(out.data, in.data, index_count, vertex_count, unsigned(restart_index));
 }
 
 template <typename T>
-inline size_t meshopt_unstripify(T* destination, const T* indices, size_t index_count)
+inline size_t meshopt_unstripify(T* destination, const T* indices, size_t index_count, T restart_index)
 {
 	meshopt_IndexAdapter<T> in(0, indices, index_count);
 	meshopt_IndexAdapter<T> out(destination, 0, (index_count - 2) * 3);
 
-	return meshopt_unstripify(out.data, in.data, index_count);
+	return meshopt_unstripify(out.data, in.data, index_count, unsigned(restart_index));
 }
 
 template <typename T>

--- a/src/meshoptimizer.h
+++ b/src/meshoptimizer.h
@@ -217,13 +217,13 @@ MESHOPTIMIZER_EXPERIMENTAL size_t meshopt_simplifySloppy(unsigned int* destinati
 
 /**
  * Mesh stripifier
- * Converts a previously vertex cache optimized triangle list to triangle strip, stitching strips using restart index
+ * Converts a previously vertex cache optimized triangle list to triangle strip, stitching strips using restart index or degenerate triangles
  * Returns the number of indices in the resulting strip, with destination containing new index data
  * For maximum efficiency the index buffer being converted has to be optimized for vertex cache first.
  *
  * destination must contain enough space for the target index buffer, worst case can be computed with meshopt_stripifyBound
  */
-MESHOPTIMIZER_API size_t meshopt_stripify(unsigned int* destination, const unsigned int* indices, size_t index_count, size_t vertex_count);
+MESHOPTIMIZER_API size_t meshopt_stripify(unsigned int* destination, const unsigned int* indices, size_t index_count, size_t vertex_count, int use_restart);
 MESHOPTIMIZER_API size_t meshopt_stripifyBound(size_t index_count);
 
 /**
@@ -562,12 +562,12 @@ inline size_t meshopt_simplifySloppy(T* destination, const T* indices, size_t in
 }
 
 template <typename T>
-inline size_t meshopt_stripify(T* destination, const T* indices, size_t index_count, size_t vertex_count)
+inline size_t meshopt_stripify(T* destination, const T* indices, size_t index_count, size_t vertex_count, int use_restart)
 {
 	meshopt_IndexAdapter<T> in(0, indices, index_count);
-	meshopt_IndexAdapter<T> out(destination, 0, (index_count / 3) * 4);
+	meshopt_IndexAdapter<T> out(destination, 0, (index_count / 3) * 5);
 
-	return meshopt_stripify(out.data, in.data, index_count, vertex_count);
+	return meshopt_stripify(out.data, in.data, index_count, vertex_count, use_restart);
 }
 
 template <typename T>

--- a/src/meshoptimizer.h
+++ b/src/meshoptimizer.h
@@ -220,6 +220,7 @@ MESHOPTIMIZER_EXPERIMENTAL size_t meshopt_simplifySloppy(unsigned int* destinati
  * Converts a previously vertex cache optimized triangle list to triangle strip, stitching strips using restart index or degenerate triangles
  * Returns the number of indices in the resulting strip, with destination containing new index data
  * For maximum efficiency the index buffer being converted has to be optimized for vertex cache first.
+ * Using restart indices can result in ~10% smaller index buffers, but on some GPUs restart indices may result in decreased performance.
  *
  * destination must contain enough space for the target index buffer, worst case can be computed with meshopt_stripifyBound
  */

--- a/src/stripifier.cpp
+++ b/src/stripifier.cpp
@@ -48,7 +48,7 @@ static int findStripNext(const unsigned int buffer[][3], unsigned int buffer_siz
 
 } // namespace meshopt
 
-size_t meshopt_stripify(unsigned int* destination, const unsigned int* indices, size_t index_count, size_t vertex_count, int use_restart)
+size_t meshopt_stripify(unsigned int* destination, const unsigned int* indices, size_t index_count, size_t vertex_count, unsigned int restart_index)
 {
 	assert(destination != indices);
 	assert(index_count % 3 == 0);
@@ -197,11 +197,10 @@ size_t meshopt_stripify(unsigned int* destination, const unsigned int* indices, 
 				next = ec;
 			}
 
-			if (use_restart)
+			if (restart_index)
 			{
-				// strip restart index is always 0xff..ff
 				if (strip_size)
-					destination[strip_size++] = ~0u;
+					destination[strip_size++] = restart_index;
 
 				destination[strip_size++] = a;
 				destination[strip_size++] = b;
@@ -249,7 +248,7 @@ size_t meshopt_stripifyBound(size_t index_count)
 	return (index_count / 3) * 5;
 }
 
-size_t meshopt_unstripify(unsigned int* destination, const unsigned int* indices, size_t index_count)
+size_t meshopt_unstripify(unsigned int* destination, const unsigned int* indices, size_t index_count, unsigned int restart_index)
 {
 	assert(destination != indices);
 
@@ -258,7 +257,7 @@ size_t meshopt_unstripify(unsigned int* destination, const unsigned int* indices
 
 	for (size_t i = 0; i < index_count; ++i)
 	{
-		if (indices[i] == ~0u)
+		if (restart_index && indices[i] == restart_index)
 		{
 			start = i + 1;
 		}


### PR DESCRIPTION
This change adds strip stitching using degenerate triangles instead of
restart indices. This is less memory efficient, but it can improve GPU
performance on some systems since restart indices serialize
index processing.

On nyra.obj, restart indices result in 57% index data compared to
triangle lists, whereas degenerate indices result in 62%, so index data
is 1.1x bigger.

meshopt_stripifyBound always assumes worst case so that we don't need to
pass an extra parameter.