### PR TITLE
Build Wasm versions of codecbench with debug symbols

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,10 +105,10 @@ codecbench: tools/codecbench.cpp $(LIBRARY)
 	$(CXX) $^ $(CXXFLAGS) $(LDFLAGS) -o $@
 
 codecbench.js codecbench.wasm: tools/codecbench.cpp ${LIBRARY_SOURCES}
-	emcc $^ -O3 -DNDEBUG -s TOTAL_MEMORY=268435456 -o $@
+	emcc $^ -O3 -g -DNDEBUG -s TOTAL_MEMORY=268435456 -o $@
 
 codecbench-simd.js codecbench-simd.wasm: tools/codecbench.cpp ${LIBRARY_SOURCES}
-	emcc $^ -O3 -DNDEBUG -s TOTAL_MEMORY=268435456 -msimd128 -o $@
+	emcc $^ -O3 -g -DNDEBUG -s TOTAL_MEMORY=268435456 -msimd128 -o $@
 
 $(LIBRARY): $(LIBRARY_OBJECTS)
 	ar rcs $@ $^


### PR DESCRIPTION
This will affect `codecbench`'s code size (probably not a high area of concern) but will make the generated Wasm much easier to analyze. Alternately, we could make the `WASM_FLAGS` variable more generic (which would involve some refactoring) and include the `-g` there.