### PR TITLE
gltfpack: Fixed missing mime_type

### DIFF
--- a/gltf/write.cpp
+++ b/gltf/write.cpp
@@ -567,6 +567,10 @@ void writeImage(std::string& json, std::vector<BufferView>& views, const cgltf_i
 
 		mime_type = inferMimeType(image.uri);
 	}
+	else if (image.uri)
+	{
+		mime_type = image.mime_type ? image.mime_type : inferMimeType(image.uri);
+	}
 
 	if (!img_data.empty())
 	{


### PR DESCRIPTION
Encoding basisu/ktx2 textures fails if the mime_type is not setup.
basisu command fails if the input file has the extension `.raw` instead of `.png`.

Happened when converting glTF-JSON (with separate texture file) to glTF-JSON (with -tc option).

Tried to upload a sample file, but github throws errors :/




