### PR TITLE
gltfpack: Implement UASTC support

### DIFF
--- a/extern/basisu_format.h
+++ b/extern/basisu_format.h
@@ -1,5 +1,5 @@
 // basis_file_headers.h + basisu.h
-// Copyright (C) 2019 Binomial LLC. All Rights Reserved.
+// Copyright (C) 2019-2020 Binomial LLC. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -37,7 +37,7 @@ namespace basist
 	// Slice desc header flags
 	enum basis_slice_desc_flags
 	{
-		cSliceDescFlagsIsAlphaData = 1,
+		cSliceDescFlagsHasAlpha = 1,
 		cSliceDescFlagsFrameIsIFrame = 2			// Video only: Frame doesn't refer to previous frame (no usage of conditional replenishment pred symbols)
 	};
 
@@ -64,9 +64,9 @@ namespace basist
 	// File header files
 	enum basis_header_flags
 	{
-		cBASISHeaderFlagETC1S = 1,					// Always set for basis universal files
+		cBASISHeaderFlagETC1S = 1,					// Always set for ETC1S files. Not set for UASTC files.
 		cBASISHeaderFlagYFlipped = 2,				// Set if the texture had to be Y flipped before encoding
-		cBASISHeaderFlagHasAlphaSlices = 4		// True if the odd slices contain alpha data
+		cBASISHeaderFlagHasAlphaSlices = 4		// True if any slices contain alpha (for ETC1S, if the odd slices contain alpha data)
 	};
 
 	// The image type field attempts to describe how to interpret the image data in a Basis file.
@@ -86,6 +86,12 @@ namespace basist
 	enum
 	{
 		cBASISMaxUSPerFrame = 0xFFFFFF
+	};
+
+	enum basis_tex_format
+	{
+		cETC1S = 0,
+		cUASTC4x4 = 1
 	};
 
 	struct basis_file_header
@@ -108,7 +114,7 @@ namespace basist
 
 		basisu::packed_uint<3>      m_total_images;	// The total # of images
 				
-		basisu::packed_uint<1>      m_format;			// enum basist::block_format
+		basisu::packed_uint<1>      m_tex_format;		// enum basis_tex_format
 		basisu::packed_uint<2>      m_flags;			// enum basist::header_flags
 		basisu::packed_uint<1>      m_tex_type;		// enum basist::basis_texture_type
 		basisu::packed_uint<3>      m_us_per_frame;	// Framerate of video, in microseconds per frame

--- a/extern/khr_df.h
+++ b/extern/khr_df.h
@@ -323,6 +323,8 @@ typedef enum _khr_df_model_e {
     /* PowerVR Texture Compression */
     KHR_DF_MODEL_PVRTC         = 164U,
     KHR_DF_MODEL_PVRTC2        = 165U,
+    /* Universal Adaptive Scalable Texture Compression */
+    KHR_DF_MODEL_UASTC         = 166U,
     /* Proprietary formats (ATITC, etc.) should follow */
     KHR_DF_MODEL_MAX = 0xFFU
 } khr_df_model_e;

--- a/gltf/basistoktx.cpp
+++ b/gltf/basistoktx.cpp
@@ -147,7 +147,7 @@ std::string basisToKtx(const std::string& basis, bool srgb)
 	assert(basis_header.m_total_slices > 0);
 	assert(basis_header.m_total_images == 1);
 
-	assert(basis_header.m_format == 0);
+	assert(basis_header.m_tex_format == basist::cETC1S);
 	assert(basis_header.m_flags & basist::cBASISHeaderFlagETC1S);
 	assert(!(basis_header.m_flags & basist::cBASISHeaderFlagYFlipped));
 	assert(basis_header.m_tex_type == basist::cBASISTexType2D);

--- a/gltf/basistoktx.cpp
+++ b/gltf/basistoktx.cpp
@@ -42,6 +42,7 @@ struct Ktx2LevelIndex
 
 enum
 {
+	Ktx2SupercompressionSchemeNone = 0,
 	Ktx2SupercompressionSchemeBasis = 1,
 };
 
@@ -95,7 +96,7 @@ static void write(std::string& data, size_t offset, const T& value)
 	memcpy(&data[offset], &value, sizeof(T));
 }
 
