### PR TITLE
spatial: Introduce spatialSort and spatialSortTriangles

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,7 @@ set(SOURCES
     src/overdrawanalyzer.cpp
     src/overdrawoptimizer.cpp
     src/simplifier.cpp
+    src/spatialorder.cpp
     src/stripifier.cpp
     src/vcacheanalyzer.cpp
     src/vcacheoptimizer.cpp

--- a/demo/main.cpp
+++ b/demo/main.cpp
@@ -771,6 +771,68 @@ void meshlets(const Mesh& mesh)
 	       (endc - startc) * 1000);
 }
 
+void spatialSort(const Mesh& mesh)
+{
+	typedef PackedVertexOct PV;
+
+	std::vector<PV> pv(mesh.vertices.size());
+	packMesh(pv, mesh.vertices);
+
+	double start = timestamp();
+
+	std::vector<unsigned int> remap(mesh.vertices.size());
+	meshopt_spatialSort(&remap[0], &mesh.vertices[0].px, mesh.vertices.size(), sizeof(Vertex));
+
+	double end = timestamp();
+
+	meshopt_remapVertexBuffer(&pv[0], &pv[0], mesh.vertices.size(), sizeof(PV), &remap[0]);
+
+	std::vector<unsigned char> vbuf(meshopt_encodeVertexBufferBound(mesh.vertices.size(), sizeof(PV)));
+	vbuf.resize(meshopt_encodeVertexBuffer(&vbuf[0], vbuf.size(), &pv[0], mesh.vertices.size(), sizeof(PV)));
+
+	size_t csize = compress(vbuf);
+
+	printf("Spatial  : %.1f bits/vertex (post-deflate %.1f bits/vertex); sort %.2f msec\n",
+	       double(vbuf.size() * 8) / double(mesh.vertices.size()),
+	       double(csize * 8) / double(mesh.vertices.size()),
+	       (end - start) * 1000);
+}
+
+void spatialSortTriangles(const Mesh& mesh)
+{
+	typedef PackedVertexOct PV;
+
+	Mesh copy = mesh;
+
+	double start = timestamp();
+
+	meshopt_spatialSortTriangles(&copy.indices[0], &copy.indices[0], mesh.indices.size(), &copy.vertices[0].px, copy.vertices.size(), sizeof(Vertex));
+
+	double end = timestamp();
+
+	meshopt_optimizeVertexCache(&copy.indices[0], &copy.indices[0], copy.indices.size(), copy.vertices.size());
+	meshopt_optimizeVertexFetch(&copy.vertices[0], &copy.indices[0], copy.indices.size(), &copy.vertices[0], copy.vertices.size(), sizeof(Vertex));
+
+	std::vector<PV> pv(mesh.vertices.size());
+	packMesh(pv, copy.vertices);
+
+	std::vector<unsigned char> vbuf(meshopt_encodeVertexBufferBound(mesh.vertices.size(), sizeof(PV)));
+	vbuf.resize(meshopt_encodeVertexBuffer(&vbuf[0], vbuf.size(), &pv[0], mesh.vertices.size(), sizeof(PV)));
+
+	std::vector<unsigned char> ibuf(meshopt_encodeIndexBufferBound(mesh.indices.size(), mesh.vertices.size()));
+	ibuf.resize(meshopt_encodeIndexBuffer(&ibuf[0], ibuf.size(), &copy.indices[0], mesh.indices.size()));
+
+	size_t csizev = compress(vbuf);
+	size_t csizei = compress(ibuf);
+
+	printf("SpatialT : %.1f bits/vertex (post-deflate %.1f bits/vertex); %.1f bits/triangle (post-deflate %.1f bits/triangle); sort %.2f msec\n",
+	       double(vbuf.size() * 8) / double(mesh.vertices.size()),
+	       double(csizev * 8) / double(mesh.vertices.size()),
+	       double(ibuf.size() * 8) / double(mesh.indices.size() / 3),
+	       double(csizei * 8) / double(mesh.indices.size() / 3),
+	       (end - start) * 1000);
+}
+
 bool loadMesh(Mesh& mesh, const char* path)
 {
 	double start = timestamp();
@@ -924,6 +986,9 @@ void process(const char* path)
 	simplifySloppy(mesh);
 	simplifyComplete(mesh);
 
+	spatialSort(mesh);
+	spatialSortTriangles(mesh);
+
 	if (path)
 		processDeinterleaved(path);
 }
