### PR TITLE
gltfpack: Impement support for Basis texture conversion

### DIFF
--- a/tools/gltfpack.cpp
+++ b/tools/gltfpack.cpp
@@ -2706,15 +2706,22 @@ bool readFile(const char* path, std::string& data)
 	}
 
 	data.resize(length);
-
-	if (fread(&data[0], 1, data.size(), file) != data.size())
-	{
-		fclose(file);
-		return false;
-	}
-
+	size_t result = fread(&data[0], 1, data.size(), file);
 	fclose(file);
-	return true;
+
+	return result == data.size();
+}
+
+bool writeFile(const char* path, const std::string& data)
+{
+	FILE* file = fopen(path, "wb");
+	if (!file)
+		return false;
+
+	size_t result = fwrite(&data[0], 1, data.size(), file);
+	fclose(file);
+
+	return result == data.size();
 }
 
 bool encodeBasis(const char* input, const char* output, bool normal_map)

--- a/tools/gltfpack.cpp
+++ b/tools/gltfpack.cpp
@@ -2736,6 +2736,14 @@ bool writeBasisImage(std::string& json, const char* path, bool normal_map, const
 	cmd += " -output_file ";
 	cmd += basis_full_path;
 
+#ifdef _WIN32
+	cmd += " >nul";
+#else
+	cmd += " >/dev/null";
+#endif
+
+	printf("Compressing %s to %s\n", full_path.c_str(), basis_full_path.c_str());
+
 	if (system(cmd.c_str()) != 0)
 		return false;
 

--- a/tools/gltfpack.cpp
+++ b/tools/gltfpack.cpp
@@ -3540,6 +3540,14 @@ void process(cgltf_data* data, const char* input_path, const char* output_path, 
 
 	for (size_t i = 0; i < data->images_count; ++i)
 	{
+		if (settings.verbose && settings.texture_basis)
+		{
+			const char* uri = data->images[i].uri;
+			bool embedded = !uri || strncmp(uri, "data:", 5) == 0;
+
+			printf("image %d (%s) is being encoded with Basis\n", int(i), embedded ? "embedded" : uri);
+		}
+
 		writeImage(json_images, views, data->images[i], images[i], i, input_path, output_path, settings);
 	}
 

--- a/tools/gltfpack.cpp
+++ b/tools/gltfpack.cpp
@@ -2756,9 +2756,9 @@ bool encodeBasisData(const std::string& data, std::string& result, bool normal_m
 	std::string temp_output = getFullPath(temp_name.c_str(), output_path) + ".basis";
 
 	bool ok =
-		writeFile(temp_input.c_str(), data) &&
-		encodeBasisFile(temp_input.c_str(), temp_output.c_str(), normal_map) &&
-		readFile(temp_output.c_str(), result);
+	    writeFile(temp_input.c_str(), data) &&
+	    encodeBasisFile(temp_input.c_str(), temp_output.c_str(), normal_map) &&
+	    readFile(temp_output.c_str(), result);
 
 	unlink(temp_input.c_str());
 	unlink(temp_output.c_str());
@@ -2792,9 +2792,6 @@ void writeImage(std::string& json, std::vector<BufferView>& views, const cgltf_i
 
 		mime_type = inferMimeType(image.uri);
 	}
-
-	comma(json);
-	append(json, "{");
 
 	if (!img_data.empty())
 	{
@@ -2846,8 +2843,6 @@ void writeImage(std::string& json, std::vector<BufferView>& views, const cgltf_i
 	{
 		fprintf(stderr, "Warning: ignoring image %d since it has no URI and no valid buffer data\n", int(index));
 	}
-
-	append(json, "}");
 }
 
 void writeMeshAttributes(std::string& json, std::vector<BufferView>& views, std::string& json_accessors, size_t& accr_offset, const Mesh& mesh, int target, const QuantizationParams& qp, const Settings& settings)
@@ -3548,7 +3543,10 @@ void process(cgltf_data* data, const char* input_path, const char* output_path, 
 			printf("image %d (%s) is being encoded with Basis\n", int(i), embedded ? "embedded" : uri);
 		}
 
+		comma(json_images);
+		append(json_images, "{");
 		writeImage(json_images, views, data->images[i], images[i], i, input_path, output_path, settings);
+		append(json_images, "}");
 	}
 
 	for (size_t i = 0; i < data->textures_count; ++i)


### PR DESCRIPTION
When -tb is specified, we run all textures from the input asset through
Basis, and place the results into .basis folder next to the scene asset.

Embedding textures is supported using image/basis MIME type although
this is not supported by any glTF renderers - the plan is to migrate this code
to use KTX2 once there's some support for it anywhere.

Also normal encoding quality is pretty bad - it requires splitting the image into
two channels, which again isn't supported by any existing renderers.