### PR TITLE
gltfpack: Implement animation support

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -56,6 +56,7 @@
 				camera.position.z = 3.0;
 
 				scene = new THREE.Scene();
+				scene.background = new THREE.Color(0x300a24);
 
 				var ambientLight = new THREE.AmbientLight(0xcccccc, 0.3);
 				scene.add(ambientLight);

--- a/demo/index.html
+++ b/demo/index.html
@@ -38,21 +38,10 @@
 		<script>
 			var container;
 
-			var camera, scene, renderer;
+			var camera, scene, renderer, mixer, clock;
 
 			var windowHalfX = window.innerWidth / 2;
 			var windowHalfY = window.innerHeight / 2;
-
-			var timers = {};
-
-			console.time = function(label) {
-				timers[label] = performance.now();
-			};
-
-			console.timeEnd = function(label) {
-				var time = performance.now() - timers[label];
-				document.getElementById('info').append(label + " took " + time.toFixed(2) + " ms");
-			};
 
 			init();
 			animate();
@@ -68,7 +57,7 @@
 
 				scene = new THREE.Scene();
 
-				var ambientLight = new THREE.AmbientLight(0xcccccc, 0.2);
+				var ambientLight = new THREE.AmbientLight(0xcccccc, 0.3);
 				scene.add(ambientLight);
 
 				var pointLight = new THREE.PointLight(0xffffff, 0.8);
@@ -77,11 +66,27 @@
 				scene.add(camera);
 
 				var onProgress = function (xhr) {};
-				var onError = function () {};
+				var onError = function (e) {
+					console.log(e);
+				};
 
 				var loader = new THREE.GLTFLoader()
 				loader.setMeshoptDecoder(MeshoptDecoder)
-				loader.load('pirate.glb', function (gltf) { scene.add(gltf.scene); }, onProgress, onError);
+				loader.load('pirate.glb', function (gltf) {
+					var bbox = new THREE.Box3().setFromObject(gltf.scene);
+					var scale = 2 / (bbox.max.y - bbox.min.y);
+
+					gltf.scene.scale.set(scale, scale, scale);
+					gltf.scene.position.set(0, 0, 0);
+
+					scene.add(gltf.scene);
+
+					mixer = new THREE.AnimationMixer(gltf.scene);
+
+					if (gltf.animations.length) {
+						mixer.clipAction(gltf.animations[gltf.animations.length - 1]).play();
+					}
+				}, onProgress, onError);
 
 				renderer = new THREE.WebGLRenderer();
 				renderer.setPixelRatio(window.devicePixelRatio);
@@ -89,6 +94,8 @@
 				container.appendChild(renderer.domElement);
 
 				window.addEventListener('resize', onWindowResize, false);
+
+				clock = new THREE.Clock();
 			}
 
 			function onWindowResize()
@@ -104,6 +111,10 @@
 
 			function animate()
 			{
+				if (mixer) {
+					mixer.update(clock.getDelta());
+				}
+
 				requestAnimationFrame(animate);
 				render();
 			}

--- a/tools/gltfpack.cpp
+++ b/tools/gltfpack.cpp
@@ -834,6 +834,12 @@ const char* shapeType(cgltf_type type)
 		return "\"VEC3\"";
 	case cgltf_type_vec4:
 		return "\"VEC4\"";
+	case cgltf_type_mat2:
+		return "\"MAT2\"";
+	case cgltf_type_mat3:
+		return "\"MAT3\"";
+	case cgltf_type_mat4:
+		return "\"MAT4\"";
 	default:
 		return "\"\"";
 	}
@@ -1100,8 +1106,11 @@ void writeBufferView(std::string& json, cgltf_buffer_view_type type, size_t coun
 		json += ",\"byteStride\":";
 		json += to_string(stride);
 	}
-	json += ",\"target\":";
-	json += (type == cgltf_buffer_view_type_vertices) ? "34962" : "34963";
+	if (type == cgltf_buffer_view_type_vertices || type == cgltf_buffer_view_type_indices)
+	{
+		json += ",\"target\":";
+		json += (type == cgltf_buffer_view_type_vertices) ? "34962" : "34963";
+	}
 	if (compressed)
 	{
 		json += ",\"extensions\":{";
@@ -1531,22 +1540,10 @@ bool process(Scene& scene, const Settings& settings, std::string& json, std::str
 		}
 
 		comma(json_buffer_views);
-		json_buffer_views += "{\"buffer\":0";
-		json_buffer_views += ",\"byteLength\":";
-		json_buffer_views += to_string(bin.size() - bin_offset);
-		json_buffer_views += ",\"byteOffset\":";
-		json_buffer_views += to_string(bin_offset);
-		json_buffer_views += "}";
+		writeBufferView(json_buffer_views, cgltf_buffer_view_type_invalid, skin.joints_count, 64, bin_offset, bin.size() - bin_offset, false);
 
 		comma(json_accessors);
-		json_accessors += "{\"bufferView\":";
-		json_accessors += to_string(view_offset);
-		json_accessors += ",\"componentType\":";
-		json_accessors += componentType(cgltf_component_type_r_32f);
-		json_accessors += ",\"count\":";
-		json_accessors += to_string(skin.joints_count);
-		json_accessors += ",\"type\":\"MAT4\"";
-		json_accessors += "}";
+		writeAccessor(json_accessors, view_offset, cgltf_type_mat4, cgltf_component_type_r_32f, false, skin.joints_count);
 
 		size_t matrix_view = view_offset;
 


### PR DESCRIPTION
This change adds animation support to gltfpack; we now support TRS tracks for nodes with linear interpolation.

All animation tracks are resampled at a fixed frequency which allows us to share the input accessor; additionally constant tracks are folded into a singleton input/output.

There's currently no quantization/compression involved; 16-bit quaternion quantization reduces the size substantially but it doesn't look like Three.JS or Babylon.JS support it right now :(