### PR TITLE
Merge Linux and macOS builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,8 +3,12 @@ name: build
 on: [push, pull_request]
 
 jobs:
-  linux:
-    runs-on: ubuntu-latest
+  unix:
+    strategy:
+      matrix:
+        os: [ubuntu, macos]
+    name: ${{matrix.os}}
+    runs-on: ${{matrix.os}}-latest
     steps:
     - uses: actions/checkout@v1
     - name: make test
@@ -18,27 +22,10 @@ jobs:
         make -j2 config=coverage test
         find . -type f -name '*.gcno' -exec gcov -p {} +
         sed -i -e "s/#####\(.*\)\(\/\/ unreachable.*\)/    -\1\2/" *.gcov
-        bash <(curl -s https://codecov.io/bash) -f 'src#*.gcov' -X search -t ${{secrets.CODECOV_TOKEN}}
+        bash <(curl -s https://codecov.io/bash) -f 'src#*.gcov' -X search -t ${{secrets.CODECOV_TOKEN}} -B ${{github.ref}}
     - uses: actions/upload-artifact@v1
       with:
-        name: gltfpack-linux
-        path: gltfpack
-
-  macos:
-    runs-on: macos-latest
-    steps:
-    - uses: actions/checkout@v1
-    - name: make test
-      run: |
-        make -j2 config=sanitize test
-        make -j2 config=debug test
-        make -j2 config=release test
-        make -j2 config=release gltfpack
-    - name: make iphone
-      run: make -j2 config=iphone
-    - uses: actions/upload-artifact@v1
-      with:
-        name: gltfpack-macos
+        name: gltfpack-${{matrix.os}}
         path: gltfpack
 
   windows:

--- a/src/vertexcodec.cpp
+++ b/src/vertexcodec.cpp
@@ -309,7 +309,7 @@ static const unsigned char* decodeBytesGroup(const unsigned char* data, unsigned
 		memcpy(buffer, data, kByteGroupSize);
 		return data + kByteGroupSize;
 	default:
-		assert(!"Unexpected bit length"); // This can never happen since bitslog2 is a 2-bit value
+		assert(!"Unexpected bit length"); // unreachable since bitslog2 is a 2-bit value
 		return data;
 	}
 
@@ -521,7 +521,7 @@ static const unsigned char* decodeBytesGroupSimd(const unsigned char* data, unsi
 	}
 
 	default:
-		assert(!"Unexpected bit length"); // This can never happen since bitslog2 is a 2-bit value
+		assert(!"Unexpected bit length"); // unreachable since bitslog2 is a 2-bit value
 		return data;
 	}
 }
@@ -649,7 +649,7 @@ static const unsigned char* decodeBytesGroupSimd(const unsigned char* data, unsi
 	}
 
 	default:
-		assert(!"Unexpected bit length"); // This can never happen since bitslog2 is a 2-bit value
+		assert(!"Unexpected bit length"); // unreachable since bitslog2 is a 2-bit value
 		return data;
 	}
 }


### PR DESCRIPTION
This change merges the GitHub configurations for macOS and Linux into
one which adds support for coverage reports from macOS/clang.