### PR TITLE
gltfpack: Improve robustness when dealing with invalid files

### DIFF
--- a/tools/gltfpack.cpp
+++ b/tools/gltfpack.cpp
@@ -196,6 +196,13 @@ const char* getError(cgltf_result result)
 	case cgltf_result_out_of_memory:
 		return "out of memory";
 
+	case cgltf_result_legacy_gltf:
+		return "legacy GLTF";
+
+	case cgltf_result_data_too_short:
+	case cgltf_result_unknown_format:
+		return "not a GLTF file";
+
 	default:
 		return "unknown error";
 	}

--- a/tools/gltfpack.cpp
+++ b/tools/gltfpack.cpp
@@ -785,25 +785,12 @@ void mergeMeshes(Mesh& target, const Mesh& mesh)
 
 void mergeMeshes(std::vector<Mesh>& meshes, const Settings& settings)
 {
-	size_t write = 0;
-
 	for (size_t i = 0; i < meshes.size(); ++i)
 	{
-		if (meshes[i].streams.empty())
+		Mesh& target = meshes[i];
+
+		if (target.streams.empty())
 			continue;
-
-		Mesh& target = meshes[write];
-
-		if (i != write)
-		{
-			Mesh& mesh = meshes[i];
-
-			// note: this copy is expensive; we could use move in C++11 or swap manually which is a bit painful...
-			target = mesh;
-
-			mesh.streams.clear();
-			mesh.indices.clear();
-		}
 
 		size_t target_vertices = target.streams[0].data.size();
 		size_t target_indices = target.indices.size();
@@ -839,6 +826,34 @@ void mergeMeshes(std::vector<Mesh>& meshes, const Settings& settings)
 
 		assert(target.streams[0].data.size() == target_vertices);
 		assert(target.indices.size() == target_indices);
+	}
+}
+
+void filterEmptyMeshes(std::vector<Mesh>& meshes)
+{
+	size_t write = 0;
+
+	for (size_t i = 0; i < meshes.size(); ++i)
+	{
+		Mesh& mesh = meshes[i];
+
+		if (mesh.streams.empty())
+			continue;
+
+		if (mesh.streams[0].data.empty())
+			continue;
+
+		if (mesh.type == cgltf_primitive_type_triangles && mesh.indices.empty())
+			continue;
+
+		if (i != write)
+		{
+			// note: this copy is expensive; we could use move in C++11 or swap manually which is a bit painful...
+			meshes[write] = mesh;
+
+			mesh.streams.clear();
+			mesh.indices.clear();
+		}
 
 		write++;
 	}
@@ -3702,6 +3717,7 @@ void process(cgltf_data* data, const char* input_path, const char* output_path, 
 
 	mergeMeshMaterials(data, meshes);
 	mergeMeshes(meshes, settings);
+	filterEmptyMeshes(meshes);
 
 	markNeededNodes(data, nodes, meshes, settings);
 
@@ -3718,6 +3734,8 @@ void process(cgltf_data* data, const char* input_path, const char* output_path, 
 	{
 		processMesh(meshes[i], settings);
 	}
+
+	filterEmptyMeshes(meshes); // some meshes may become empty after processing
 
 	if (settings.verbose)
 	{

--- a/tools/gltfpack.cpp
+++ b/tools/gltfpack.cpp
@@ -177,12 +177,12 @@ struct BufferView
 	size_t bytes;
 };
 
-const char* getError(cgltf_result result)
+const char* getError(cgltf_result result, cgltf_data* data)
 {
 	switch (result)
 	{
 	case cgltf_result_file_not_found:
-		return "file not found";
+		return data ? "resource not found" : "file not found";
 
 	case cgltf_result_io_error:
 		return "I/O error";
@@ -200,8 +200,10 @@ const char* getError(cgltf_result result)
 		return "legacy GLTF";
 
 	case cgltf_result_data_too_short:
-	case cgltf_result_unknown_format:
 		return "not a GLTF file";
+
+	case cgltf_result_unknown_format:
+		return data ? "unknown resource format" : "not a GLTF file";
 
 	default:
 		return "unknown error";
@@ -4130,7 +4132,7 @@ int gltfpack(const char* input, const char* output, const Settings& settings)
 		const char* error = NULL;
 
 		if (result != cgltf_result_success)
-			error = getError(result);
+			error = getError(result, data);
 		else if (requiresExtension(data, "KHR_draco_mesh_compression"))
 			error = "file requires Draco mesh compression support";
 		else if (requiresExtension(data, "MESHOPT_compression"))

--- a/tools/gltfpack.cpp
+++ b/tools/gltfpack.cpp
@@ -848,11 +848,16 @@ void filterEmptyMeshes(std::vector<Mesh>& meshes)
 
 		if (i != write)
 		{
-			// note: this copy is expensive; we could use move in C++11 or swap manually which is a bit painful...
-			meshes[write] = mesh;
+			// the following code is roughly equivalent to meshes[write] = std::move(mesh)
+			std::vector<Stream> streams;
+			streams.swap(mesh.streams);
 
-			mesh.streams.clear();
-			mesh.indices.clear();
+			std::vector<unsigned int> indices;
+			indices.swap(mesh.indices);
+
+			meshes[write] = mesh;
+			meshes[write].streams.swap(streams);
+			meshes[write].indices.swap(indices);
 		}
 
 		write++;


### PR DESCRIPTION
This change makes gltfpack more robust when processing files that aren't valid or clean. In particular:

- Error messages for various invalid files are now cleaner, with glTF 1.0 files highlighted specifically
- Meshes can now become empty during processing (e.g. all triangles are degenerate) and will be skipped; associated nodes are still emitted for now
- Dummy buffers can no longer be referenced from accessors - this caused NULL pointer dereference before
- Index data is now correctly validated before use