### PR TITLE
Use config=sanitize for gltfpack testing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,7 +74,7 @@ jobs:
         repository: KhronosGroup/glTF-Sample-Models
         path: glTF-Sample-Models
     - name: make
-      run: make -j2 config=debug gltfpack
+      run: make -j2 config=sanitize gltfpack
     - name: test
       run: find glTF-Sample-Models/2.0/ -name *.gltf | xargs ./gltfpack -cc -test
     - name: pack


### PR DESCRIPTION
This makes sure gltfpack and the algorithms it uses are sanitizer-clean
and that gltfpack doesn't leak memory.

This required fixing a few memory leaks in cgltf.