### PR TITLE
gltfpack: Minor Basis tweaks and demo integration

### DIFF
--- a/demo/GLTFLoader.js
+++ b/demo/GLTFLoader.js
@@ -14,6 +14,7 @@ THREE.GLTFLoader = ( function () {
 
 		this.dracoLoader = null;
 		this.ddsLoader = null;
+		this.basisLoader = null;
 		this.meshoptDecoder = null;
 
 	}
@@ -107,6 +108,13 @@ THREE.GLTFLoader = ( function () {
 		setDDSLoader: function ( ddsLoader ) {
 
 			this.ddsLoader = ddsLoader;
+			return this;
+
+		},
+
+		setBasisLoader: function ( basisLoader ) {
+
+			this.basisLoader = basisLoader;
 			return this;
 
 		},
@@ -222,7 +230,8 @@ THREE.GLTFLoader = ( function () {
 
 				path: path || this.resourcePath || '',
 				crossOrigin: this.crossOrigin,
-				manager: this.manager
+				manager: this.manager,
+				basisLoader: this.basisLoader,
 
 			} );
 
@@ -1970,11 +1979,29 @@ THREE.GLTFLoader = ( function () {
 
 			var loader = options.manager.getHandler( sourceURI );
 
+			if ( ! loader && textureExtensions[ EXTENSIONS.MSFT_TEXTURE_DDS ] ) {
+
+				loader = parser.extensions[ EXTENSIONS.MSFT_TEXTURE_DDS ].ddsLoader
+
+			}
+
+			if ( ! loader && options.basisLoader ) {
+
+				if ( source.uri !== undefined && source.uri.toLowerCase().endsWith(".basis") ) {
+
+					loader = options.basisLoader;
+
+				} else if ( source.bufferView !== undefined && source.mimeType == "image/basis" ) {
+
+					loader = options.basisLoader;
+
+				}
+
+			}
+
 			if ( ! loader ) {
 
-				loader = textureExtensions[ EXTENSIONS.MSFT_TEXTURE_DDS ]
-					? parser.extensions[ EXTENSIONS.MSFT_TEXTURE_DDS ].ddsLoader
-					: textureLoader;
+				loader = textureLoader;
 
 			}
 

--- a/demo/GLTFLoader.js
+++ b/demo/GLTFLoader.js
@@ -231,6 +231,7 @@ THREE.GLTFLoader = ( function () {
 				path: path || this.resourcePath || '',
 				crossOrigin: this.crossOrigin,
 				manager: this.manager,
+				ddsLoader: this.ddsLoader,
 				basisLoader: this.basisLoader,
 
 			} );
@@ -1982,6 +1983,20 @@ THREE.GLTFLoader = ( function () {
 			if ( ! loader && textureExtensions[ EXTENSIONS.MSFT_TEXTURE_DDS ] ) {
 
 				loader = parser.extensions[ EXTENSIONS.MSFT_TEXTURE_DDS ].ddsLoader
+
+			}
+
+			if ( ! loader && options.ddsLoader ) {
+
+				if ( source.uri !== undefined && source.uri.toLowerCase().endsWith(".dds") ) {
+
+					loader = options.ddsLoader;
+
+				} else if ( source.bufferView !== undefined && source.mimeType == "image/vnd-ms.dds" ) {
+
+					loader = options.ddsLoader;
+
+				}
 
 			}
 

--- a/tools/gltfpack.cpp
+++ b/tools/gltfpack.cpp
@@ -2749,7 +2749,8 @@ bool encodeBasis(const std::string& data, std::string& result, bool normal_map, 
 	if (!writeFile(temp_input.c_str(), data))
 		return false;
 
-	std::string cmd = "basisu";
+	const char* basisu_path = getenv("BASISU_PATH");
+	std::string cmd = basisu_path ? basisu_path : "basisu";
 
 	char ql[16];
 	sprintf(ql, "%d", (quality * 255 + 50) / 100);


### PR DESCRIPTION
This change tweaks Basis support a bit - you can now customize the path to basisu via BASISU_PATH environment variable.

It also extends demo/GLTFLoader.js with direct support for image/basis MIME type and .basis extension. The extension customization is possible by using regexp-based loader handlers, but MIME type customization has to be hacked into the glTF loader, unfortunately. I don't expect this solution to persist forever but without this it's hard to test Basis content properly.