-static void createDfd(std::vector<uint32_t>& result, int channels, bool srgb)
+static void createDfd(std::vector<uint32_t>& result, int channels, bool srgb, bool uastc)
 {
 	assert(channels <= 4);
 
@@ -112,7 +113,7 @@ static void createDfd(std::vector<uint32_t>& result, int channels, bool srgb)
 	KHR_DFDSETVAL(dfd, DESCRIPTORTYPE, KHR_DF_KHR_DESCRIPTORTYPE_BASICFORMAT);
 	KHR_DFDSETVAL(dfd, VERSIONNUMBER, KHR_DF_VERSIONNUMBER_1_3);
 	KHR_DFDSETVAL(dfd, DESCRIPTORBLOCKSIZE, descriptor_size * sizeof(uint32_t));
-	KHR_DFDSETVAL(dfd, MODEL, KHR_DF_MODEL_RGBSDA);
+	KHR_DFDSETVAL(dfd, MODEL, uastc ? KHR_DF_MODEL_UASTC : KHR_DF_MODEL_RGBSDA);
 	KHR_DFDSETVAL(dfd, PRIMARIES, KHR_DF_PRIMARIES_BT709);
 	KHR_DFDSETVAL(dfd, TRANSFER, srgb ? KHR_DF_TRANSFER_SRGB : KHR_DF_TRANSFER_LINEAR);
 	KHR_DFDSETVAL(dfd, FLAGS, KHR_DF_FLAG_ALPHA_STRAIGHT);
@@ -135,34 +136,44 @@ static void createDfd(std::vector<uint32_t>& result, int channels, bool srgb)
 	}
 }
 
