### PR TITLE
gltfpack: Implement targetNames support

### DIFF
--- a/tools/cgltf.h
+++ b/tools/cgltf.h
@@ -2012,16 +2012,15 @@ static int cgltf_parse_json_mesh(cgltf_options* options, jsmntok_t const* tokens
 		}
 		else if (cgltf_json_strcmp(tokens + i, json_chunk, "extras") == 0)
 		{
-			int skip = cgltf_parse_json_extras(tokens, i + 1, json_chunk, &out_mesh->extras);
-			if (skip < 0)
-			{
-				return skip;
-			}
+			++i;
 
-			if (tokens[i+1].type == JSMN_OBJECT)
+			out_mesh->extras.start_offset = tokens[i].start;
+			out_mesh->extras.end_offset = tokens[i].end;
+
+			if (tokens[i].type == JSMN_OBJECT)
 			{
-				int extras_size = tokens[i+1].size;
-				i += 2;
+				int extras_size = tokens[i].size;
+				++i;
 
 				for (int k = 0; k < extras_size; ++k)
 				{
@@ -2042,8 +2041,10 @@ static int cgltf_parse_json_mesh(cgltf_options* options, jsmntok_t const* tokens
 					}
 				}
 			}
-
-			i = skip;
+			else
+			{
+				i = cgltf_skip_json(tokens, i);
+			}
 		}
 		else
 		{

--- a/tools/cgltf.h
+++ b/tools/cgltf.h
@@ -373,6 +373,8 @@ typedef struct cgltf_mesh {
 	cgltf_size primitives_count;
 	cgltf_float* weights;
 	cgltf_size weights_count;
+	char** target_names;
+	cgltf_size target_names_count;
 	cgltf_extras extras;
 } cgltf_mesh;
 
@@ -1171,6 +1173,14 @@ cgltf_result cgltf_validate(cgltf_data* data)
 			}
 		}
 
+		if (data->meshes[i].target_names)
+		{
+			if (data->meshes[i].primitives_count && data->meshes[i].primitives[0].targets_count != data->meshes[i].target_names_count)
+			{
+				return cgltf_result_invalid_gltf;
+			}
+		}
+
 		for (cgltf_size j = 0; j < data->meshes[i].primitives_count; ++j)
 		{
 			if (data->meshes[i].primitives[j].targets_count != data->meshes[i].primitives[0].targets_count)
@@ -1321,6 +1331,13 @@ void cgltf_free(cgltf_data* data)
 
 		data->memory_free(data->memory_user_data, data->meshes[i].primitives);
 		data->memory_free(data->memory_user_data, data->meshes[i].weights);
+
+		for (cgltf_size j = 0; j < data->meshes[i].target_names_count; ++j)
+		{
+			data->memory_free(data->memory_user_data, data->meshes[i].target_names[j]);
+		}
+
+		data->memory_free(data->memory_user_data, data->meshes[i].target_names);
 	}
 
 	data->memory_free(data->memory_user_data, data->meshes);
@@ -1995,7 +2012,38 @@ static int cgltf_parse_json_mesh(cgltf_options* options, jsmntok_t const* tokens
 		}
 		else if (cgltf_json_strcmp(tokens + i, json_chunk, "extras") == 0)
 		{
-			i = cgltf_parse_json_extras(tokens, i + 1, json_chunk, &out_mesh->extras);
+			int skip = cgltf_parse_json_extras(tokens, i + 1, json_chunk, &out_mesh->extras);
+			if (skip < 0)
+			{
+				return skip;
+			}
+
+			if (tokens[i+1].type == JSMN_OBJECT)
+			{
+				int extras_size = tokens[i+1].size;
+				i += 2;
+
+				for (int k = 0; k < extras_size; ++k)
+				{
+					CGLTF_CHECK_KEY(tokens[i]);
+
+					if (cgltf_json_strcmp(tokens+i, json_chunk, "targetNames") == 0)
+					{
+						i = cgltf_parse_json_string_array(options, tokens, i + 1, json_chunk, &out_mesh->target_names, &out_mesh->target_names_count);
+					}
+					else
+					{
+						i = cgltf_skip_json(tokens, i+1);
+					}
+
+					if (i < 0)
+					{
+						return i;
+					}
+				}
+			}
+
+			i = skip;
 		}
 		else
 		{

--- a/tools/gltfpack.cpp
+++ b/tools/gltfpack.cpp
@@ -65,6 +65,7 @@ struct Mesh
 
 	size_t targets;
 	std::vector<float> target_weights;
+	std::vector<const char*> target_names;
 };
 
 struct Settings
@@ -321,6 +322,7 @@ void parseMeshesGltf(cgltf_data* data, std::vector<Mesh>& meshes)
 
 			result.targets = primitive.targets_count;
 			result.target_weights.assign(mesh.weights, mesh.weights + mesh.weights_count);
+			result.target_names.assign(mesh.target_names, mesh.target_names + mesh.target_names_count);
 
 			meshes.push_back(result);
 		}
@@ -637,6 +639,13 @@ bool compareMeshTargets(const Mesh& lhs, const Mesh& rhs)
 
 	for (size_t i = 0; i < lhs.target_weights.size(); ++i)
 		if (lhs.target_weights[i] != rhs.target_weights[i])
+			return false;
+
+	if (lhs.target_names.size() != rhs.target_names.size())
+		return false;
+
+	for (size_t i = 0; i < lhs.target_names.size(); ++i)
+		if (strcmp(lhs.target_names[i], rhs.target_names[i]) != 0)
 			return false;
 
 	return true;
@@ -3107,6 +3116,20 @@ void process(cgltf_data* data, std::vector<Mesh>& meshes, const Settings& settin
 			}
 			append(json_meshes, "]");
 		}
+
+		if (mesh.target_names.size())
+		{
+			append(json_meshes, ",\"extras\":{\"targetNames\":[");
+			for (size_t j = 0; j < mesh.target_names.size(); ++j)
+			{
+				comma(json_meshes);
+				append(json_meshes, "\"");
+				append(json_meshes, mesh.target_names[j]);
+				append(json_meshes, "\"");
+			}
+			append(json_meshes, "]}");
+		}
+
 		append(json_meshes, "}");
 
 		writeMeshNode(json_nodes, mesh_offset, mesh, data, qp);


### PR DESCRIPTION
We now preserve morph target names if present in the source glTF file;
meshes with the same set of targets but with different names aren't
merged to preserve name mapping.

This required extending cgltf to parse target names; patch will be submitted
to cgltf repository separately.

Fixes #61.