### PR TITLE
vertexcodec: Automatically enable SIMD with fallback for clang/gcc

### DIFF
--- a/demo/tests.cpp
+++ b/demo/tests.cpp
@@ -384,21 +384,24 @@ static void runTestsOnce()
 	simplifyPointsStuck();
 }
 
+namespace meshopt
+{
+extern unsigned int cpuid;
+}
+
 void runTests()
 {
 	runTestsOnce();
 
-#ifndef _MSC_VER
-	// On GCC/clang, we use __builtin_cpu_supports to dynamically dispatch between SIMD/scalar code
+#if !(defined(__AVX__) || defined(__SSSE3__)) && (defined(_M_IX86) || defined(_M_X64) || defined(__i386__) || defined(__x86_64__))
+	// When SSSE3/AVX support isn't enabled unconditionally, we use a cpuid-based fallback
 	// It's useful to be able to test scalar code in this case, so we temporarily fake the feature bits
 	// and restore them later
-	extern unsigned int __cpu_model[4];
-
-	unsigned int cpu_features = __cpu_model[3];
-	__cpu_model[3] = 0;
+	unsigned int cpuid = meshopt::cpuid;
+	meshopt::cpuid = 0;
 
 	runTestsOnce();
 
-	__cpu_model[3] = cpu_features;
+	meshopt::cpuid = cpuid;
 #endif
 }

--- a/demo/tests.cpp
+++ b/demo/tests.cpp
@@ -229,6 +229,79 @@ static void decodeVertexRejectMalformedHeaders()
 	assert(meshopt_decodeVertexBuffer(decoded, vertex_count, sizeof(PV), &brokenbuffer[0], brokenbuffer.size()) < 0);
 }
 
+static void decodeVertexBitGroups()
+{
+	unsigned char data[16 * 4];
+
+	// this tests 0/2/4/8 bit groups in one stream
+	for (size_t i = 0; i < 16; ++i)
+	{
+		data[i * 4 + 0] = 0;
+		data[i * 4 + 1] = (unsigned char)(i * 1);
+		data[i * 4 + 2] = (unsigned char)(i * 2);
+		data[i * 4 + 3] = (unsigned char)(i * 8);
+	}
+
+	std::vector<unsigned char> buffer(meshopt_encodeVertexBufferBound(16, 4));
+	buffer.resize(meshopt_encodeVertexBuffer(&buffer[0], buffer.size(), data, 16, 4));
+
+	unsigned char decoded[16 * 4];
+	assert(meshopt_decodeVertexBuffer(decoded, 16, 4, &buffer[0], buffer.size()) == 0);
+	assert(memcmp(decoded, data, sizeof(data)) == 0);
+}
+
+static void decodeVertexBitGroupSentinels()
+{
+	unsigned char data[16 * 4];
+
+	// this tests 0/2/4/8 bit groups and sentinels in one stream
+	for (size_t i = 0; i < 16; ++i)
+	{
+		if (i == 7 || i == 13)
+		{
+			data[i * 4 + 0] = 42;
+			data[i * 4 + 1] = 42;
+			data[i * 4 + 2] = 42;
+			data[i * 4 + 3] = 42;
+		}
+		else
+		{
+			data[i * 4 + 0] = 0;
+			data[i * 4 + 1] = (unsigned char)(i * 1);
+			data[i * 4 + 2] = (unsigned char)(i * 2);
+			data[i * 4 + 3] = (unsigned char)(i * 8);
+		}
+	}
+
+	std::vector<unsigned char> buffer(meshopt_encodeVertexBufferBound(16, 4));
+	buffer.resize(meshopt_encodeVertexBuffer(&buffer[0], buffer.size(), data, 16, 4));
+
+	unsigned char decoded[16 * 4];
+	assert(meshopt_decodeVertexBuffer(decoded, 16, 4, &buffer[0], buffer.size()) == 0);
+	assert(memcmp(decoded, data, sizeof(data)) == 0);
+}
+
+static void decodeVertexLarge()
+{
+	unsigned char data[128 * 4];
+
+	// this tests 0/2/4/8 bit groups in one stream
+	for (size_t i = 0; i < 128; ++i)
+	{
+		data[i * 4 + 0] = 0;
+		data[i * 4 + 1] = (unsigned char)(i * 1);
+		data[i * 4 + 2] = (unsigned char)(i * 2);
+		data[i * 4 + 3] = (unsigned char)(i * 8);
+	}
+
+	std::vector<unsigned char> buffer(meshopt_encodeVertexBufferBound(128, 4));
+	buffer.resize(meshopt_encodeVertexBuffer(&buffer[0], buffer.size(), data, 128, 4));
+
+	unsigned char decoded[128 * 4];
+	assert(meshopt_decodeVertexBuffer(decoded, 128, 4, &buffer[0], buffer.size()) == 0);
+	assert(memcmp(decoded, data, sizeof(data)) == 0);
+}
+
 static void clusterBoundsDegenerate()
 {
 	const float vbd[] = {0, 0, 0, 0, 0, 0, 0, 0, 0};
@@ -372,6 +445,9 @@ static void runTestsOnce()
 	decodeVertexMemorySafe();
 	decodeVertexRejectExtraBytes();
 	decodeVertexRejectMalformedHeaders();
+	decodeVertexBitGroups();
+	decodeVertexBitGroupSentinels();
+	decodeVertexLarge();
 
 	clusterBoundsDegenerate();
 

--- a/src/vertexcodec.cpp
+++ b/src/vertexcodec.cpp
@@ -1049,7 +1049,7 @@ static void __cpuid(int info[4], int kind)
 {
 	asm("cpuid"
 	    : "=a"(info[0]), "=b"(info[1]), "=c"(info[2]), "=d"(info[3])
-	    : "0"(kind));
+	    : "a"(kind));
 }
 #endif
 