-std::string basisToKtx(const std::string& basis, bool srgb)
+std::string basisToKtx(const std::string& data, bool srgb, bool uastc)
 {
 	std::string ktx;
 
 	basist::basis_file_header basis_header;
-	read(basis, 0, basis_header);
+	read(data, 0, basis_header);
 
 	assert(basis_header.m_sig == basist::basis_file_header::cBASISSigValue);
 
 	assert(basis_header.m_total_slices > 0);
 	assert(basis_header.m_total_images == 1);
 
-	assert(basis_header.m_tex_format == basist::cETC1S);
-	assert(basis_header.m_flags & basist::cBASISHeaderFlagETC1S);
+	assert(basis_header.m_tex_format == uastc ? basist::cUASTC4x4 : basist::cETC1S);
+	assert(!(basis_header.m_flags & basist::cBASISHeaderFlagETC1S) == uastc);
 	assert(!(basis_header.m_flags & basist::cBASISHeaderFlagYFlipped));
 	assert(basis_header.m_tex_type == basist::cBASISTexType2D);
 
+	if (uastc)
+	{
+		assert(basis_header.m_endpoint_cb_file_size == 0);
+		assert(basis_header.m_selector_cb_file_size == 0);
+		assert(basis_header.m_tables_file_size == 0);
+		assert(basis_header.m_extended_file_size == 0);
+	}
+
 	bool has_alpha = (basis_header.m_flags & basist::cBASISHeaderFlagHasAlphaSlices) != 0;
+	bool alpha_slices = has_alpha && !uastc;
+	bool basis = !uastc;
 
 	std::vector<basist::basis_slice_desc> slices(basis_header.m_total_slices);
 
 	for (size_t i = 0; i < basis_header.m_total_slices; ++i)
-		read(basis, basis_header.m_slice_desc_file_ofs + i * sizeof(basist::basis_slice_desc), slices[i]);
+		read(data, basis_header.m_slice_desc_file_ofs + i * sizeof(basist::basis_slice_desc), slices[i]);
 
 	assert(slices[0].m_level_index == 0);
 	uint32_t width = slices[0].m_orig_width;
 	uint32_t height = slices[0].m_orig_height;
-	uint32_t levels = has_alpha ? uint32_t(slices.size()) / 2 : uint32_t(slices.size());
+	uint32_t levels = alpha_slices ? uint32_t(slices.size()) / 2 : uint32_t(slices.size());
 
 	Ktx2Header ktx_header = {};
 	memcpy(ktx_header.identifier, Ktx2FileIdentifier, sizeof(Ktx2FileIdentifier));
@@ -172,12 +183,12 @@ std::string basisToKtx(const std::string& basis, bool srgb)
 	ktx_header.layerCount = 0;
 	ktx_header.faceCount = 1;
 	ktx_header.levelCount = levels;
-	ktx_header.supercompressionScheme = Ktx2SupercompressionSchemeBasis;
+	ktx_header.supercompressionScheme = basis ? Ktx2SupercompressionSchemeBasis : Ktx2SupercompressionSchemeNone;
 
 	size_t header_size = sizeof(Ktx2Header) + levels * sizeof(Ktx2LevelIndex);
 
 	std::vector<uint32_t> dfd;
-	createDfd(dfd, has_alpha ? 4 : 3, srgb);
+	createDfd(dfd, has_alpha ? 4 : 3, srgb, uastc);
 
 	const char* kvp_data[][2] = {
 	    {"KTXwriter", "gltfpack"},
@@ -202,18 +213,21 @@ std::string basisToKtx(const std::string& basis, bool srgb)
 	size_t kvp_size = kvp.size();
 	size_t dfd_size = dfd.size() * sizeof(uint32_t);
 
-	size_t bgd_size =
-	    sizeof(Ktx2BasisGlobalHeader) + sizeof(Ktx2BasisImageDesc) * levels +
-	    basis_header.m_endpoint_cb_file_size + basis_header.m_selector_cb_file_size + basis_header.m_tables_file_size;
-
 	ktx_header.dfdByteOffset = uint32_t(header_size);
 	ktx_header.dfdByteLength = uint32_t(dfd_size);
 
 	ktx_header.kvdByteOffset = uint32_t(header_size + dfd_size);
 	ktx_header.kvdByteLength = uint32_t(kvp_size);
 
-	ktx_header.sgdByteOffset = (header_size + dfd_size + kvp_size + 7) & ~7;
-	ktx_header.sgdByteLength = bgd_size;
+	if (basis)
+	{
+		size_t bgd_size =
+		    sizeof(Ktx2BasisGlobalHeader) + sizeof(Ktx2BasisImageDesc) * levels +
+		    basis_header.m_endpoint_cb_file_size + basis_header.m_selector_cb_file_size + basis_header.m_tables_file_size;
+
+		ktx_header.sgdByteOffset = (header_size + dfd_size + kvp_size + 7) & ~7;
+		ktx_header.sgdByteLength = bgd_size;
+	}
 
 	// KTX2 header
 	write(ktx, ktx_header);
@@ -235,48 +249,54 @@ std::string basisToKtx(const std::string& basis, bool srgb)
 	ktx.resize((ktx.size() + 7) & ~7);
 
 	// supercompression global data
-	Ktx2BasisGlobalHeader sgd_header = {};
-	sgd_header.globalFlags = basis_header.m_flags;
-	sgd_header.endpointCount = uint16_t(basis_header.m_total_endpoints);
-	sgd_header.selectorCount = uint16_t(basis_header.m_total_selectors);
-	sgd_header.endpointsByteLength = basis_header.m_endpoint_cb_file_size;
-	sgd_header.selectorsByteLength = basis_header.m_selector_cb_file_size;
-	sgd_header.tablesByteLength = basis_header.m_tables_file_size;
-	sgd_header.extendedByteLength = basis_header.m_extended_file_size;
+	if (basis)
+	{
+		Ktx2BasisGlobalHeader sgd_header = {};
+		sgd_header.globalFlags = basis_header.m_flags;
+		sgd_header.endpointCount = uint16_t(basis_header.m_total_endpoints);
+		sgd_header.selectorCount = uint16_t(basis_header.m_total_selectors);
+		sgd_header.endpointsByteLength = basis_header.m_endpoint_cb_file_size;
+		sgd_header.selectorsByteLength = basis_header.m_selector_cb_file_size;
+		sgd_header.tablesByteLength = basis_header.m_tables_file_size;
+		sgd_header.extendedByteLength = basis_header.m_extended_file_size;
 
-	write(ktx, sgd_header);
+		write(ktx, sgd_header);
+	}
 
 	size_t sgd_level_offset = ktx.size();
 
-	for (size_t i = 0; i < levels; ++i)
+	if (basis)
 	{
-		Ktx2BasisImageDesc sgd_image = {}; // This will be patched later
-		write(ktx, sgd_image);
-	}
+		for (size_t i = 0; i < levels; ++i)
+		{
+			Ktx2BasisImageDesc sgd_image = {}; // This will be patched later
+			write(ktx, sgd_image);
+		}
 
-	ktx.append(basis.substr(basis_header.m_endpoint_cb_file_ofs, basis_header.m_endpoint_cb_file_size));
-	ktx.append(basis.substr(basis_header.m_selector_cb_file_ofs, basis_header.m_selector_cb_file_size));
-	ktx.append(basis.substr(basis_header.m_tables_file_ofs, basis_header.m_tables_file_size));
-	ktx.append(basis.substr(basis_header.m_extended_file_ofs, basis_header.m_extended_file_size));
+		ktx.append(data.substr(basis_header.m_endpoint_cb_file_ofs, basis_header.m_endpoint_cb_file_size));
+		ktx.append(data.substr(basis_header.m_selector_cb_file_ofs, basis_header.m_selector_cb_file_size));
+		ktx.append(data.substr(basis_header.m_tables_file_ofs, basis_header.m_tables_file_size));
+		ktx.append(data.substr(basis_header.m_extended_file_ofs, basis_header.m_extended_file_size));
+	}
 
 	// mip levels
 	for (size_t i = 0; i < levels; ++i)
 	{
 		size_t level_index = levels - i - 1;
-		size_t slice_index = level_index * (has_alpha + 1);
+		size_t slice_index = level_index * (alpha_slices + 1);
 
 		const basist::basis_slice_desc& slice = slices[slice_index];
-		const basist::basis_slice_desc* slice_alpha = has_alpha ? &slices[slice_index + 1] : 0;
+		const basist::basis_slice_desc* slice_alpha = alpha_slices ? &slices[slice_index + 1] : 0;
 
 		assert(slice.m_image_index == 0);
 		assert(slice.m_level_index == level_index);
 
 		size_t file_offset = ktx.size();
 
-		ktx.append(basis.substr(slice.m_file_ofs, slice.m_file_size));
+		ktx.append(data.substr(slice.m_file_ofs, slice.m_file_size));
 
 		if (slice_alpha)
-			ktx.append(basis.substr(slice_alpha->m_file_ofs, slice_alpha->m_file_size));
+			ktx.append(data.substr(slice_alpha->m_file_ofs, slice_alpha->m_file_size));
 
 		Ktx2LevelIndex le = {};
 		le.byteOffset = file_offset;
@@ -285,17 +305,20 @@ std::string basisToKtx(const std::string& basis, bool srgb)
 
 		write(ktx, ktx_level_offset + level_index * sizeof(Ktx2LevelIndex), le);
 
-		Ktx2BasisImageDesc sgd_image = {};
-		sgd_image.rgbSliceByteOffset = 0;
-		sgd_image.rgbSliceByteLength = slice.m_file_size;
-
-		if (slice_alpha)
+		if (basis)
 		{
-			sgd_image.alphaSliceByteOffset = slice.m_file_size;
-			sgd_image.alphaSliceByteLength = slice_alpha->m_file_size;
-		}
+			Ktx2BasisImageDesc sgd_image = {};
+			sgd_image.rgbSliceByteOffset = 0;
+			sgd_image.rgbSliceByteLength = slice.m_file_size;
 
-		write(ktx, sgd_level_offset + level_index * sizeof(Ktx2BasisImageDesc), sgd_image);
+			if (slice_alpha)
+			{
+				sgd_image.alphaSliceByteOffset = slice.m_file_size;
+				sgd_image.alphaSliceByteLength = slice_alpha->m_file_size;
+			}
+
+			write(ktx, sgd_level_offset + level_index * sizeof(Ktx2BasisImageDesc), sgd_image);
+		}
 	}
 
 	return ktx;
