### PR TITLE
Fix build on old Apple Clang versions

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,8 @@
+# See https://editorconfig.org/ for more info
+
+[*]
+charset = utf-8
+indent_style = tab
+indent_size = 4
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/src/vertexfilter.cpp
+++ b/src/vertexfilter.cpp
@@ -162,7 +162,9 @@ inline uint64_t rotateleft64(uint64_t v, int x)
 {
 #if defined(_MSC_VER) && !defined(__clang__)
 	return _rotl64(v, x);
-#elif defined(__clang__) && __clang_major__ >= 8
+// Apple's Clang 8 is actually vanilla Clang 3.9, there we need to look for
+// version 11 instead: https://en.wikipedia.org/wiki/Xcode#Toolchain_versions
+#elif defined(__clang__) && ((!defined(__apple_build_version__) && __clang_major__ >= 8) || __clang_major__ >= 11)
 	return __builtin_rotateleft64(v, x);
 #else
 	return (v << (x & 63)) | (v >> ((64 - x) & 63));


### PR DESCRIPTION
*(I have to admit my monster [build matrix](https://magnum.graphics/build-status/) contains a bunch of outdated systems.)*

On Apple platforms, `__clang_major__` follows a different versioning scheme and version 8 is actually vanilla Clang 3.9, which made the build fail due to `__builtin_rotateleft64` not being defined. Extended the condition to check for version 11 instead if the compiler is Apple Clang. [Version mapping table on Wikipedia](https://en.wikipedia.org/wiki/Xcode#Toolchain_versions) for reference.

Also added an [.editorconfig](https://editorconfig.org) so editors implicitly know to indent with tabs plus a bunch of other good defaults.