### PR TITLE
Add 'config=scalar' build flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,10 @@ ifeq ($(config),trace)
 	CXXFLAGS+=-DTRACE=2
 endif
 
+ifeq ($(config),scalar)
+	CXXFLAGS+=-O3 -DNDEBUG -DMESHOPTIMIZER_NO_SIMD
+endif
+
 ifeq ($(config),release)
 	CXXFLAGS+=-O3 -DNDEBUG
 endif

--- a/src/vertexcodec.cpp
+++ b/src/vertexcodec.cpp
@@ -4,6 +4,9 @@
 #include <assert.h>
 #include <string.h>
 
+// Detect SIMD settings.
+#if !defined(MESHOPTIMIZER_NO_SIMD)
+
 #if defined(__ARM_NEON__) || defined(__ARM_NEON)
 #define SIMD_NEON
 #endif
@@ -39,6 +42,8 @@
 #define SIMD_WASM
 #define SIMD_TARGET __attribute__((target("unimplemented-simd128")))
 #endif
+
+#endif // !MESHOPTIMIZER_NO_SIMD
 
 #ifndef SIMD_TARGET
 #define SIMD_TARGET

--- a/src/vertexfilter.cpp
+++ b/src/vertexfilter.cpp
@@ -3,6 +3,9 @@
 
 #include <math.h>
 
+// Detect SIMD settings.
+#if !defined(MESHOPTIMIZER_NO_SIMD)
+
 #if defined(__SSE2__)
 #define SIMD_SSE
 #endif
@@ -15,6 +18,8 @@
 #if defined(__wasm_simd128__)
 #define SIMD_WASM
 #endif
+
+#endif // !MESHOPTIMIZER_NO_SIMD
 
 #ifdef SIMD_SSE
 #include <emmintrin.h>


### PR DESCRIPTION
This allows building codecbench with no SIMD code but still with optimizations enabled. @zeux, there is likely a clearer way to do this so feel free to ask for changes or commit to this branch! The rationale for this is to build an optimized, scalar version of codecbench.