@@ -342,11 +365,11 @@ int main(int argc, const char** argv)
 	if (argc < 2)
 		return 1;
 
-	std::string basis;
-	if (!readFile(argv[1], basis))
+	std::string data;
+	if (!readFile(argv[1], data))
 		return 1;
 
-	std::string ktx = basisToKtx(basis, true);
+	std::string ktx = basisToKtx(data, true, false);
 
 	if (!writeFile(argv[2], ktx))
 		return 1;

--- a/gltf/basistoktx.cpp
+++ b/gltf/basistoktx.cpp
@@ -155,7 +155,7 @@ std::string basisToKtx(const std::string& data, bool srgb, bool uastc)
 	assert(basis_header.m_total_slices > 0);
 	assert(basis_header.m_total_images == 1);
 
-	assert(basis_header.m_tex_format == uastc ? basist::cUASTC4x4 : basist::cETC1S);
+	assert(basis_header.m_tex_format == uint32_t(uastc ? basist::cUASTC4x4 : basist::cETC1S));
 	assert(!(basis_header.m_flags & basist::cBASISHeaderFlagETC1S) == uastc);
 	assert(!(basis_header.m_flags & basist::cBASISHeaderFlagYFlipped));
 	assert(basis_header.m_tex_type == basist::cBASISTexType2D);