@@ -934,9 +999,15 @@ void processDev(const char* path)
 	if (!loadMesh(mesh, path))
 		return;
 
-	simplifySloppy(mesh, 0.5f);
-	simplifySloppy(mesh, 0.1f);
-	simplifySloppy(mesh, 0.01f);
+	Mesh copy = mesh;
+	meshopt_optimizeVertexCache(&copy.indices[0], &copy.indices[0], copy.indices.size(), copy.vertices.size());
+	meshopt_optimizeVertexFetch(&copy.vertices[0], &copy.indices[0], copy.indices.size(), &copy.vertices[0], copy.vertices.size(), sizeof(Vertex));
+
+	encodeIndex(copy);
+	encodeVertex<PackedVertexOct>(copy, "O");
+
+	spatialSort(mesh);
+	spatialSortTriangles(mesh);
 }
 
 int main(int argc, char** argv)

--- a/demo/main.cpp
+++ b/demo/main.cpp
@@ -781,7 +781,7 @@ void spatialSort(const Mesh& mesh)
 	double start = timestamp();
 
 	std::vector<unsigned int> remap(mesh.vertices.size());
-	meshopt_spatialSort(&remap[0], &mesh.vertices[0].px, mesh.vertices.size(), sizeof(Vertex));
+	meshopt_spatialSortRemap(&remap[0], &mesh.vertices[0].px, mesh.vertices.size(), sizeof(Vertex));
 
 	double end = timestamp();
 

