### PR TITLE
Add gltf-validator to gltfpack CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,3 +77,11 @@ jobs:
       run: make -j2 config=debug gltfpack
     - name: test
       run: find glTF-Sample-Models/2.0/ -name *.gltf | xargs ./gltfpack -cc -test
+    - name: pack
+      run: find glTF-Sample-Models/2.0/ -name *.gltf | xargs -I '{}' ./gltfpack -i '{}' -o '{}-pack.gltf'
+    - name: validate
+      run: |
+        curl -sL $VALIDATOR | tar xJ
+        find glTF-Sample-Models/2.0/ -name *-pack.gltf | xargs -L 1 ./gltf_validator -r -a
+      env:
+        VALIDATOR: https://github.com/KhronosGroup/glTF-Validator/releases/download/2.0.0-dev.3.2/gltf_validator-2.0.0-dev.3.2-linux64.tar.xz

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,7 +78,7 @@ jobs:
     - name: test
       run: find glTF-Sample-Models/2.0/ -name *.gltf | xargs ./gltfpack -cc -test
     - name: pack
-      run: find glTF-Sample-Models/2.0/ -name *.gltf | xargs -I '{}' ./gltfpack -i '{}' -o '{}-pack.gltf'
+      run: find glTF-Sample-Models/2.0/ -name *.gltf | grep -v glTF-Draco | xargs -I '{}' ./gltfpack -i '{}' -o '{}-pack.gltf'
     - name: validate
       run: |
         curl -sL $VALIDATOR | tar xJ

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,10 +78,10 @@ jobs:
     - name: test
       run: find glTF-Sample-Models/2.0/ -name *.gltf | xargs ./gltfpack -cc -test
     - name: pack
-      run: find glTF-Sample-Models/2.0/ -name *.gltf | grep -v glTF-Draco | xargs -I '{}' ./gltfpack -i '{}' -o '{}-pack.gltf'
+      run: find glTF-Sample-Models/2.0/ -name *.gltf | grep -v glTF-Draco | xargs -I '{}' ./gltfpack -i '{}' -o '{}pack.gltf'
     - name: validate
       run: |
         curl -sL $VALIDATOR | tar xJ
-        find glTF-Sample-Models/2.0/ -name *-pack.gltf | xargs -L 1 ./gltf_validator -r -a
+        find glTF-Sample-Models/2.0/ -name *.gltfpack.gltf | xargs -L 1 ./gltf_validator -r -a
       env:
         VALIDATOR: https://github.com/KhronosGroup/glTF-Validator/releases/download/2.0.0-dev.3.2/gltf_validator-2.0.0-dev.3.2-linux64.tar.xz


### PR DESCRIPTION
We now convert all .gltf models using gltfpack and run them through
gltf-validator to make sure the output is valid.