### PR TITLE
Support BUILD_SHARED_LIBS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,7 @@ cmake_minimum_required(VERSION 3.0)
 
 option(BUILD_DEMO "Build demo" OFF)
 option(BUILD_TOOLS "Build tools" OFF)
+option(BUILD_SHARED_LIBS "Build shared libraries" OFF)
 
 set(SOURCES
     src/meshoptimizer.h
@@ -21,13 +22,37 @@ set(SOURCES
     src/vfetchoptimizer.cpp
 )
 
-add_library(meshoptimizer STATIC ${SOURCES})
+add_library(meshoptimizer ${SOURCES})
 target_include_directories(meshoptimizer INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}/src")
 
 if(MSVC)
 	target_compile_options(meshoptimizer PRIVATE /W4 /WX)
 else()
 	target_compile_options(meshoptimizer PRIVATE -Wall -Wextra -Werror)
+endif()
+
+if(BUILD_SHARED_LIBS)
+    set_target_properties(
+        meshoptimizer
+        PROPERTIES
+        CXX_VISIBILITY_PRESET hidden
+        VISIBILITY_INLINES_HIDDEN ON
+    )
+    if(WIN32)
+        target_compile_definitions(
+            meshoptimizer
+            INTERFACE
+            "MESHOPTIMIZER_API=__declspec(dllimport)"
+            PRIVATE
+            "MESHOPTIMIZER_API=__declspec(dllexport)"
+        )
+    else()
+        target_compile_definitions(
+            meshoptimizer
+            PUBLIC
+            "MESHOPTIMIZER_API=__attribute__((visibility(\"default\")))"
+        )
+    endif()
 endif()
 
 if(BUILD_DEMO)


### PR DESCRIPTION
Adds the ability to build as a shared library using the global CMake option BUILD_SHARED_LIBS