### PR TITLE
gltfpack: Implement support for all primitive modes

### DIFF
--- a/gltf/gltfpack.h
+++ b/gltf/gltfpack.h
@@ -185,11 +185,19 @@ struct BufferView
 		Kind_Count
 	};
 
+	enum Compression
+	{
+		Compression_None = -1,
+		Compression_Attribute,
+		Compression_Index,
+		Compression_IndexSequence,
+	};
+
 	Kind kind;
 	StreamFormat::Filter filter;
-	int variant;
+	Compression compression;
 	size_t stride;
-	bool compressed;
+	int variant;
 
 	std::string data;
 
@@ -246,8 +254,9 @@ StreamFormat writeKeyframeStream(std::string& bin, cgltf_animation_path_type typ
 
 void compressVertexStream(std::string& bin, const std::string& data, size_t count, size_t stride);
 void compressIndexStream(std::string& bin, const std::string& data, size_t count, size_t stride);
+void compressIndexSequence(std::string& bin, const std::string& data, size_t count, size_t stride);
 
-size_t getBufferView(std::vector<BufferView>& views, BufferView::Kind kind, StreamFormat::Filter filter, int variant, size_t stride, bool compressed);
+size_t getBufferView(std::vector<BufferView>& views, BufferView::Kind kind, StreamFormat::Filter filter, BufferView::Compression compression, size_t stride, int variant = 0);
 
 void comma(std::string& s);
 void append(std::string& s, size_t v);
@@ -260,7 +269,7 @@ const char* attributeType(cgltf_attribute_type type);
 const char* animationPath(cgltf_animation_path_type type);
 
 void writeMaterial(std::string& json, const cgltf_data* data, const cgltf_material& material, const QuantizationTexture* qt);
-void writeBufferView(std::string& json, BufferView::Kind kind, StreamFormat::Filter filter, size_t count, size_t stride, size_t bin_offset, size_t bin_size, int compression, size_t compressed_offset, size_t compressed_size);
+void writeBufferView(std::string& json, BufferView::Kind kind, StreamFormat::Filter filter, size_t count, size_t stride, size_t bin_offset, size_t bin_size, BufferView::Compression compression, size_t compressed_offset, size_t compressed_size);
 void writeImage(std::string& json, std::vector<BufferView>& views, const cgltf_image& image, const ImageInfo& info, size_t index, const char* input_path, const char* output_path, const Settings& settings);
 void writeTexture(std::string& json, const cgltf_texture& texture, cgltf_data* data, const Settings& settings);
 void writeMeshAttributes(std::string& json, std::vector<BufferView>& views, std::string& json_accessors, size_t& accr_offset, const Mesh& mesh, int target, const QuantizationPosition& qp, const QuantizationTexture& qt, const Settings& settings);

--- a/gltf/mesh.cpp
+++ b/gltf/mesh.cpp
@@ -212,7 +212,7 @@ void filterEmptyMeshes(std::vector<Mesh>& meshes)
 		if (mesh.streams[0].data.empty())
 			continue;
 
-		if (mesh.type == cgltf_primitive_type_triangles && mesh.indices.empty())
+		if (mesh.type != cgltf_primitive_type_points && mesh.indices.empty())
 			continue;
 
 		// the following code is roughly equivalent to meshes[write] = std::move(mesh)
@@ -349,6 +349,8 @@ static void reindexMesh(Mesh& mesh)
 
 static void filterTriangles(Mesh& mesh)
 {
+	assert(mesh.type == cgltf_primitive_type_triangles);
+
 	unsigned int* indices = &mesh.indices[0];
 	size_t total_indices = mesh.indices.size();
 
@@ -381,6 +383,8 @@ static Stream* getStream(Mesh& mesh, cgltf_attribute_type type, int index = 0)
 
 static void simplifyMesh(Mesh& mesh, float threshold, bool aggressive)
 {
+	assert(mesh.type == cgltf_primitive_type_triangles);
+
 	if (threshold >= 1)
 		return;
 
@@ -413,6 +417,8 @@ static void simplifyMesh(Mesh& mesh, float threshold, bool aggressive)
 
 static void optimizeMesh(Mesh& mesh, bool compressmore)
 {
+	assert(mesh.type == cgltf_primitive_type_triangles);
+
 	size_t vertex_count = mesh.streams[0].data.size();
 
 	if (compressmore)
@@ -544,6 +550,8 @@ static void filterBones(Mesh& mesh)
 
 static void simplifyPointMesh(Mesh& mesh, float threshold)
 {
+	assert(mesh.type == cgltf_primitive_type_points);
+
 	if (threshold >= 1)
 		return;
 
@@ -578,6 +586,8 @@ static void simplifyPointMesh(Mesh& mesh, float threshold)
 
 static void sortPointMesh(Mesh& mesh)
 {
+	assert(mesh.type == cgltf_primitive_type_points);
+
 	const Stream* positions = getStream(mesh, cgltf_attribute_type_position);
 	if (!positions)
 		return;
@@ -605,6 +615,9 @@ void processMesh(Mesh& mesh, const Settings& settings)
 		assert(mesh.indices.empty());
 		simplifyPointMesh(mesh, settings.simplify_threshold);
 		sortPointMesh(mesh);
+		break;
+
+	case cgltf_primitive_type_lines:
 		break;
 
 	case cgltf_primitive_type_triangles:

--- a/gltf/stream.cpp
+++ b/gltf/stream.cpp
@@ -719,14 +719,31 @@ void compressIndexStream(std::string& bin, const std::string& data, size_t count
 {
 	assert(stride == 2 || stride == 4);
 	assert(data.size() == count * stride);
+	assert(count % 3 == 0);
 
-	std::vector<unsigned char> compressed(meshopt_encodeIndexBufferBound(count, count * 3));
+	std::vector<unsigned char> compressed(meshopt_encodeIndexBufferBound(count, count));
 	size_t size = 0;
 
 	if (stride == 2)
 		size = meshopt_encodeIndexBuffer(&compressed[0], compressed.size(), reinterpret_cast<const uint16_t*>(data.c_str()), count);
 	else
 		size = meshopt_encodeIndexBuffer(&compressed[0], compressed.size(), reinterpret_cast<const uint32_t*>(data.c_str()), count);
+
+	bin.append(reinterpret_cast<const char*>(&compressed[0]), size);
+}
+
+void compressIndexSequence(std::string& bin, const std::string& data, size_t count, size_t stride)
+{
+	assert(stride == 2 || stride == 4);
+	assert(data.size() == count * stride);
+
+	std::vector<unsigned char> compressed(meshopt_encodeIndexSequenceBound(count, count));
+	size_t size = 0;
+
+	if (stride == 2)
+		size = meshopt_encodeIndexSequence(&compressed[0], compressed.size(), reinterpret_cast<const uint16_t*>(data.c_str()), count);
+	else
+		size = meshopt_encodeIndexSequence(&compressed[0], compressed.size(), reinterpret_cast<const uint32_t*>(data.c_str()), count);
 
 	bin.append(reinterpret_cast<const char*>(&compressed[0]), size);
 }


### PR DESCRIPTION
We now support points, triangles and lines in the backend; frontend
converts all other primitive types during parsing.

Index buffers that don't contain triangle lists are encoded using new sequence codec.

The only combination we don't support now is indexed points.