--- a/gltf/gltfpack.cpp
+++ b/gltf/gltfpack.cpp
@@ -799,6 +799,7 @@ int main(int argc, char** argv)
 		}
 		else if (strcmp(arg, "-tu") == 0)
 		{
+			settings.texture_basis = true;
 			settings.texture_uastc = true;
 		}
 		else if (strcmp(arg, "-tc") == 0)

--- a/gltf/gltfpack.cpp
+++ b/gltf/gltfpack.cpp
@@ -797,6 +797,10 @@ int main(int argc, char** argv)
 		{
 			settings.texture_basis = true;
 		}
+		else if (strcmp(arg, "-tu") == 0)
+		{
+			settings.texture_uastc = true;
+		}
 		else if (strcmp(arg, "-tc") == 0)
 		{
 			settings.texture_basis = true;
@@ -900,6 +904,7 @@ int main(int argc, char** argv)
 			fprintf(stderr, "\t-tb: convert all textures to Basis Universal format (with basisu executable); will be removed in the future\n");
 			fprintf(stderr, "\t-tc: convert all textures to KTX2 with BasisU supercompression (using basisu executable)\n");
 			fprintf(stderr, "\t-tq N: set texture encoding quality (default: 50; N should be between 1 and 100\n");
+			fprintf(stderr, "\t-tu: use UASTC when encoding textures (much higher quality and much larger size)\n");
 			fprintf(stderr, "\nSimplification:\n");
 			fprintf(stderr, "\t-si R: simplify meshes to achieve the ratio R (default: 1; R should be between 0 and 1)\n");
 			fprintf(stderr, "\t-sa: aggressively simplify to the target ratio disregarding quality\n");

--- a/gltf/gltfpack.h
+++ b/gltf/gltfpack.h
@@ -224,9 +224,9 @@ void mergeMeshMaterials(cgltf_data* data, std::vector<Mesh>& meshes, const Setti
 void markNeededMaterials(cgltf_data* data, std::vector<MaterialInfo>& materials, const std::vector<Mesh>& meshes);
 
 void analyzeImages(cgltf_data* data, std::vector<ImageInfo>& images);
-std::string inferMimeType(const char* path);
+const char* inferMimeType(const char* path);
 bool checkBasis();
-bool encodeBasis(const std::string& data, std::string& result, bool normal_map, bool srgb, int quality);
+bool encodeBasis(const std::string& data, const char* mime_type, std::string& result, bool normal_map, bool srgb, int quality);
 std::string basisToKtx(const std::string& basis, bool srgb);
 
 void markAnimated(cgltf_data* data, std::vector<NodeInfo>& nodes, const std::vector<Animation>& animations);

--- a/gltf/gltfpack.h
+++ b/gltf/gltfpack.h
@@ -228,7 +228,7 @@ void analyzeImages(cgltf_data* data, std::vector<ImageInfo>& images);
 const char* inferMimeType(const char* path);
 bool checkBasis();
 bool encodeBasis(const std::string& data, const char* mime_type, std::string& result, bool normal_map, bool srgb, int quality, bool uastc);
-std::string basisToKtx(const std::string& basis, bool srgb);
+std::string basisToKtx(const std::string& data, bool srgb, bool uastc);
 
 void markAnimated(cgltf_data* data, std::vector<NodeInfo>& nodes, const std::vector<Animation>& animations);
 void markNeededNodes(cgltf_data* data, std::vector<NodeInfo>& nodes, const std::vector<Mesh>& meshes, const std::vector<Animation>& animations, const Settings& settings);

--- a/gltf/gltfpack.h
+++ b/gltf/gltfpack.h
@@ -96,6 +96,7 @@ struct Settings
 	bool texture_embed;
 	bool texture_basis;
 	bool texture_ktx2;
+	bool texture_uastc;
 
 	int texture_quality;
 
@@ -226,7 +227,7 @@ void markNeededMaterials(cgltf_data* data, std::vector<MaterialInfo>& materials,
 void analyzeImages(cgltf_data* data, std::vector<ImageInfo>& images);
 const char* inferMimeType(const char* path);
 bool checkBasis();
-bool encodeBasis(const std::string& data, const char* mime_type, std::string& result, bool normal_map, bool srgb, int quality);
+bool encodeBasis(const std::string& data, const char* mime_type, std::string& result, bool normal_map, bool srgb, int quality, bool uastc);
 std::string basisToKtx(const std::string& basis, bool srgb);
 
 void markAnimated(cgltf_data* data, std::vector<NodeInfo>& nodes, const std::vector<Animation>& animations);

--- a/gltf/image.cpp
+++ b/gltf/image.cpp
@@ -99,7 +99,7 @@ bool checkBasis()
 #endif
 }
 
-bool encodeBasis(const std::string& data, const char* mime_type, std::string& result, bool normal_map, bool srgb, int quality)
+bool encodeBasis(const std::string& data, const char* mime_type, std::string& result, bool normal_map, bool srgb, int quality, bool uastc)
 {
 	TempFile temp_input(mimeExtension(mime_type));
 	TempFile temp_output(".basis");
@@ -126,6 +126,11 @@ bool encodeBasis(const std::string& data, const char* mime_type, std::string& re
 	else if (!srgb)
 	{
 		cmd += " -linear";
+	}
+
+	if (uastc)
+	{
+		cmd += " -uastc";
 	}
 
 	cmd += " -file ";

--- a/gltf/image.cpp
+++ b/gltf/image.cpp
@@ -10,11 +10,10 @@
 #define pclose _pclose
 #endif
 
-static const char* kMimeTypes[][2] =
-{
-	{ "image/jpeg", ".jpg" },
-	{ "image/jpeg", ".jpeg" },
-	{ "image/png", ".png" },
+static const char* kMimeTypes[][2] = {
+    {"image/jpeg", ".jpg"},
+    {"image/jpeg", ".jpeg"},
+    {"image/png", ".png"},
 };
 
 void analyzeImages(cgltf_data* data, std::vector<ImageInfo>& images)

--- a/gltf/image.cpp
+++ b/gltf/image.cpp
@@ -5,11 +5,6 @@
 #include <stdlib.h>
 #include <string.h>
 
-#ifdef _WIN32
-#define popen _popen
-#define pclose _pclose
-#endif
-
 static const char* kMimeTypes[][2] = {
     {"image/jpeg", ".jpg"},
     {"image/jpeg", ".jpeg"},
@@ -74,28 +69,20 @@ static const char* mimeExtension(const char* mime_type)
 
 bool checkBasis()
 {
-#ifdef __EMSCRIPTEN__
-	return false;
-#else
 	const char* basisu_path = getenv("BASISU_PATH");
 	std::string cmd = basisu_path ? basisu_path : "basisu";
 
+	cmd += " -version";
+
 #ifdef _WIN32
-	cmd += " 2>nul";
+	cmd += " >nul 2>nul";
 #else
-	cmd += " 2>/dev/null";
+	cmd += " >/dev/null 2>/dev/null";
 #endif
 
-	FILE* pipe = popen(cmd.c_str(), "r");
-	if (!pipe)
-		return false;
+	int rc = system(cmd.c_str());
 
-	char buf[15];
-	size_t read = fread(buf, 1, sizeof(buf), pipe);
-	pclose(pipe);
-
-	return read == sizeof(buf) && memcmp(buf, "Basis Universal", sizeof(buf)) == 0;
-#endif
+	return rc == 0;
 }
 
 bool encodeBasis(const std::string& data, const char* mime_type, std::string& result, bool normal_map, bool srgb, int quality, bool uastc)

--- a/gltf/write.cpp
+++ b/gltf/write.cpp
@@ -574,7 +574,7 @@ void writeImage(std::string& json, std::vector<BufferView>& views, const cgltf_i
 		{
 			std::string encoded;
 
-			if (encodeBasis(img_data, mime_type.c_str(), encoded, info.normal_map, info.srgb, settings.texture_quality))
+			if (encodeBasis(img_data, mime_type.c_str(), encoded, info.normal_map, info.srgb, settings.texture_quality, settings.texture_uastc))
 			{
 				if (settings.texture_ktx2)
 					encoded = basisToKtx(encoded, info.srgb);
@@ -603,7 +603,7 @@ void writeImage(std::string& json, std::vector<BufferView>& views, const cgltf_i
 			{
 				std::string encoded;
 
-				if (encodeBasis(img_data, mime_type.c_str(), encoded, info.normal_map, info.srgb, settings.texture_quality))
+				if (encodeBasis(img_data, mime_type.c_str(), encoded, info.normal_map, info.srgb, settings.texture_quality, settings.texture_uastc))
 				{
 					if (settings.texture_ktx2)
 						encoded = basisToKtx(encoded, info.srgb);

--- a/gltf/write.cpp
+++ b/gltf/write.cpp
@@ -577,7 +577,7 @@ void writeImage(std::string& json, std::vector<BufferView>& views, const cgltf_i
 			if (encodeBasis(img_data, mime_type.c_str(), encoded, info.normal_map, info.srgb, settings.texture_quality, settings.texture_uastc))
 			{
 				if (settings.texture_ktx2)
-					encoded = basisToKtx(encoded, info.srgb);
+					encoded = basisToKtx(encoded, info.srgb, settings.texture_uastc);
 
 				writeEmbeddedImage(json, views, encoded.c_str(), encoded.size(), settings.texture_ktx2 ? "image/ktx2" : "image/basis");
 			}
@@ -606,7 +606,7 @@ void writeImage(std::string& json, std::vector<BufferView>& views, const cgltf_i
 				if (encodeBasis(img_data, mime_type.c_str(), encoded, info.normal_map, info.srgb, settings.texture_quality, settings.texture_uastc))
 				{
 					if (settings.texture_ktx2)
-						encoded = basisToKtx(encoded, info.srgb);
+						encoded = basisToKtx(encoded, info.srgb, settings.texture_uastc);
 
 					if (writeFile(basis_full_path.c_str(), encoded))
 					{

--- a/gltf/write.cpp
+++ b/gltf/write.cpp
@@ -574,7 +574,7 @@ void writeImage(std::string& json, std::vector<BufferView>& views, const cgltf_i
 		{
 			std::string encoded;
 
-			if (encodeBasis(img_data, encoded, info.normal_map, info.srgb, settings.texture_quality))
+			if (encodeBasis(img_data, mime_type.c_str(), encoded, info.normal_map, info.srgb, settings.texture_quality))
 			{
 				if (settings.texture_ktx2)
 					encoded = basisToKtx(encoded, info.srgb);
@@ -603,7 +603,7 @@ void writeImage(std::string& json, std::vector<BufferView>& views, const cgltf_i
 			{
 				std::string encoded;
 
-				if (encodeBasis(img_data, encoded, info.normal_map, info.srgb, settings.texture_quality))
+				if (encodeBasis(img_data, mime_type.c_str(), encoded, info.normal_map, info.srgb, settings.texture_quality))
 				{
 					if (settings.texture_ktx2)
 						encoded = basisToKtx(encoded, info.srgb);


### PR DESCRIPTION
This change adds a flag, -tu, that enables UASTC support both when encoding raw .basis files, and when encoding .ktx2 files.

The .ktx2 implementation may not be fully correct since the KTX DataFormat specification isn't fully complete here.

The .basis implementation has been tested using https://github.com/mrdoob/three.js/pull/18943.

Note that this change does *not* have RDO support - RDO encoding in basisu is *really* slow, and I'd need to figure out how to best map quality to the UASTC input parameters.

Additionally this change fixes support for basisu 1.12 and - miraculously - allows us to compress basis textures from Node as long as basis executable is available...