### PR TITLE
Add GitHub Actions build

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -1,0 +1,47 @@
+name: C/C++ CI
+
+on: [push]
+
+jobs:
+  unix:
+    runs-on: ${{matrix.os}}-latest
+    strategy:
+      matrix:
+        os: [ubuntu, macos]
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: make test
+      run: |
+        make -j2 config=sanitize test
+        make -j2 config=debug test
+        make -j2 config=release test
+        make -j2 config=release gltfpack
+    - name: make iphone
+      if: matrix.os == 'macos'
+      run: make -j2 config=iphone
+    - name: make coverage
+      if: matrix.os == 'ubuntu'
+      run: |
+        make -j2 config=coverage test
+        find . -type f -name '*.gcno' -exec gcov -p {} +
+        sed -i -e "s/#####\(.*\)\(\/\/ unreachable.*\)/    -\1\2/" *.gcov
+        bash <(curl -s https://codecov.io/bash) -f 'src#*.gcov' -X search -t ${{secrets.CODECOV_TOKEN}}
+
+  windows:
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        arch: [Win32, x64]
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: cmake configure
+      run: cmake . -DBUILD_DEMO=ON -DBUILD_TOOLS=ON -A ${{matrix.arch}}
+    - name: cmake test
+      shell: bash # necessary for fail-fast
+      run: |
+        cmake --build . -- -property:Configuration=Debug -verbosity:minimal
+        Debug/demo.exe demo/pirate.obj
+        cmake --build . -- -property:Configuration=Release -verbosity:minimal
+        Release/demo.exe demo/pirate.obj

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,6 @@
-name: C/C++ CI
+name: Build
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   unix:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,12 +3,25 @@ name: Build
 on: [push, pull_request]
 
 jobs:
-  unix:
-    runs-on: ${{matrix.os}}-latest
-    strategy:
-      matrix:
-        os: [ubuntu, macos]
+  linux:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: make test
+      run: |
+        make -j2 config=sanitize test
+        make -j2 config=debug test
+        make -j2 config=release test
+        make -j2 config=release gltfpack
+    - name: make coverage
+      run: |
+        make -j2 config=coverage test
+        find . -type f -name '*.gcno' -exec gcov -p {} +
+        sed -i -e "s/#####\(.*\)\(\/\/ unreachable.*\)/    -\1\2/" *.gcov
+        bash <(curl -s https://codecov.io/bash) -f 'src#*.gcov' -X search -t ${{secrets.CODECOV_TOKEN}}
 
+  macos:
+    runs-on: macos-latest
     steps:
     - uses: actions/checkout@v1
     - name: make test
@@ -18,22 +31,13 @@ jobs:
         make -j2 config=release test
         make -j2 config=release gltfpack
     - name: make iphone
-      if: matrix.os == 'macos'
       run: make -j2 config=iphone
-    - name: make coverage
-      if: matrix.os == 'ubuntu'
-      run: |
-        make -j2 config=coverage test
-        find . -type f -name '*.gcno' -exec gcov -p {} +
-        sed -i -e "s/#####\(.*\)\(\/\/ unreachable.*\)/    -\1\2/" *.gcov
-        bash <(curl -s https://codecov.io/bash) -f 'src#*.gcov' -X search -t ${{secrets.CODECOV_TOKEN}}
 
   windows:
     runs-on: windows-latest
     strategy:
       matrix:
         arch: [Win32, x64]
-
     steps:
     - uses: actions/checkout@v1
     - name: cmake configure

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ ifeq ($(config),iphone)
 	IPHONESDK=/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk
 	CFLAGS+=-arch armv7 -arch arm64 -isysroot $(IPHONESDK)
 	CXXFLAGS+=-arch armv7 -arch arm64 -isysroot $(IPHONESDK) -stdlib=libc++
-	LDFLAGS+=-arch armv7 -arch arm64 -L $(IPHONESDK)/usr/lib -mios-version-min=7.0
+	LDFLAGS+=-arch armv7 -arch arm64 -isysroot $(IPHONESDK) -L $(IPHONESDK)/usr/lib -mios-version-min=7.0
 endif
 
 ifeq ($(config),trace)


### PR DESCRIPTION
This adds integration with GitHub Actions in addition to Travis CI; everything except for Linux/clang build is supported here, including code coverage reports.