### PR TITLE
CI build performance improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,17 +18,17 @@ matrix:
         - TARGET="Visual Studio 15 2017 Win64"
 
 script:
-  - if [[ "$TRAVIS_COMPILER" == "gcc" ]]; then make config=coverage test; fi
-  - if [[ "$TRAVIS_COMPILER" == "clang" ]]; then make config=sanitize test; fi
-  - if [[ "$TRAVIS_OS_NAME" != "windows" ]]; then make config=debug test; fi
-  - if [[ "$TRAVIS_OS_NAME" != "windows" ]]; then make config=release test; fi
-  - if [[ "$TRAVIS_OS_NAME" != "windows" ]]; then make config=release gltfpack; fi
+  - if [[ "$TRAVIS_COMPILER" == "gcc" ]]; then make -j2 config=coverage test; fi
+  - if [[ "$TRAVIS_COMPILER" == "clang" ]]; then make -j2 config=sanitize test; fi
+  - if [[ "$TRAVIS_OS_NAME" != "windows" ]]; then make -j2 config=debug test; fi
+  - if [[ "$TRAVIS_OS_NAME" != "windows" ]]; then make -j2 config=release test; fi
+  - if [[ "$TRAVIS_OS_NAME" != "windows" ]]; then make -j2 config=release gltfpack; fi
   - if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then cmake -G "$TARGET" -DBUILD_DEMO=ON -DBUILD_TOOLS=ON; fi
   - if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then cmake --build . -- -property:Configuration=Debug -verbosity:minimal; fi
   - if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then ./Debug/demo.exe demo/pirate.obj; fi
   - if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then cmake --build . -- -property:Configuration=Release -verbosity:minimal; fi
   - if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then ./Release/demo.exe demo/pirate.obj; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then make config=iphone; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then make -j2 config=iphone; fi
 
 after_script:
   - if [[ "$TRAVIS_COMPILER" == "gcc" ]]; then

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.0)
 
-project(meshoptimizer VERSION 0.12)
+project(meshoptimizer VERSION 0.12 LANGUAGES CXX)
 
 option(BUILD_DEMO "Build demo" OFF)
 option(BUILD_TOOLS "Build tools" OFF)


### PR DESCRIPTION
- CMake project now specifies C++ as a project language, which saves ~10 seconds on configuring C compiler in CMake
- All make invocations use two cores for a ~5 second speed boost on macOS/Linux builds