### PR TITLE
gltfpack: Quantization improvements

### DIFF
--- a/tools/gltfpack.cpp
+++ b/tools/gltfpack.cpp
@@ -198,17 +198,20 @@ void parseMeshesGltf(cgltf_data* data, std::vector<Mesh>& meshes)
 		{
 			const cgltf_primitive& primitive = mesh.primitives[pi];
 
+			if (!primitive.indices)
+				continue;
+
+			if (primitive.type != cgltf_primitive_type_triangles)
+				continue;
+
 			Mesh result;
 
 			result.material = primitive.material;
 			result.skin = node.skin;
 
-			if (cgltf_accessor* a = primitive.indices)
-			{
-				result.indices.resize(a->count);
-				for (size_t i = 0; i < a->count; ++i)
-					result.indices[i] = unsigned(cgltf_accessor_read_index(a, i));
-			}
+			result.indices.resize(primitive.indices->count);
+			for (size_t i = 0; i < primitive.indices->count; ++i)
+				result.indices[i] = unsigned(cgltf_accessor_read_index(primitive.indices, i));
 
 			for (size_t ai = 0; ai < primitive.attributes_count; ++ai)
 			{
@@ -229,8 +232,7 @@ void parseMeshesGltf(cgltf_data* data, std::vector<Mesh>& meshes)
 			if (!node.skin)
 				transformMesh(result, &node);
 
-			if (result.indices.size() && result.streams.size())
-				meshes.push_back(result);
+			meshes.push_back(result);
 		}
 	}
 }

