### PR TITLE
gltfpack: Rework animation processing pipeline

### DIFF
--- a/tools/cgltf.h
+++ b/tools/cgltf.h
@@ -1286,6 +1286,38 @@ cgltf_result cgltf_validate(cgltf_data* data)
 		}
 	}
 
+	for (cgltf_size i = 0; i < data->animations_count; ++i)
+	{
+		for (cgltf_size j = 0; j < data->animations[i].channels_count; ++j)
+		{
+			cgltf_animation_channel* channel = &data->animations[i].channels[j];
+
+			if (!channel->target_node)
+			{
+				continue;
+			}
+
+			cgltf_size components = 1;
+
+			if (channel->target_path == cgltf_animation_path_type_weights)
+			{
+				if (!channel->target_node->mesh || !channel->target_node->mesh->primitives_count)
+				{
+					return cgltf_result_invalid_gltf;
+				}
+
+				components = channel->target_node->mesh->primitives[0].targets_count;
+			}
+
+			cgltf_size values = channel->sampler->interpolation == cgltf_interpolation_type_cubic_spline ? 3 : 1;
+
+			if (channel->sampler->input->count * components * values != channel->sampler->output->count)
+			{
+				return cgltf_result_data_too_short;
+			}
+		}
+	}
+
 	return cgltf_result_success;
 }
 

--- a/tools/cgltf.h
+++ b/tools/cgltf.h
@@ -1258,6 +1258,34 @@ cgltf_result cgltf_validate(cgltf_data* data)
 		}
 	}
 
+	for (cgltf_size i = 0; i < data->nodes_count; ++i)
+	{
+		cgltf_node* p1 = data->nodes[i].parent;
+		cgltf_node* p2 = p1 ? p1->parent : NULL;
+
+		while (p1 && p2)
+		{
+			if (p1 == p2)
+			{
+				return cgltf_result_invalid_gltf;
+			}
+
+			p1 = p1->parent;
+			p2 = p2->parent ? p2->parent->parent : NULL;
+		}
+	}
+
+	for (cgltf_size i = 0; i < data->scenes_count; ++i)
+	{
+		for (cgltf_size j = 0; j < data->scenes[i].nodes_count; ++j)
+		{
+			if (data->scenes[i].nodes[j]->parent)
+			{
+				return cgltf_result_invalid_gltf;
+			}
+		}
+	}
+
 	return cgltf_result_success;
 }
 

--- a/tools/gltfpack.cpp
+++ b/tools/gltfpack.cpp
@@ -600,7 +600,6 @@ void parseAnimations(cgltf_data* data, std::vector<Animation>& animations)
 		for (size_t j = 0; j < animation.channels_count; ++j)
 		{
 			const cgltf_animation_channel& channel = animation.channels[j];
-			const cgltf_animation_sampler& sampler = animation.samplers[j];
 
 			if (!channel.target_node)
 			{
@@ -620,10 +619,10 @@ void parseAnimations(cgltf_data* data, std::vector<Animation>& animations)
 
 			track.components = (channel.target_path == cgltf_animation_path_type_weights) ? track.node->mesh->primitives[0].targets_count : 1;
 
-			track.interpolation = sampler.interpolation;
+			track.interpolation = channel.sampler->interpolation;
 
-			readAccessor(track.time, sampler.input);
-			readAccessor(track.data, sampler.output);
+			readAccessor(track.time, channel.sampler->input);
+			readAccessor(track.data, channel.sampler->output);
 
 			result.tracks.push_back(track);
 		}

--- a/tools/gltfpack.cpp
+++ b/tools/gltfpack.cpp
@@ -2393,6 +2393,28 @@ float getDelta(const Attr& l, const Attr& r, cgltf_animation_path_type type)
 	}
 }
 
