### PR TITLE
gltfpack: Enable animation compression 

### DIFF
--- a/demo/GLTFLoader.js
+++ b/demo/GLTFLoader.js
@@ -1039,18 +1039,20 @@ THREE.GLTFLoader = ( function () {
 			var result = new ArrayBuffer(count * stride);
 			var source = buffer.slice(byteOffset, byteOffset + byteLength);
 
-			switch ( extensionDef.mode ) {
+			var sourceArray = new Uint8Array(source);
 
-				case 'VERTEX':
-					decoder.decodeVertexBuffer(new Uint8Array(result), count, stride, new Uint8Array(source));
+			switch ( sourceArray[0] >> 4 ) {
+
+				case 0xA:
+					decoder.decodeVertexBuffer(new Uint8Array(result), count, stride, sourceArray);
 					break;
 
-				case 'INDEX':
-					decoder.decodeIndexBuffer(new Uint8Array(result), count, stride, new Uint8Array(source));
+				case 0xE:
+					decoder.decodeIndexBuffer(new Uint8Array(result), count, stride, sourceArray);
 					break;
 
 				default:
-					throw new Error( 'Unknown decode mode: ' + extensionDef.mode );
+					throw new Error( 'THREE.GLTFLoader: Unrecognized meshopt buffer header.' );
 
 			}
 

--- a/demo/GLTFLoader.js
+++ b/demo/GLTFLoader.js
@@ -2951,12 +2951,52 @@ THREE.GLTFLoader = ( function () {
 
 				}
 
+				var outputArray = outputAccessor.array;
+
+				if ( outputAccessor.normalized ) {
+
+					var scale;
+
+					if ( outputArray.constructor === Int8Array ) {
+
+						scale = 1 / 127;
+
+					} else if ( outputArray.constructor === Uint8Array ) {
+
+						scale = 1 / 255;
+
+					} else if ( outputArray.constructor == Int16Array ) {
+
+						scale = 1 / 32767;
+
+					} else if ( outputArray.constructor === Uint16Array ) {
+
+						scale = 1 / 65535;
+
+					} else {
+
+						throw new Error( 'THREE.GLTFLoader: Unsupported output accessor component type.' );
+
+					}
+
+					var scaled = new Float32Array( outputArray.length );
+
+					for ( var j = 0, jl = outputArray.length; j < jl; j ++ ) {
+
+						scaled[j] = outputArray[j] * scale;
+
+					}
+
+					outputArray = scaled;
+
+				}
+
 				for ( var j = 0, jl = targetNames.length; j < jl; j ++ ) {
 
 					var track = new TypedKeyframeTrack(
 						targetNames[ j ] + '.' + PATH_PROPERTIES[ target.path ],
 						inputAccessor.array,
-						outputAccessor.array,
+						outputArray,
 						interpolation
 					);
 

--- a/tools/gltfpack.cpp
+++ b/tools/gltfpack.cpp
@@ -791,38 +791,21 @@ StreamFormat writeKeyframeStream(std::string& bin, cgltf_animation_path_type typ
 {
 	if (type == cgltf_animation_path_type_rotation)
 	{
-		// TODO: in theory, we can use short-normalized quaternion tracks although it looks like three.js and babylon.js have issues with those
-		if (0)
+		for (size_t i = 0; i < data.size(); ++i)
 		{
-			for (size_t i = 0; i < data.size(); ++i)
-			{
-				const Attr& a = data[i];
+			const Attr& a = data[i];
 
-				int16_t v[4] = {
-				    int16_t(meshopt_quantizeSnorm(a.f[0], 16)),
-				    int16_t(meshopt_quantizeSnorm(a.f[1], 16)),
-				    int16_t(meshopt_quantizeSnorm(a.f[2], 16)),
-				    int16_t(meshopt_quantizeSnorm(a.f[3], 16)),
-				};
-				bin.append(reinterpret_cast<const char*>(v), sizeof(v));
-			}
-
-			StreamFormat format = {cgltf_type_vec4, cgltf_component_type_r_16, true, 8};
-			return format;
+			int16_t v[4] = {
+			    int16_t(meshopt_quantizeSnorm(a.f[0], 16)),
+			    int16_t(meshopt_quantizeSnorm(a.f[1], 16)),
+			    int16_t(meshopt_quantizeSnorm(a.f[2], 16)),
+			    int16_t(meshopt_quantizeSnorm(a.f[3], 16)),
+			};
+			bin.append(reinterpret_cast<const char*>(v), sizeof(v));
 		}
-		else
-		{
-			for (size_t i = 0; i < data.size(); ++i)
-			{
-				const Attr& a = data[i];
 
-				float v[4] = {a.f[0], a.f[1], a.f[2], a.f[3]};
-				bin.append(reinterpret_cast<const char*>(v), sizeof(v));
-			}
-
-			StreamFormat format = {cgltf_type_vec4, cgltf_component_type_r_32f, false, 16};
-			return format;
-		}
+		StreamFormat format = {cgltf_type_vec4, cgltf_component_type_r_16, true, 8};
+		return format;
 	}
 	else
 	{
@@ -1211,9 +1194,7 @@ void writeBufferView(std::string& json, cgltf_buffer_view_type type, size_t coun
 	{
 		json += ",\"extensions\":{";
 		json += "\"KHR_meshopt_compression\":{";
-		json += "\"mode\":";
-		json += (type == cgltf_buffer_view_type_vertices) ? "\"VERTEX\"" : (type == cgltf_buffer_view_type_indices) ? "\"INDEX\"" : "\"GENERIC\"";
-		json += ",\"count\":";
+		json += "\"count\":";
 		json += to_string(count);
 		json += ",\"byteStride\":";
 		json += to_string(stride);
@@ -1908,8 +1889,7 @@ bool process(Scene& scene, const Settings& settings, std::string& json, std::str
 			size_t bin_offset = bin.size();
 			StreamFormat format = writeKeyframeStream(bin, channel.target_path, track);
 
-			// TODO: need to enable GENERIC support in GLTFLoader.js
-			bool compress = settings.compress && !tc && false;
+			bool compress = settings.compress && !tc;
 
 			if (compress)
 				compressVertexStream(bin, bin_offset, track.size(), format.stride);

--- a/tools/gltfpack.cpp
+++ b/tools/gltfpack.cpp
@@ -2156,7 +2156,7 @@ int main(int argc, char** argv)
 		std::string binname = binpath;
 		std::string::size_type slash = binname.find_last_of("/\\");
 		if (slash != std::string::npos)
-			binname.erase(0, slash);
+			binname.erase(0, slash + 1);
 
 		FILE* outjson = fopen(output, "wb");
 		FILE* outbin = fopen(binpath.c_str(), "wb");


### PR DESCRIPTION
Since there.js now supports quantized quaternion rotations, we can
enable rotation track quantization; also remove compression mode from
GLTF file as it's redundant in presence of the first byte, and start
compressing animation data for further benefits.
