### PR TITLE
Improve SIMD support in vertex codec

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,24 +1,23 @@
 language: cpp
 
-matrix:
-  include:
-    - os: linux
-      compiler: gcc
-    - os: linux
-      compiler: clang
-    - os: linux
-      compiler: gcc
-      arch: arm64
-    - os: osx
-      compiler: clang
-    - os: windows
-      compiler: cl
-      env:
-        - TARGET="Visual Studio 15 2017"
-    - os: windows
-      compiler: cl
-      env:
-        - TARGET="Visual Studio 15 2017 Win64"
+jobs:
+  - os: linux
+    compiler: gcc
+  - os: linux
+    compiler: clang
+  - os: linux
+    compiler: gcc
+    arch: arm64
+  - os: osx
+    compiler: clang
+  - os: windows
+    compiler: cl
+    env:
+      - TARGET="Visual Studio 15 2017"
+  - os: windows
+    compiler: cl
+    env:
+      - TARGET="Visual Studio 15 2017 Win64"
 
 script:
   - if [[ "$TRAVIS_COMPILER" == "gcc" ]]; then make -j2 config=coverage test; fi

--- a/demo/main.cpp
+++ b/demo/main.cpp
@@ -1016,7 +1016,13 @@ void processDev(const char* path)
 	if (!loadMesh(mesh, path))
 		return;
 
-	simplifyPoints(mesh);
+	Mesh copy = mesh;
+	meshopt_optimizeVertexCache(&copy.indices[0], &copy.indices[0], copy.indices.size(), copy.vertices.size());
+	meshopt_optimizeVertexFetch(&copy.vertices[0], &copy.indices[0], copy.indices.size(), &copy.vertices[0], copy.vertices.size(), sizeof(Vertex));
+
+	encodeIndex(copy);
+	encodeVertex<PackedVertex>(copy, "");
+	encodeVertex<PackedVertexOct>(copy, "O");
 }
 
 int main(int argc, char** argv)

