### PR TITLE
gltfpack: Quantize floating-point values for keyframe tracks

### DIFF
--- a/tools/gltfpack.cpp
+++ b/tools/gltfpack.cpp
@@ -1513,11 +1513,7 @@ StreamFormat writeVertexStream(std::string& bin, const Stream& stream, const Qua
 		{
 			const Attr& a = stream.data[i];
 
-			float v[4] = {
-			    a.f[0],
-			    a.f[1],
-			    a.f[2],
-			    a.f[3]};
+			float v[4] = {a.f[0], a.f[1], a.f[2], a.f[3]};
 			bin.append(reinterpret_cast<const char*>(v), sizeof(v));
 		}
 
@@ -1644,17 +1640,35 @@ StreamFormat writeKeyframeStream(std::string& bin, cgltf_animation_path_type typ
 		StreamFormat format = {cgltf_type_scalar, cgltf_component_type_r_8u, true, 1};
 		return format;
 	}
+	else if (type == cgltf_animation_path_type_translation || type == cgltf_animation_path_type_scale)
+	{
+		int bits = 15;
+
+		for (size_t i = 0; i < data.size(); ++i)
+		{
+			const Attr& a = data[i];
+
+			float v[3] = {
+				meshopt_quantizeFloat(a.f[0], bits),
+				meshopt_quantizeFloat(a.f[1], bits),
+				meshopt_quantizeFloat(a.f[2], bits)};
+			bin.append(reinterpret_cast<const char*>(v), sizeof(v));
+		}
+
+		StreamFormat format = {cgltf_type_vec3, cgltf_component_type_r_32f, false, 12};
+		return format;
+	}
 	else
 	{
 		for (size_t i = 0; i < data.size(); ++i)
 		{
 			const Attr& a = data[i];
 
-			float v[3] = {a.f[0], a.f[1], a.f[2]};
+			float v[4] = {a.f[0], a.f[1], a.f[2], a.f[3]};
 			bin.append(reinterpret_cast<const char*>(v), sizeof(v));
 		}
 
-		StreamFormat format = {cgltf_type_vec3, cgltf_component_type_r_32f, false, 12};
+		StreamFormat format = {cgltf_type_vec4, cgltf_component_type_r_32f, false, 16};
 		return format;
 	}
 }


### PR DESCRIPTION
When we can't use fixed point quantization (translation/rotation), we
fall back to floating-point quantization which leaves the least
significant mantissa byte as 0. This results in noticeable improvement
in compression ratio - on two examples, translation track got ~1.6x
smaller (64->40 bits in one case and 40->24 in another).

It remains to be seen how acceptable the quality reduction here is - I'm
worried about translations in particular as there are extreme cases
(e.g. an object moving from 0 to 1000) where this type of change makes
the destination of the movement noticeably off (precision around 1000
drops from 6.1e-5 to 1.6e-2).