### PR TITLE
CMake: make shared libs work again

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,11 @@ option(MESHOPT_BUILD_TOOLS "Build tools" OFF)
 option(MESHOPT_BUILD_SHARED_LIBS "Build shared libraries" OFF)
 set(MESHOPT_BUILD_TOOLS_GLFW_FOLDER_NAME "" CACHE STRING "Custom folder to look for GLFW")
 
+# add_library() needs BUILD_SHARED_LIBS set to decide between static and
+# shared. This also sets it back to OFF in case parent project has
+# BUILD_SHARED_LIBS but wants MESHOPT_BUILD_SHARED_LIBS to be OFF.
+set(BUILD_SHARED_LIBS ${MESHOPT_BUILD_SHARED_LIBS})
+
 set(SOURCES
     src/meshoptimizer.h
     src/allocator.cpp


### PR DESCRIPTION
Just a minor buildsystem thing. 

`BUILD_SHARED_LIBS` got renamed to `MESHOPT_BUILD_SHARED_LIBS` by @corporateshark in #91, but the unprefixed variant is what still needs to be set for `add_library()` to work as desired. Without this, enabling `MESHOPT_BUILD_SHARED_LIBS` still produced an `*.a` file and additionally made CMake complain about visibility presets being set for static libs.

By the way, I packaged the latest release for ArchLinux and will be maintaining it for the foreseeable future (https://aur.archlinux.org/packages/meshoptimizer/), would it make sense to mention it in the README?

Thank you!