### PR TITLE
Add ARM64 config to Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,9 @@ matrix:
       compiler: gcc
     - os: linux
       compiler: clang
+    - os: linux
+      compiler: gcc
+      arch: arm64
     - os: osx
       compiler: clang
     - os: windows

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,9 @@ matrix:
       env:
         - TARGET="Visual Studio 15 2017 Win64"
 
+before_script:
+  - if [[ "$TRAVIS_COMPILER" == "gcc" ]]; then sudo apt install g++; fi
+
 script:
   - if [[ "$TRAVIS_COMPILER" == "gcc" ]]; then make -j2 config=coverage test; fi
   - if [[ "$TRAVIS_COMPILER" == "clang" ]]; then make -j2 config=sanitize test; fi


### PR DESCRIPTION
This lets us test the NEON version of the vertex codec in CI. Before this change, we were building the vertex codec for armv7 and aarch64 on macOS, but didn't have a way to test it. Now we can run the tests as well, including code coverage.