+float getDeltaTolerance(cgltf_animation_path_type type)
+{
+	switch (type)
+	{
+	case cgltf_animation_path_type_translation:
+		return 0.001f; // linear
+
+	case cgltf_animation_path_type_rotation:
+		return 0.001f; // radians
+
+	case cgltf_animation_path_type_scale:
+		return 0.001f; // ratio
+
+	case cgltf_animation_path_type_weights:
+		return 0.001f; // linear
+
+	default:
+		assert(!"Uknown animation path type");
+		return 0;
+	}
+}
+
 bool isTrackConstant(const cgltf_animation_sampler& sampler, cgltf_animation_path_type type, cgltf_node* target_node, Attr* out_first = 0)
 {
 	const float tolerance = 1e-3f;
@@ -2602,14 +2624,7 @@ bool isTrackConstant(const std::vector<Attr>& data, cgltf_animation_path_type ty
 {
 	assert(data.size() == frames * components);
 
-	static const float tolerance[] =
-	{
-		0.f, //
-		0.001f, // translation, linear
-		0.001f, // rotation, radians
-		0.001f, // scale, ratio delta
-		0.001f, // weights, linear
-	};
+	float tolerance = getDeltaTolerance(type);
 
 	for (int i = 1; i < frames; ++i)
 	{
@@ -2617,7 +2632,7 @@ bool isTrackConstant(const std::vector<Attr>& data, cgltf_animation_path_type ty
 		{
 			float delta = getDelta(data[j], data[i * components + j], type);
 
-			if (delta > tolerance[type])
+			if (delta > tolerance)
 				return false;
 		}
 	}

--- a/tools/gltfpack.cpp
+++ b/tools/gltfpack.cpp
@@ -2620,17 +2620,17 @@ void resampleKeyframes(std::vector<Attr>& data, const std::vector<float>& input,
 	}
 }
 
-bool isTrackConstant(const std::vector<Attr>& data, cgltf_animation_path_type type, int frames, size_t components)
+bool isTrackEqual(const std::vector<Attr>& data, cgltf_animation_path_type type, int frames, const Attr* value, size_t components)
 {
 	assert(data.size() == frames * components);
 
 	float tolerance = getDeltaTolerance(type);
 
-	for (int i = 1; i < frames; ++i)
+	for (int i = 0; i < frames; ++i)
 	{
 		for (size_t j = 0; j < components; ++j)
 		{
-			float delta = getDelta(data[j], data[i * components + j], type);
+			float delta = getDelta(value[j], data[i * components + j], type);
 
 			if (delta > tolerance)
 				return false;
@@ -2671,8 +2671,9 @@ void processAnimation(Animation& animation, const Settings& settings)
 		track.time.clear();
 		track.data.swap(result);
 
-		if (isTrackConstant(track.data, track.path, frames, track.components))
+		if (isTrackEqual(track.data, track.path, frames, &track.data[0], track.components))
 		{
+			// track is constant (equal to first keyframe), we only need the first keyframe
 			track.data.resize(track.components);
 		}
 	}

--- a/tools/gltfpack.cpp
+++ b/tools/gltfpack.cpp
@@ -2598,21 +2598,9 @@ void resampleKeyframes(std::vector<Attr>& data, const std::vector<float>& input,
 	}
 }
 
-bool isTrackConstant(const std::vector<Attr>& data, cgltf_animation_path_type type, size_t components)
+bool isTrackConstant(const std::vector<Attr>& data, cgltf_animation_path_type type, int frames, size_t components)
 {
-	float max_delta = 0.f;
-
-	for (size_t i = 1; i < data.size(); ++i)
-	{
-		for (size_t j = 0; j < components; ++j)
-		{
-			float delta = getDelta(data[j], data[i * components + j], type);
-
-			max_delta = std::max(max_delta, delta);
-		}
-	}
-
-	printf("%f\n", max_delta);
+	assert(data.size() == frames * components);
 
 	static const float tolerance[] =
 	{
@@ -2623,7 +2611,7 @@ bool isTrackConstant(const std::vector<Attr>& data, cgltf_animation_path_type ty
 		0.001f, // weights, linear
 	};
 
-	for (size_t i = 1; i < data.size(); ++i)
+	for (int i = 1; i < frames; ++i)
 	{
 		for (size_t j = 0; j < components; ++j)
 		{
@@ -2668,9 +2656,7 @@ void processAnimation(Animation& animation, const Settings& settings)
 		track.time.clear();
 		track.data.swap(result);
 
-		printf("animation %s node %s track %s components %d\n", animation.name, track.node->name, animationPath(track.path), int(track.components));
-
-		if (isTrackConstant(track.data, track.path, track.components))
+		if (isTrackConstant(track.data, track.path, frames, track.components))
 		{
 			track.data.resize(track.components);
 		}

--- a/tools/gltfpack.cpp
+++ b/tools/gltfpack.cpp
@@ -607,12 +607,6 @@ void parseAnimations(cgltf_data* data, std::vector<Animation>& animations)
 				continue;
 			}
 
-			if (channel.target_path == cgltf_animation_path_type_weights && (!channel.target_node->mesh || channel.target_node->mesh->primitives_count == 0 || channel.target_node->mesh->primitives[0].targets_count == 0))
-			{
-				fprintf(stderr, "Warning: ignoring channel %d of animation %d because it contains invalid morph weight animation\n", int(j), int(i));
-				continue;
-			}
-
 			Track track = {};
 			track.node = channel.target_node;
 			track.path = channel.target_path;


### PR DESCRIPTION
This change reworks the animation processing pipeline to resemble that of meshes - animations are separately parsed, processed (optimized) and written. This allows us to more easily analyze and optimize animations in different ways.

This change also switches the error function for rotation and scale; rotations now use relative rotation angle (in radians), and scale uses relative scale delta from 1. This increases the size of some files where we previously culled rotation animations too aggressively.

Also morph target weight animations now also support dummy track optimization, so occasionally the files are smaller.