--- a/tools/gltfpack.cpp
+++ b/tools/gltfpack.cpp
@@ -64,6 +64,7 @@ struct Settings
 {
 	int pos_bits;
 	int tex_bits;
+	int nrm_bits;
 	bool nrm_unit;
 
 	int anim_freq;
@@ -647,6 +648,8 @@ StreamFormat writeVertexStream(std::string& bin, const Stream& stream, const Qua
 	}
 	else if (stream.type == cgltf_attribute_type_normal)
 	{
+		int bits = settings.nrm_unit ? 8 : settings.nrm_bits;
+
 		for (size_t i = 0; i < stream.data.size(); ++i)
 		{
 			const Attr& a = stream.data[i];
@@ -657,9 +660,9 @@ StreamFormat writeVertexStream(std::string& bin, const Stream& stream, const Qua
 				rescaleNormal(nx, ny, nz);
 
 			int8_t v[4] = {
-			    int8_t(meshopt_quantizeSnorm(nx, 8)),
-			    int8_t(meshopt_quantizeSnorm(ny, 8)),
-			    int8_t(meshopt_quantizeSnorm(nz, 8)),
+			    int8_t(meshopt_quantizeSnorm(nx, bits)),
+			    int8_t(meshopt_quantizeSnorm(ny, bits)),
+			    int8_t(meshopt_quantizeSnorm(nz, bits)),
 			    0};
 			bin.append(reinterpret_cast<const char*>(v), sizeof(v));
 		}
@@ -669,6 +672,8 @@ StreamFormat writeVertexStream(std::string& bin, const Stream& stream, const Qua
 	}
 	else if (stream.type == cgltf_attribute_type_tangent)
 	{
+		int bits = settings.nrm_unit ? 8 : settings.nrm_bits;
+
 		for (size_t i = 0; i < stream.data.size(); ++i)
 		{
 			const Attr& a = stream.data[i];
@@ -679,9 +684,9 @@ StreamFormat writeVertexStream(std::string& bin, const Stream& stream, const Qua
 				rescaleNormal(nx, ny, nz);
 
 			int8_t v[4] = {
-			    int8_t(meshopt_quantizeSnorm(nx, 8)),
-			    int8_t(meshopt_quantizeSnorm(ny, 8)),
-			    int8_t(meshopt_quantizeSnorm(nz, 8)),
+			    int8_t(meshopt_quantizeSnorm(nx, bits)),
+			    int8_t(meshopt_quantizeSnorm(ny, bits)),
+			    int8_t(meshopt_quantizeSnorm(nz, bits)),
 			    int8_t(meshopt_quantizeSnorm(nw, 8))};
 			bin.append(reinterpret_cast<const char*>(v), sizeof(v));
 		}
@@ -2210,6 +2215,7 @@ int main(int argc, char** argv)
 	Settings settings = {};
 	settings.pos_bits = 14;
 	settings.tex_bits = 12;
+	settings.nrm_bits = 8;
 	settings.anim_freq = 30;
 
 	const char* input = 0;
@@ -2227,6 +2233,10 @@ int main(int argc, char** argv)
 		else if (strcmp(arg, "-vt") == 0 && i + 1 < argc && isdigit(argv[i + 1][0]))
 		{
 			settings.tex_bits = atoi(argv[++i]);
+		}
+		else if (strcmp(arg, "-vn") == 0 && i + 1 < argc && isdigit(argv[i + 1][0]))
+		{
+			settings.nrm_bits = atoi(argv[++i]);
 		}
 		else if (strcmp(arg, "-vu") == 0)
 		{
@@ -2274,8 +2284,9 @@ int main(int argc, char** argv)
 		fprintf(stderr, "Options:\n");
 		fprintf(stderr, "-i file: input file to process, .obj/.gltf/.glb\n");
 		fprintf(stderr, "-o file: output file path, .gltf/.glb\n");
-		fprintf(stderr, "-vp N: use N-bit quantization for position (default: 14; N should be between 1 and 16)\n");
+		fprintf(stderr, "-vp N: use N-bit quantization for positions (default: 14; N should be between 1 and 16)\n");
 		fprintf(stderr, "-vt N: use N-bit quantization for texture corodinates (default: 12; N should be between 1 and 16)\n");
+		fprintf(stderr, "-vn N: use N-bit quantization for normals and tangents (default: 8; N should be between 1 and 8)\n");
 		fprintf(stderr, "-vu: use unit-length normal/tangent vectors (default: off)\n");
 		fprintf(stderr, "-af N: resample animations at N Hz (default: 30)\n");
 		fprintf(stderr, "-ac: keep constant animation tracks even if they don't modify the node transform\n");

--- a/tools/gltfpack.cpp
+++ b/tools/gltfpack.cpp
@@ -63,9 +63,11 @@ struct Mesh
 struct Settings
 {
 	int pos_bits;
-	int uv_bits;
+	int tex_bits;
+
 	int anim_freq;
 	bool anim_const;
+
 	bool compress;
 	bool verbose;
 };
@@ -555,7 +557,7 @@ QuantizationParams prepareQuantization(const std::vector<Mesh>& meshes, const Se
 		result.pos_scale = std::max(pos_max.f[0] - pos_min.f[0], std::max(pos_max.f[1] - pos_min.f[1], pos_max.f[2] - pos_min.f[2]));
 	}
 
-	result.uv_bits = settings.uv_bits;
+	result.uv_bits = settings.tex_bits;
 
 	Attr uv_min, uv_max;
 	if (getAttributeBounds(meshes, cgltf_attribute_type_texcoord, uv_min, uv_max))
@@ -2202,11 +2204,12 @@ int main(int argc, char** argv)
 {
 	Settings settings = {};
 	settings.pos_bits = 14;
-	settings.uv_bits = 12;
+	settings.tex_bits = 12;
 	settings.anim_freq = 30;
 
 	const char* input = 0;
 	const char* output = 0;
+	bool help = false;
 
 	for (int i = 1; i < argc; ++i)
 	{
@@ -2218,7 +2221,7 @@ int main(int argc, char** argv)
 		}
 		else if (strcmp(arg, "-vt") == 0 && i + 1 < argc && isdigit(argv[i + 1][0]))
 		{
-			settings.uv_bits = atoi(argv[++i]);
+			settings.tex_bits = atoi(argv[++i]);
 		}
 		else if (strcmp(arg, "-af") == 0 && i + 1 < argc && isdigit(argv[i + 1][0]))
 		{
@@ -2244,6 +2247,10 @@ int main(int argc, char** argv)
 		{
 			settings.verbose = true;
 		}
+		else if (strcmp(arg, "-h") == 0)
+		{
+			help = true;
+		}
 		else
 		{
 			fprintf(stderr, "Unrecognized option %s\n", arg);
@@ -2251,7 +2258,7 @@ int main(int argc, char** argv)
 		}
 	}
 
-	if (!input || !output)
+	if (!input || !output || help)
 	{
 		fprintf(stderr, "Usage: gltfpack [options] -i input -o output\n");
 		fprintf(stderr, "\n");
@@ -2264,6 +2271,7 @@ int main(int argc, char** argv)
 		fprintf(stderr, "-ac: keep constant animation tracks even if they don't modify the node transform\n");
 		fprintf(stderr, "-c: produce compressed glb files\n");
 		fprintf(stderr, "-v: verbose output\n");
+		fprintf(stderr, "-h: display this help and exit\n");
 
 		return 1;
 	}


### PR DESCRIPTION
This PR adds support for custom normal quantization, unit-length normals and cleans up the code a bit.

Custom normal quantization is helpful because normals/tangents are hard to compress due to high entropy, and often 5 or 6 bits are enough.
Unit-length normal support is valuable for renderers that don't normalize (and presumably don't scale!) normals. Unit-length normals are slightly less precise and larger, so this option is off by default.