--- a/src/meshoptimizer.h
+++ b/src/meshoptimizer.h
@@ -343,6 +343,19 @@ MESHOPTIMIZER_EXPERIMENTAL struct meshopt_Bounds meshopt_computeClusterBounds(co
 MESHOPTIMIZER_EXPERIMENTAL struct meshopt_Bounds meshopt_computeMeshletBounds(const struct meshopt_Meshlet* meshlet, const float* vertex_positions, size_t vertex_count, size_t vertex_positions_stride);
 
 /**
+ * Experimental: Spatial order generator
+ * Generates a remap table that can be used to reorder points for spatial locality.
+ * Resulting remap table maps old vertices to new vertices and can be used in meshopt_remapVertexBuffer.
+ */
+MESHOPTIMIZER_EXPERIMENTAL void meshopt_spatialSort(unsigned int* destination, const float* vertex_positions, size_t vertex_count, size_t vertex_positions_stride);
+
+/**
+ * Experimental: Spatial order generator
+ * Reorders triangles for spatial locality.
+ */
+MESHOPTIMIZER_EXPERIMENTAL void meshopt_spatialSortTriangles(unsigned int* destination, const unsigned int* indices, size_t index_count, const float* vertex_positions, size_t vertex_count, size_t vertex_positions_stride);
+
+/**
  * Set allocation callbacks
  * These callbacks will be used instead of the default operator new/operator delete for all temporary allocations in the library.
  * Note that all algorithms only allocate memory for temporary use.
@@ -619,6 +632,15 @@ inline meshopt_Bounds meshopt_computeClusterBounds(const T* indices, size_t inde
 	meshopt_IndexAdapter<T> in(0, indices, index_count);
 
 	return meshopt_computeClusterBounds(in.data, index_count, vertex_positions, vertex_count, vertex_positions_stride);
+}
+
+template <typename T>
+inline void meshopt_spatialSortTriangles(T* destination, const T* indices, size_t index_count, const float* vertex_positions, size_t vertex_count, size_t vertex_positions_stride)
+{
+	meshopt_IndexAdapter<T> in(0, indices, index_count);
+	meshopt_IndexAdapter<T> out(destination, 0, index_count);
+
+	meshopt_spatialSortTriangles(out.data, in.data, index_count, vertex_positions, vertex_count, vertex_positions_stride);
 }
 #endif
 

--- a/src/meshoptimizer.h
+++ b/src/meshoptimizer.h
@@ -343,15 +343,21 @@ MESHOPTIMIZER_EXPERIMENTAL struct meshopt_Bounds meshopt_computeClusterBounds(co
 MESHOPTIMIZER_EXPERIMENTAL struct meshopt_Bounds meshopt_computeMeshletBounds(const struct meshopt_Meshlet* meshlet, const float* vertex_positions, size_t vertex_count, size_t vertex_positions_stride);
 
 /**
- * Experimental: Spatial order generator
+ * Experimental: Spatial sorter
  * Generates a remap table that can be used to reorder points for spatial locality.
  * Resulting remap table maps old vertices to new vertices and can be used in meshopt_remapVertexBuffer.
+ *
+ * destination must contain enough space for the resulting remap table (vertex_count elements)
  */
-MESHOPTIMIZER_EXPERIMENTAL void meshopt_spatialSort(unsigned int* destination, const float* vertex_positions, size_t vertex_count, size_t vertex_positions_stride);
+MESHOPTIMIZER_EXPERIMENTAL void meshopt_spatialSortRemap(unsigned int* destination, const float* vertex_positions, size_t vertex_count, size_t vertex_positions_stride);
 
 /**
- * Experimental: Spatial order generator
- * Reorders triangles for spatial locality.
+ * Experimental: Spatial sorter
+ * Reorders triangles for spatial locality, and generates a new index buffer. The resulting index buffer can be used with other functions like optimizeVertexCache.
+ *
+ * destination must contain enough space for the resulting index buffer (index_count elements)
+ * indices must contain index data that is the result of meshopt_optimizeVertexCache (*not* the original mesh indices!)
+ * vertex_positions should have float3 position in the first 12 bytes of each vertex - similar to glVertexPointer
  */
 MESHOPTIMIZER_EXPERIMENTAL void meshopt_spatialSortTriangles(unsigned int* destination, const unsigned int* indices, size_t index_count, const float* vertex_positions, size_t vertex_count, size_t vertex_positions_stride);
 

--- a/src/spatialorder.cpp
+++ b/src/spatialorder.cpp
@@ -49,6 +49,7 @@ static void computeOrder(unsigned int* result, const float* vertex_positions_dat
 
 	float scale = extent == 0 ? 0.f : 1.f / extent;
 
+	// generate Morton order based on the position inside a unit cube
 	for (size_t i = 0; i < vertex_count; ++i)
 	{
 		const float* v = vertex_positions_data + i * vertex_stride_float;
@@ -61,11 +62,11 @@ static void computeOrder(unsigned int* result, const float* vertex_positions_dat
 	}
 }
 
-// TODO: is it faster to use [3][1024]?
 static void computeHistogram(unsigned int (&hist)[1024][3], const unsigned int* data, size_t count)
 {
 	memset(hist, 0, sizeof(hist));
 
+	// compute 3 10-bit histograms in parallel
 	for (size_t i = 0; i < count; ++i)
 	{
 		unsigned int id = data[i];
@@ -77,6 +78,7 @@ static void computeHistogram(unsigned int (&hist)[1024][3], const unsigned int* 
 
 	unsigned int sumx = 0, sumy = 0, sumz = 0;
 
+	// replace histogram data with prefix histogram sums in-place
 	for (int i = 0; i < 1024; ++i)
 	{
 		unsigned int hx = hist[i][0], hy = hist[i][1], hz = hist[i][2];
@@ -147,27 +149,26 @@ void meshopt_spatialSortTriangles(unsigned int* destination, const unsigned int*
 
 	(void)vertex_count;
 
-	meshopt_Allocator allocator;
-
-	float* centroids = allocator.allocate<float>(index_count);
-
+	size_t face_count = index_count / 3;
 	size_t vertex_stride_float = vertex_positions_stride / sizeof(float);
 
-	for (size_t i = 0; i < index_count; i += 3)
+	meshopt_Allocator allocator;
+
+	float* centroids = allocator.allocate<float>(face_count * 3);
+
+	for (size_t i = 0; i < face_count; ++i)
 	{
-		unsigned int a = indices[i + 0], b = indices[i + 1], c = indices[i + 2];
+		unsigned int a = indices[i * 3 + 0], b = indices[i * 3 + 1], c = indices[i * 3 + 2];
 		assert(a < vertex_count && b < vertex_count && c < vertex_count);
 
 		const float* va = vertex_positions + a * vertex_stride_float;
 		const float* vb = vertex_positions + b * vertex_stride_float;
 		const float* vc = vertex_positions + c * vertex_stride_float;
 
-		centroids[i + 0] = (va[0] + vb[0] + vc[0]) / 3.f;
-		centroids[i + 1] = (va[1] + vb[1] + vc[1]) / 3.f;
-		centroids[i + 2] = (va[2] + vb[2] + vc[2]) / 3.f;
+		centroids[i * 3 + 0] = (va[0] + vb[0] + vc[0]) / 3.f;
+		centroids[i * 3 + 1] = (va[1] + vb[1] + vc[1]) / 3.f;
+		centroids[i * 3 + 2] = (va[2] + vb[2] + vc[2]) / 3.f;
 	}
-
-	size_t face_count = index_count / 3;
 
 	unsigned int* remap = allocator.allocate<unsigned int>(face_count);
 

--- a/src/spatialorder.cpp
+++ b/src/spatialorder.cpp
@@ -1,0 +1,188 @@
+// This file is part of meshoptimizer library; see meshoptimizer.h for version/license details
+#include "meshoptimizer.h"
+
+#include <assert.h>
+#include <float.h>
+#include <string.h>
+
+namespace meshopt
+{
+
+static void computeOrder(unsigned int* result, const float* vertex_positions_data, size_t vertex_count, size_t vertex_positions_stride)
+{
+	size_t vertex_stride_float = vertex_positions_stride / sizeof(float);
+
+	float minv[3] = {FLT_MAX, FLT_MAX, FLT_MAX};
+	float maxv[3] = {-FLT_MAX, -FLT_MAX, -FLT_MAX};
+
+	for (size_t i = 0; i < vertex_count; ++i)
+	{
+		const float* v = vertex_positions_data + i * vertex_stride_float;
+
+		for (int j = 0; j < 3; ++j)
+		{
+			float vj = v[j];
+
+			minv[j] = minv[j] > vj ? vj : minv[j];
+			maxv[j] = maxv[j] < vj ? vj : maxv[j];
+		}
+	}
+
+	float extent = 0.f;
+
+	extent = (maxv[0] - minv[0]) < extent ? extent : (maxv[0] - minv[0]);
+	extent = (maxv[1] - minv[1]) < extent ? extent : (maxv[1] - minv[1]);
+	extent = (maxv[2] - minv[2]) < extent ? extent : (maxv[2] - minv[2]);
+
+	float scale = extent == 0 ? 0.f : 1.f / extent;
+
+	for (size_t i = 0; i < vertex_count; ++i)
+	{
+		const float* v = vertex_positions_data + i * vertex_stride_float;
+
+		int x = int((v[0] - minv[0]) * scale * 1023.f + 0.5f);
+		int y = int((v[1] - minv[1]) * scale * 1023.f + 0.5f);
+		int z = int((v[2] - minv[2]) * scale * 1023.f + 0.5f);
+
+		// a *not* very efficient morton order calculation :)
+		unsigned int id = 0;
+
+		for (int bit = 0; bit < 10; ++bit)
+		{
+			id |= ((x >> bit) & 1) << (bit * 3 + 0);
+			id |= ((y >> bit) & 1) << (bit * 3 + 1);
+			id |= ((z >> bit) & 1) << (bit * 3 + 2);
+		}
+
+		result[i] = id;
+	}
+}
+
+// TODO: is it faster to use [3][1024]?
+static void computeHistogram(unsigned int (&hist)[1024][3], const unsigned int* data, size_t count)
+{
+	memset(hist, 0, sizeof(hist));
+
+	for (size_t i = 0; i < count; ++i)
+	{
+		unsigned int id = data[i];
+
+		hist[(id >> 0) & 1023][0]++;
+		hist[(id >> 10) & 1023][1]++;
+		hist[(id >> 20) & 1023][2]++;
+	}
+
+	unsigned int sumx = 0, sumy = 0, sumz = 0;
+
+	for (int i = 0; i < 1024; ++i)
+	{
+		unsigned int hx = hist[i][0], hy = hist[i][1], hz = hist[i][2];
+
+		hist[i][0] = sumx;
+		hist[i][1] = sumy;
+		hist[i][2] = sumz;
+
+		sumx += hx;
+		sumy += hy;
+		sumz += hz;
+	}
+
+	assert(sumx == count && sumy == count && sumz == count);
+}
+
+static void radixPass(unsigned int* destination, const unsigned int* source, const unsigned int* keys, size_t count, unsigned int (&hist)[1024][3], int pass)
+{
+	int bitoff = pass * 10;
+
+	for (size_t i = 0; i < count; ++i)
+	{
+		unsigned int id = (keys[source[i]] >> bitoff) & 1023;
+
+		destination[hist[id][pass]++] = source[i];
+	}
+}
+
+} // namespace meshopt
+
+void meshopt_spatialSort(unsigned int* destination, const float* vertex_positions, size_t vertex_count, size_t vertex_positions_stride)
+{
+	using namespace meshopt;
+
+	assert(vertex_positions_stride > 0 && vertex_positions_stride <= 256);
+	assert(vertex_positions_stride % sizeof(float) == 0);
+
+	meshopt_Allocator allocator;
+
+	unsigned int* keys = allocator.allocate<unsigned int>(vertex_count);
+	computeOrder(keys, vertex_positions, vertex_count, vertex_positions_stride);
+
+	unsigned int hist[1024][3];
+	computeHistogram(hist, keys, vertex_count);
+
+	unsigned int* scratch = allocator.allocate<unsigned int>(vertex_count);
+
+	for (size_t i = 0; i < vertex_count; ++i)
+		destination[i] = unsigned(i);
+
+	// 3-pass radix sort computes the resulting order into scratch
+	radixPass(scratch, destination, keys, vertex_count, hist, 0);
+	radixPass(destination, scratch, keys, vertex_count, hist, 1);
+	radixPass(scratch, destination, keys, vertex_count, hist, 2);
+
+	// since our remap table is mapping old=>new, we need to reverse it
+	for (size_t i = 0; i < vertex_count; ++i)
+		destination[scratch[i]] = unsigned(i);
+}
+
+void meshopt_spatialSortTriangles(unsigned int* destination, const unsigned int* indices, size_t index_count, const float* vertex_positions, size_t vertex_count, size_t vertex_positions_stride)
+{
+	using namespace meshopt;
+
+	assert(index_count % 3 == 0);
+	assert(vertex_positions_stride > 0 && vertex_positions_stride <= 256);
+	assert(vertex_positions_stride % sizeof(float) == 0);
+
+	meshopt_Allocator allocator;
+
+	float* centroids = allocator.allocate<float>(index_count);
+
+	size_t vertex_stride_float = vertex_positions_stride / sizeof(float);
+
+	for (size_t i = 0; i < index_count; i += 3)
+	{
+		unsigned int a = indices[i + 0], b = indices[i + 1], c = indices[i + 2];
+		assert(a < vertex_count && b < vertex_count && c < vertex_count);
+
+		const float* va = vertex_positions + a * vertex_stride_float;
+		const float* vb = vertex_positions + b * vertex_stride_float;
+		const float* vc = vertex_positions + c * vertex_stride_float;
+
+		centroids[i + 0] = (va[0] + vb[0] + vc[0]) / 3.f;
+		centroids[i + 1] = (va[1] + vb[1] + vc[1]) / 3.f;
+		centroids[i + 2] = (va[2] + vb[2] + vc[2]) / 3.f;
+	}
+
+	size_t face_count = index_count / 3;
+
+	unsigned int* remap = allocator.allocate<unsigned int>(face_count);
+
+	meshopt_spatialSort(remap, centroids, face_count, sizeof(float) * 3);
+
+	// support in-order remap
+	if (destination == indices)
+	{
+		unsigned int* indices_copy = allocator.allocate<unsigned int>(index_count);
+		memcpy(indices_copy, indices, index_count * sizeof(unsigned int));
+		indices = indices_copy;
+	}
+
+	for (size_t i = 0; i < face_count; ++i)
+	{
+		unsigned int a = indices[i * 3 + 0], b = indices[i * 3 + 1], c = indices[i * 3 + 2];
+		unsigned int r = remap[i];
+
+		destination[r * 3 + 0] = a;
+		destination[r * 3 + 1] = b;
+		destination[r * 3 + 2] = c;
+	}
+}

--- a/src/spatialorder.cpp
+++ b/src/spatialorder.cpp
@@ -107,7 +107,7 @@ static void radixPass(unsigned int* destination, const unsigned int* source, con
 
 } // namespace meshopt
 
-void meshopt_spatialSort(unsigned int* destination, const float* vertex_positions, size_t vertex_count, size_t vertex_positions_stride)
+void meshopt_spatialSortRemap(unsigned int* destination, const float* vertex_positions, size_t vertex_count, size_t vertex_positions_stride)
 {
 	using namespace meshopt;
 
@@ -169,7 +169,7 @@ void meshopt_spatialSortTriangles(unsigned int* destination, const unsigned int*
 
 	unsigned int* remap = allocator.allocate<unsigned int>(face_count);
 
-	meshopt_spatialSort(remap, centroids, face_count, sizeof(float) * 3);
+	meshopt_spatialSortRemap(remap, centroids, face_count, sizeof(float) * 3);
 
 	// support in-order remap
 	if (destination == indices)

--- a/src/spatialorder.cpp
+++ b/src/spatialorder.cpp
@@ -145,6 +145,8 @@ void meshopt_spatialSortTriangles(unsigned int* destination, const unsigned int*
 	assert(vertex_positions_stride > 0 && vertex_positions_stride <= 256);
 	assert(vertex_positions_stride % sizeof(float) == 0);
 
+	(void)vertex_count;
+
 	meshopt_Allocator allocator;
 
 	float* centroids = allocator.allocate<float>(index_count);

--- a/tools/gltfpack.cpp
+++ b/tools/gltfpack.cpp
@@ -814,7 +814,7 @@ void sortPointMesh(Mesh& mesh)
 	size_t total_vertices = mesh.streams[positions].data.size();
 
 	std::vector<unsigned int> remap(total_vertices);
-	meshopt_spatialSort(&remap[0], mesh.streams[positions].data[0].f, total_vertices, sizeof(Attr));
+	meshopt_spatialSortRemap(&remap[0], mesh.streams[positions].data[0].f, total_vertices, sizeof(Attr));
 
 	for (size_t i = 0; i < mesh.streams.size(); ++i)
 	{


### PR DESCRIPTION
These functions are designed to sort vertices or triangles by the
spatial proximity. The goal is to improve spatial locality to make
other, subsequently ran algorithms, perform better.

Currently the implementation is using Morton order, which is a
reasonable proxy but in the future we will try to use a kD tree sort.

This PR also uses the new functions to sort point cloud meshes in
gltfpack.

This substantially increases the compression efficiency; for example,
kitchen.gltf before this change had almost incompressible data (24.5
bits color, 48.0 bits positions) due to the random order. After this
change, the color gets compressed to 16.5 bits and positions get
compressed to 20.1 bits.