--- a/js/meshopt_decoder.js
+++ b/js/meshopt_decoder.js
@@ -20,6 +20,9 @@ var MeshoptDecoder = (function() {
 		.then(bytes => WebAssembly.instantiate(bytes, { env }))
 		.then(function(result) {
 			instance = result.instance;
+			if (instance.exports.__wasm_call_ctors) {
+				instance.exports.__wasm_call_ctors();
+			}
 			env.emscripten_notify_memory_growth(0);
 		});
 

--- a/src/vertexcodec.cpp
+++ b/src/vertexcodec.cpp
@@ -696,7 +696,10 @@ static v128_t decodeShuffleMask(unsigned char mask0, unsigned char mask1)
 	// TODO: 8b buffer overrun - should we use splat or extend buffers?
 	v128_t sm0 = wasm_v128_load(&kDecodeBytesGroupShuffle[mask0]);
 	v128_t sm1 = wasm_v128_load(&kDecodeBytesGroupShuffle[mask1]);
-	v128_t sm1off = wasm_i8x16_splat(kDecodeBytesGroupCount[mask0]); // TODO: use v8x16_load_splat
+
+	// TODO: we should use v8x16_load_splat
+	v128_t sm1off = wasm_v128_load(&kDecodeBytesGroupCount[mask0]);
+	sm1off = wasm_v8x16_shuffle(sm1off, sm1off, 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0);
 
 	v128_t sm1r = wasm_i8x16_add(sm1, sm1off);
 
@@ -769,8 +772,8 @@ static const unsigned char* decodeBytesGroupSimd(const unsigned char* data, unsi
 
 		v128_t shuf = decodeShuffleMask(mask0, mask1);
 
-		// TODO: test bitselect
-		v128_t result = wasm_v128_or(wasm_v8x16_swizzle(rest, shuf), wasm_v128_andnot(sel, mask));
+		// TODO: test or/andnot
+		v128_t result = wasm_v128_bitselect(sel, wasm_v8x16_swizzle(rest, shuf), mask);
 
 		wasm_v128_store(buffer, result);
 
@@ -794,8 +797,8 @@ static const unsigned char* decodeBytesGroupSimd(const unsigned char* data, unsi
 
 		v128_t shuf = decodeShuffleMask(mask0, mask1);
 
-		// TODO: test bitselect
-		v128_t result = wasm_v128_or(wasm_v8x16_swizzle(rest, shuf), wasm_v128_andnot(sel, mask));
+		// TODO: test or/andnot
+		v128_t result = wasm_v128_bitselect(sel, wasm_v8x16_swizzle(rest, shuf), mask);
 
 		wasm_v128_store(buffer, result);
 

--- a/src/vertexcodec.cpp
+++ b/src/vertexcodec.cpp
@@ -1158,7 +1158,8 @@ int meshopt_decodeVertexBuffer(void* destination, size_t vertex_count, size_t ve
 #endif
 
 #if defined(SIMD_WASM)
-	if (!gDecodeBytesGroupInitialized) // ???
+	// TODO: workaround for https://github.com/emscripten-core/emscripten/issues/9767
+	if (!gDecodeBytesGroupInitialized)
 		gDecodeBytesGroupInitialized = decodeBytesGroupBuildTables();
 #endif
 

--- a/src/vertexcodec.cpp
+++ b/src/vertexcodec.cpp
@@ -12,7 +12,7 @@
 #define SIMD_SSE
 #endif
 
-#if defined(__AVX512VBMI2__) && defined(__POPCNT__)
+#if defined(__AVX512VBMI2__) && defined(__AVX512VBMI__) && defined(__AVX512VL__) && defined(__POPCNT__)
 #undef SIMD_SSE
 #define SIMD_AVX
 #endif

--- a/src/vertexcodec.cpp
+++ b/src/vertexcodec.cpp
@@ -49,11 +49,6 @@
 
 #ifdef SIMD_WASM
 #include <wasm_simd128.h>
-#define wasm_v32x4_splat(v, i) wasm_v8x16_shuffle(v, v, 4*i,4*i+1,4*i+2,4*i+3, 4*i,4*i+1,4*i+2,4*i+3, 4*i,4*i+1,4*i+2,4*i+3, 4*i,4*i+1,4*i+2,4*i+3)
-#define wasm_unpacklo_v8x16(a, b) wasm_v8x16_shuffle(a, b, 0,16, 1,17, 2,18, 3,19, 4,20, 5,21, 6,22, 7,23)
-#define wasm_unpackhi_v8x16(a, b) wasm_v8x16_shuffle(a, b, 8,24, 9,25, 10,26, 11,27, 12,28, 13,29, 14,30, 15,31)
-#define wasm_unpacklo_v16x8(a, b) wasm_v8x16_shuffle(a, b, 0,1,16,17, 2,3,18,19, 4,5,20,21, 6,7,22,23)
-#define wasm_unpackhi_v16x8(a, b) wasm_v8x16_shuffle(a, b, 8,9,24,25, 10,11,26,27, 12,13,28,29, 14,15,30,31)
 #endif
 
 #ifndef TRACE
@@ -62,6 +57,15 @@
 
 #if TRACE
 #include <stdio.h>
+#endif
+
+#ifdef SIMD_WASM
+#include <wasm_simd128.h>
+#define wasm_v32x4_splat(v, i) wasm_v8x16_shuffle(v, v, 4*i,4*i+1,4*i+2,4*i+3, 4*i,4*i+1,4*i+2,4*i+3, 4*i,4*i+1,4*i+2,4*i+3, 4*i,4*i+1,4*i+2,4*i+3)
+#define wasm_unpacklo_v8x16(a, b) wasm_v8x16_shuffle(a, b, 0,16, 1,17, 2,18, 3,19, 4,20, 5,21, 6,22, 7,23)
+#define wasm_unpackhi_v8x16(a, b) wasm_v8x16_shuffle(a, b, 8,24, 9,25, 10,26, 11,27, 12,28, 13,29, 14,30, 15,31)
+#define wasm_unpacklo_v16x8(a, b) wasm_v8x16_shuffle(a, b, 0,1,16,17, 2,3,18,19, 4,5,20,21, 6,7,22,23)
+#define wasm_unpackhi_v16x8(a, b) wasm_v8x16_shuffle(a, b, 8,9,24,25, 10,11,26,27, 12,13,28,29, 14,15,30,31)
 #endif
 
 namespace meshopt
@@ -712,25 +716,25 @@ static void wasmMoveMask(v128_t mask, unsigned char& mask0, unsigned char& mask1
 
 	// TODO
 	mask0 = 0;
-	mask0 |= wasm_u8x16_extract_lane(m1, 0) << 7;
-	mask0 |= wasm_u8x16_extract_lane(m1, 1) << 6;
-	mask0 |= wasm_u8x16_extract_lane(m1, 2) << 5;
-	mask0 |= wasm_u8x16_extract_lane(m1, 3) << 4;
-	mask0 |= wasm_u8x16_extract_lane(m1, 4) << 3;
-	mask0 |= wasm_u8x16_extract_lane(m1, 5) << 2;
-	mask0 |= wasm_u8x16_extract_lane(m1, 6) << 1;
-	mask0 |= wasm_u8x16_extract_lane(m1, 7) << 0;
+	mask0 |= wasm_u8x16_extract_lane(m1, 0) << 0;
+	mask0 |= wasm_u8x16_extract_lane(m1, 1) << 1;
+	mask0 |= wasm_u8x16_extract_lane(m1, 2) << 2;
+	mask0 |= wasm_u8x16_extract_lane(m1, 3) << 3;
+	mask0 |= wasm_u8x16_extract_lane(m1, 4) << 4;
+	mask0 |= wasm_u8x16_extract_lane(m1, 5) << 5;
+	mask0 |= wasm_u8x16_extract_lane(m1, 6) << 6;
+	mask0 |= wasm_u8x16_extract_lane(m1, 7) << 7;
 
 	// TODO
 	mask1 = 0;
-	mask1 |= wasm_u8x16_extract_lane(m1, 8) << 7;
-	mask1 |= wasm_u8x16_extract_lane(m1, 9) << 6;
-	mask1 |= wasm_u8x16_extract_lane(m1, 10) << 5;
-	mask1 |= wasm_u8x16_extract_lane(m1, 11) << 4;
-	mask1 |= wasm_u8x16_extract_lane(m1, 12) << 3;
-	mask1 |= wasm_u8x16_extract_lane(m1, 13) << 2;
-	mask1 |= wasm_u8x16_extract_lane(m1, 14) << 1;
-	mask1 |= wasm_u8x16_extract_lane(m1, 15) << 0;
+	mask1 |= wasm_u8x16_extract_lane(m1, 8) << 0;
+	mask1 |= wasm_u8x16_extract_lane(m1, 9) << 1;
+	mask1 |= wasm_u8x16_extract_lane(m1, 10) << 2;
+	mask1 |= wasm_u8x16_extract_lane(m1, 11) << 3;
+	mask1 |= wasm_u8x16_extract_lane(m1, 12) << 4;
+	mask1 |= wasm_u8x16_extract_lane(m1, 13) << 5;
+	mask1 |= wasm_u8x16_extract_lane(m1, 14) << 6;
+	mask1 |= wasm_u8x16_extract_lane(m1, 15) << 7;
 }
 #endif
 
@@ -773,7 +777,7 @@ static const unsigned char* decodeBytesGroupSimd(const unsigned char* data, unsi
 		v128_t shuf = decodeShuffleMask(mask0, mask1);
 
 		// TODO: test or/andnot
-		v128_t result = wasm_v128_bitselect(sel, wasm_v8x16_swizzle(rest, shuf), mask);
+		v128_t result = wasm_v128_bitselect(wasm_v8x16_swizzle(rest, shuf), sel, mask);
 
 		wasm_v128_store(buffer, result);
 
@@ -798,7 +802,7 @@ static const unsigned char* decodeBytesGroupSimd(const unsigned char* data, unsi
 		v128_t shuf = decodeShuffleMask(mask0, mask1);
 
 		// TODO: test or/andnot
-		v128_t result = wasm_v128_bitselect(sel, wasm_v8x16_swizzle(rest, shuf), mask);
+		v128_t result = wasm_v128_bitselect(wasm_v8x16_swizzle(rest, shuf), sel, mask);
 
 		wasm_v128_store(buffer, result);
 
@@ -1185,6 +1189,11 @@ int meshopt_decodeVertexBuffer(void* destination, size_t vertex_count, size_t ve
 	decode = decodeVertexBlockSimd;
 #else
 	decode = decodeVertexBlock;
+#endif
+
+#if defined(SIMD_WASM)
+	if (!gDecodeBytesGroupInitialized) // ???
+		gDecodeBytesGroupInitialized = decodeBytesGroupBuildTables();
 #endif
 
 #if defined(SIMD_SSE) || defined(SIMD_NEON) || defined(SIMD_WASM)

--- a/src/vertexcodec.cpp
+++ b/src/vertexcodec.cpp
@@ -12,7 +12,7 @@
 #define SIMD_SSE
 #endif
 
-#if defined(__AVX512VBMI2__)
+#if defined(__AVX512VBMI2__) && defined(__POPCNT__)
 #undef SIMD_SSE
 #define SIMD_AVX
 #endif
@@ -553,7 +553,7 @@ static const unsigned char* decodeBytesGroupSimd(const unsigned char* data, unsi
 
 		_mm_storeu_si128(reinterpret_cast<__m128i*>(buffer), result);
 
-		return skip + __builtin_popcount(mask16);
+		return skip + _mm_popcnt_u32(mask16);
 	}
 
 	case 3:


### PR DESCRIPTION
This change adds AVX512 and WASM SIMD support for vertex codec.

AVX512 version gives a minor speedup compared to SSSE3 version - it's ~10% faster to decode; however it also is ~2x smaller which is nice-to-have. Because the speedup isn't very significant we only activate this version if AVX512 instructions are declared to be supported - this happens in gcc/clang when -march=icelake-client is specified. Note that the implementation requires AVX512VL and AVX512VBMI2.

WASM SIMD version is around 3 times faster than the scalar version, which is about the same speedup that SIMD gives for native versions. This currently only works on the bleeding edge of the entire ecosystem - requires several fixes in LLVM/binaryen and Chrome Canary to support swizzle and some other instructions.

Note that WASM SIMD version has a few TODO comments where we use suboptimal or slightly unsafe instructions. This is because Chrome Canary doesn't support load_splat variants. When this support is implemented, we can switch to using better and hopefully faster intrinsics, although I'd expect the performance gains to be minimal.

Performance as measured on i5-1035G4 on buddha.obj using the position stream (4.4 MB uncompressed, 8 byte position data):

C++ scalar: 0.72 GB/s
C++ SSSE3: 2.15 GB/s
C++ AVX512: 2.42 GB/s
wasm scalar: 0.44 GB/s
wasm SIMD: 1.23 GB/s