### PR TITLE
gltfpack: Implement "keep extras" flag

### DIFF
--- a/gltf/gltfpack.cpp
+++ b/gltf/gltfpack.cpp
@@ -182,7 +182,7 @@ void process(cgltf_data* data, const char* input_path, const char* output_path, 
 		}
 	}
 
-	mergeMeshMaterials(data, meshes);
+	mergeMeshMaterials(data, meshes, settings);
 	mergeMeshes(meshes, settings);
 	filterEmptyMeshes(meshes);
 

--- a/gltf/gltfpack.cpp
+++ b/gltf/gltfpack.cpp
@@ -467,7 +467,7 @@ void process(cgltf_data* data, const char* input_path, const char* output_path, 
 	if (data->asset.extras.start_offset)
 	{
 		append(json, ",\"extras\":");
-		json.append(data->json + data->asset.extras.start_offset, data->json + data->asset.extras.end_offset);
+		appendJson(json, data->json + data->asset.extras.start_offset, data->json + data->asset.extras.end_offset);
 	}
 	append(json, "}");
 

--- a/gltf/gltfpack.cpp
+++ b/gltf/gltfpack.cpp
@@ -272,7 +272,7 @@ void process(cgltf_data* data, const char* input_path, const char* output_path, 
 
 		comma(json_materials);
 		append(json_materials, "{");
-		writeMaterialInfo(json_materials, data, material, qt_materials[i]);
+		writeMaterial(json_materials, data, material, qt_materials[i]);
 		if (settings.keep_extras)
 			writeExtras(json_materials, data, material.extras);
 		append(json_materials, "}");
@@ -421,24 +421,7 @@ void process(cgltf_data* data, const char* input_path, const char* output_path, 
 
 		size_t matrix_accr = writeJointBindMatrices(views, json_accessors, accr_offset, skin, qp, settings);
 
-		comma(json_skins);
-		append(json_skins, "{");
-		append(json_skins, "\"joints\":[");
-		for (size_t j = 0; j < skin.joints_count; ++j)
-		{
-			comma(json_skins);
-			append(json_skins, size_t(nodes[skin.joints[j] - data->nodes].remap));
-		}
-		append(json_skins, "]");
-		append(json_skins, ",\"inverseBindMatrices\":");
-		append(json_skins, matrix_accr);
-		if (skin.skeleton)
-		{
-			comma(json_skins);
-			append(json_skins, "\"skeleton\":");
-			append(json_skins, size_t(nodes[skin.skeleton - data->nodes].remap));
-		}
-		append(json_skins, "}");
+		writeSkin(json_skins, skin, matrix_accr, nodes, data);
 	}
 
 	for (size_t i = 0; i < animations.size(); ++i)

--- a/gltf/gltfpack.cpp
+++ b/gltf/gltfpack.cpp
@@ -273,6 +273,8 @@ void process(cgltf_data* data, const char* input_path, const char* output_path, 
 		comma(json_materials);
 		append(json_materials, "{");
 		writeMaterialInfo(json_materials, data, material, qt_materials[i]);
+		if (settings.keep_extras)
+			writeExtras(json_materials, data, material.extras);
 		append(json_materials, "}");
 
 		mi.remap = int(material_offset);
@@ -464,11 +466,7 @@ void process(cgltf_data* data, const char* input_path, const char* output_path, 
 	append(json, "\"version\":\"2.0\",\"generator\":\"gltfpack ");
 	append(json, getVersion());
 	append(json, "\"");
-	if (data->asset.extras.start_offset)
-	{
-		append(json, ",\"extras\":");
-		appendJson(json, data->json + data->asset.extras.start_offset, data->json + data->asset.extras.end_offset);
-	}
+	writeExtras(json, data, data->asset.extras);
 	append(json, "}");
 
 	const ExtensionInfo extensions[] = {
@@ -775,6 +773,10 @@ int main(int argc, char** argv)
 		{
 			settings.keep_named = true;
 		}
+		else if (strcmp(arg, "-ke") == 0)
+		{
+			settings.keep_extras = true;
+		}
 		else if (strcmp(arg, "-si") == 0 && i + 1 < argc && isdigit(argv[i + 1][0]))
 		{
 			settings.simplify_threshold = float(atof(argv[++i]));
@@ -879,6 +881,7 @@ int main(int argc, char** argv)
 		fprintf(stderr, "-af N: resample animations at N Hz (default: 30)\n");
 		fprintf(stderr, "-ac: keep constant animation tracks even if they don't modify the node transform\n");
 		fprintf(stderr, "-kn: keep named nodes and meshes attached to named nodes so that named nodes can be transformed externally\n");
+		fprintf(stderr, "-ke: keep extras data\n");
 		fprintf(stderr, "-si R: simplify meshes to achieve the ratio R (default: 1; R should be between 0 and 1)\n");
 		fprintf(stderr, "-sa: aggressively simplify to the target ratio disregarding quality\n");
 		fprintf(stderr, "-te: embed all textures into main buffer\n");

--- a/gltf/gltfpack.h
+++ b/gltf/gltfpack.h
@@ -251,7 +251,7 @@ void appendJson(std::string& s, const char* begin, const char* end);
 const char* attributeType(cgltf_attribute_type type);
 const char* animationPath(cgltf_animation_path_type type);
 
-void writeMaterialInfo(std::string& json, const cgltf_data* data, const cgltf_material& material, const QuantizationTexture& qt);
+void writeMaterial(std::string& json, const cgltf_data* data, const cgltf_material& material, const QuantizationTexture& qt);
 void writeBufferView(std::string& json, BufferView::Kind kind, StreamFormat::Filter filter, size_t count, size_t stride, size_t bin_offset, size_t bin_size, int compression, size_t compressed_offset, size_t compressed_size);
 void writeImage(std::string& json, std::vector<BufferView>& views, const cgltf_image& image, const ImageInfo& info, size_t index, const char* input_path, const char* output_path, const Settings& settings);
 void writeTexture(std::string& json, const cgltf_texture& texture, cgltf_data* data, const Settings& settings);
@@ -259,6 +259,7 @@ void writeMeshAttributes(std::string& json, std::vector<BufferView>& views, std:
 size_t writeMeshIndices(std::vector<BufferView>& views, std::string& json_accessors, size_t& accr_offset, const Mesh& mesh, const Settings& settings);
 size_t writeJointBindMatrices(std::vector<BufferView>& views, std::string& json_accessors, size_t& accr_offset, const cgltf_skin& skin, const QuantizationPosition& qp, const Settings& settings);
 void writeMeshNode(std::string& json, size_t mesh_offset, const Mesh& mesh, cgltf_data* data, const QuantizationPosition& qp);
+void writeSkin(std::string& json, const cgltf_skin& skin, size_t matrix_accr, const std::vector<NodeInfo>& nodes, cgltf_data* data);
 void writeNode(std::string& json, const cgltf_node& node, const std::vector<NodeInfo>& nodes, cgltf_data* data);
 void writeAnimation(std::string& json, std::vector<BufferView>& views, std::string& json_accessors, size_t& accr_offset, const Animation& animation, size_t i, cgltf_data* data, const std::vector<NodeInfo>& nodes, const Settings& settings);
 void writeCamera(std::string& json, const cgltf_camera& camera);

--- a/gltf/gltfpack.h
+++ b/gltf/gltfpack.h
@@ -214,7 +214,7 @@ void mergeMeshes(std::vector<Mesh>& meshes, const Settings& settings);
 void filterEmptyMeshes(std::vector<Mesh>& meshes);
 
 bool usesTextureSet(const cgltf_material& material, int set);
-void mergeMeshMaterials(cgltf_data* data, std::vector<Mesh>& meshes);
+void mergeMeshMaterials(cgltf_data* data, std::vector<Mesh>& meshes, const Settings& settings);
 void markNeededMaterials(cgltf_data* data, std::vector<MaterialInfo>& materials, const std::vector<Mesh>& meshes);
 
 void analyzeImages(cgltf_data* data, std::vector<ImageInfo>& images);

--- a/gltf/gltfpack.h
+++ b/gltf/gltfpack.h
@@ -245,6 +245,7 @@ void append(std::string& s, size_t v);
 void append(std::string& s, float v);
 void append(std::string& s, const char* v);
 void append(std::string& s, const std::string& v);
+void appendJson(std::string& s, const char* begin, const char* end);
 
 const char* attributeType(cgltf_attribute_type type);
 const char* animationPath(cgltf_animation_path_type type);

--- a/gltf/gltfpack.h
+++ b/gltf/gltfpack.h
@@ -84,6 +84,7 @@ struct Settings
 	bool anim_const;
 
 	bool keep_named;
+	bool keep_extras;
 
 	float simplify_threshold;
 	bool simplify_aggressive;
@@ -264,6 +265,7 @@ void writeCamera(std::string& json, const cgltf_camera& camera);
 void writeLight(std::string& json, const cgltf_light& light);
 void writeArray(std::string& json, const char* name, const std::string& contents);
 void writeExtensions(std::string& json, const ExtensionInfo* extensions, size_t count);
+void writeExtras(std::string& json, const cgltf_data* data, const cgltf_extras& extras);
 
 /**
  * Copyright (c) 2016-2020 Arseny Kapoulkine

--- a/gltf/json.cpp
+++ b/gltf/json.cpp
@@ -34,3 +34,41 @@ void append(std::string& s, const std::string& v)
 {
 	s += v;
 }
+
+void appendJson(std::string& s, const char* begin, const char* end)
+{
+	enum State
+	{
+		None,
+		Escape,
+		Quoted
+	} state = None;
+
+	for (const char* it = begin; it != end; ++it)
+	{
+		char ch = *it;
+
+		// whitespace outside of quoted strings can be ignored
+		if (state != None || !isspace(ch))
+			s += ch;
+
+		// the finite automata tracks whether we're inside a quoted string
+		switch (state)
+		{
+		case None:
+			state = (ch == '"') ? Quoted : None;
+			break;
+
+		case Quoted:
+			state = (ch == '"') ? None : (ch == '\\') ? Escape : Quoted;
+			break;
+
+		case Escape:
+			state = Quoted;
+			break;
+
+		default:
+			assert(!"Unexpected parsing state");
+		}
+	}
+}

--- a/gltf/write.cpp
+++ b/gltf/write.cpp
@@ -1103,3 +1103,13 @@ void writeExtensions(std::string& json, const ExtensionInfo* extensions, size_t 
 		}
 	append(json, "]");
 }
+
+void writeExtras(std::string& json, const cgltf_data* data, const cgltf_extras& extras)
+{
+	if (extras.start_offset == extras.end_offset)
+		return;
+
+	comma(json);
+	append(json, "\"extras\":");
+	appendJson(json, data->json + extras.start_offset, data->json + extras.end_offset);
+}

--- a/gltf/write.cpp
+++ b/gltf/write.cpp
@@ -146,7 +146,7 @@ static void writeTextureInfo(std::string& json, const cgltf_data* data, const cg
 	append(json, "}}}");
 }
 
-void writeMaterialInfo(std::string& json, const cgltf_data* data, const cgltf_material& material, const QuantizationTexture& qt)
+void writeMaterial(std::string& json, const cgltf_data* data, const cgltf_material& material, const QuantizationTexture& qt)
 {
 	static const float white[4] = {1, 1, 1, 1};
 	static const float black[4] = {0, 0, 0, 0};
@@ -767,6 +767,28 @@ void writeMeshNode(std::string& json, size_t mesh_offset, const Mesh& mesh, cglt
 			append(json, mesh.node->weights[j]);
 		}
 		append(json, "]");
+	}
+	append(json, "}");
+}
+
+void writeSkin(std::string& json, const cgltf_skin& skin, size_t matrix_accr, const std::vector<NodeInfo>& nodes, cgltf_data* data)
+{
+	comma(json);
+	append(json, "{");
+	append(json, "\"joints\":[");
+	for (size_t j = 0; j < skin.joints_count; ++j)
+	{
+		comma(json);
+		append(json, size_t(nodes[skin.joints[j] - data->nodes].remap));
+	}
+	append(json, "]");
+	append(json, ",\"inverseBindMatrices\":");
+	append(json, matrix_accr);
+	if (skin.skeleton)
+	{
+		comma(json);
+		append(json, "\"skeleton\":");
+		append(json, size_t(nodes[skin.skeleton - data->nodes].remap));
 	}
 	append(json, "}");
 }


### PR DESCRIPTION
When a new flag, -ke, is set, we are starting to preserve .extras data in several objects.

This PR does it for materials only for now.

Closes #108.