--- a/src/vertexcodec.cpp
+++ b/src/vertexcodec.cpp
@@ -24,7 +24,7 @@
 #endif
 
 // GCC 4.9+ and clang 3.8+ support targeting SIMD instruction sets from individual functions
-#if !defined(SIMD_SSE) && !defined(SIMD_AVX) && ((defined(__clang__) && __clang_major__ * 100 + __clang_minor__ >= 308) || (defined(__GNUC__) && __GNUC__ * 100 + __GNUC_MINOR__ >= 409)) && (defined(__i686__) || defined(__x86_64__))
+#if !defined(SIMD_SSE) && !defined(SIMD_AVX) && ((defined(__clang__) && __clang_major__ * 100 + __clang_minor__ >= 308) || (defined(__GNUC__) && __GNUC__ * 100 + __GNUC_MINOR__ >= 409)) && (defined(__i386__) || defined(__x86_64__))
 #define SIMD_SSE
 #define SIMD_FALLBACK
 #define SIMD_TARGET __attribute__((target("ssse3")))
@@ -1047,9 +1047,17 @@ static const unsigned char* decodeVertexBlockSimd(const unsigned char* data, con
 #if defined(SIMD_SSE) && defined(SIMD_FALLBACK) && !defined(_MSC_VER)
 static void __cpuid(int info[4], int kind)
 {
+#if defined( __i386__) && defined(__PIC__)
+	asm("mov %%ebx, %%edi\n"
+		"cpuid\n"
+		"xchg %%edi, %%ebx\n"
+	    : "=a"(info[0]), "=D"(info[1]), "=c"(info[2]), "=d"(info[3])
+	    : "a"(kind));
+#else
 	asm("cpuid"
 	    : "=a"(info[0]), "=b"(info[1]), "=c"(info[2]), "=d"(info[3])
 	    : "a"(kind));
+#endif
 }
 #endif
 

--- a/src/vertexcodec.cpp
+++ b/src/vertexcodec.cpp
@@ -1157,7 +1157,9 @@ int meshopt_decodeVertexBuffer(void* destination, size_t vertex_count, size_t ve
 
 	const unsigned char* (*decode)(const unsigned char*, const unsigned char*, unsigned char*, size_t, size_t, unsigned char[256]) = 0;
 
-#if defined(SIMD_SSE) && defined(SIMD_FALLBACK)
+#if defined(SIMD_SSE) && defined(SIMD_FALLBACK) && !defined(_MSC_VER) // test
+	decode = __builtin_cpu_supports("ssse3") ? decodeVertexBlockSimd : decodeVertexBlock;
+#elif defined(SIMD_SSE) && defined(SIMD_FALLBACK)
 	int cpuinfo[4] = {};
 #ifdef _MSC_VER
 	__cpuid(cpuinfo, 1);

--- a/src/vertexcodec.cpp
+++ b/src/vertexcodec.cpp
@@ -23,6 +23,13 @@
 #include <intrin.h> // __cpuid
 #endif
 
+// GCC 4.9+ and clang 3.8+ support targeting SIMD instruction sets from individual functions
+#if !defined(SIMD_SSE) && !defined(SIMD_AVX) && ((defined(__clang__) && __clang_major__ * 100 + __clang_minor__ >= 308) || (defined(__GNUC__) && __GNUC__ * 100 + __GNUC_MINOR__ >= 409)) && (defined(__i686__) || defined(__x86_64__))
+#define SIMD_SSE
+#define SIMD_FALLBACK
+#define SIMD_TARGET __attribute__((target("ssse3")))
+#endif
+
 #if !defined(SIMD_NEON) && defined(_MSC_VER) && (defined(_M_ARM) || defined(_M_ARM64))
 #define SIMD_NEON
 #endif
@@ -30,6 +37,10 @@
 // WebAssembly SIMD implementation requires a few bleeding edge intrinsics that are only available in Chrome Canary
 #if defined(__wasm_simd128__) && defined(__wasm_unimplemented_simd128__)
 #define SIMD_WASM
+#endif
+
+#ifndef SIMD_TARGET
+#define SIMD_TARGET
 #endif
 
 #ifdef SIMD_SSE
@@ -446,6 +457,7 @@ static bool gDecodeBytesGroupInitialized = decodeBytesGroupBuildTables();
 #endif
 
 #ifdef SIMD_SSE
+SIMD_TARGET
 static __m128i decodeShuffleMask(unsigned char mask0, unsigned char mask1)
 {
 	__m128i sm0 = _mm_loadl_epi64(reinterpret_cast<const __m128i*>(&kDecodeBytesGroupShuffle[mask0]));
@@ -457,6 +469,7 @@ static __m128i decodeShuffleMask(unsigned char mask0, unsigned char mask1)
 	return _mm_unpacklo_epi64(sm0, sm1r);
 }
 
+SIMD_TARGET
 static const unsigned char* decodeBytesGroupSimd(const unsigned char* data, unsigned char* buffer, int bitslog2)
 {
 	switch (bitslog2)
@@ -814,6 +827,7 @@ static const unsigned char* decodeBytesGroupSimd(const unsigned char* data, unsi
 #endif
 
 #if defined(SIMD_SSE) || defined(SIMD_AVX)
+SIMD_TARGET
 static void transpose8(__m128i& x0, __m128i& x1, __m128i& x2, __m128i& x3)
 {
 	__m128i t0 = _mm_unpacklo_epi8(x0, x1);
@@ -827,6 +841,7 @@ static void transpose8(__m128i& x0, __m128i& x1, __m128i& x2, __m128i& x3)
 	x3 = _mm_unpackhi_epi16(t1, t3);
 }
 
+SIMD_TARGET
 static __m128i unzigzag8(__m128i v)
 {
 	__m128i xl = _mm_sub_epi8(_mm_setzero_si128(), _mm_and_si128(v, _mm_set1_epi8(1)));
@@ -884,6 +899,7 @@ static v128_t unzigzag8(v128_t v)
 #endif
 
 #if defined(SIMD_SSE) || defined(SIMD_AVX) || defined(SIMD_NEON) || defined(SIMD_WASM)
+SIMD_TARGET
 static const unsigned char* decodeBytesSimd(const unsigned char* data, const unsigned char* data_end, unsigned char* buffer, size_t buffer_size)
 {
 	assert(buffer_size % kByteGroupSize == 0);
@@ -929,6 +945,7 @@ static const unsigned char* decodeBytesSimd(const unsigned char* data, const uns
 	return data;
 }
 
+SIMD_TARGET
 static const unsigned char* decodeVertexBlockSimd(const unsigned char* data, const unsigned char* data_end, unsigned char* vertex_data, size_t vertex_count, size_t vertex_size, unsigned char last_vertex[256])
 {
 	assert(vertex_count > 0 && vertex_count <= kVertexBlockMaxSize);
@@ -1024,6 +1041,15 @@ static const unsigned char* decodeVertexBlockSimd(const unsigned char* data, con
 	memcpy(last_vertex, &transposed[vertex_size * (vertex_count - 1)], vertex_size);
 
 	return data;
+}
+#endif
+
+#if defined(SIMD_SSE) && defined(SIMD_FALLBACK) && !defined(_MSC_VER)
+static void __cpuid(int info[4], int kind)
+{
+	asm("cpuid"
+	    : "=a"(info[0]), "=b"(info[1]), "=c"(info[2]), "=d"(info[3])
+	    : "0"(kind));
 }
 #endif
 


### PR DESCRIPTION
This change uses clang/gcc support for "target" attribute so that by default, we use SIMD decoder in basically all cases.

This eliminates our code coverage on scalar decoding path :-/ Not sure how to deal with this yet.