### PR TITLE
gltfpack: Implement URI decoding for image/buffer paths 

### DIFF
--- a/gltf/parsegltf.cpp
+++ b/gltf/parsegltf.cpp
@@ -298,6 +298,14 @@ static bool needsDummyBuffers(cgltf_data* data)
 		}
 	}
 
+	for (size_t i = 0; i < data->images_count; ++i)
+	{
+		cgltf_image* image = &data->images[i];
+
+		if (image->buffer_view && image->buffer_view->buffer->data == NULL)
+			return true;
+	}
+
 	return false;
 }
 

--- a/gltf/write.cpp
+++ b/gltf/write.cpp
@@ -540,6 +540,19 @@ static void writeEmbeddedImage(std::string& json, std::vector<BufferView>& views
 	append(json, "\"");
 }
 
+static std::string decodeUri(const char* uri)
+{
+	std::string result = uri;
+
+	if (!result.empty())
+	{
+		cgltf_decode_uri(&result[0]);
+		result.resize(strlen(result.c_str()));
+	}
+
+	return result;
+}
+
 void writeImage(std::string& json, std::vector<BufferView>& views, const cgltf_image& image, const ImageInfo& info, size_t index, const char* input_path, const char* output_path, const Settings& settings)
 {
 	std::string img_data;
@@ -559,7 +572,7 @@ void writeImage(std::string& json, std::vector<BufferView>& views, const cgltf_i
 	{
 		if (settings.texture_embed)
 		{
-			std::string full_path = getFullPath(image.uri, input_path);
+			std::string full_path = getFullPath(decodeUri(image.uri).c_str(), input_path);
 
 			if (!readFile(full_path.c_str(), img_data))
 			{
@@ -600,9 +613,9 @@ void writeImage(std::string& json, std::vector<BufferView>& views, const cgltf_i
 	{
 		if (settings.texture_basis)
 		{
-			std::string full_path = getFullPath(image.uri, input_path);
-			std::string basis_path = getFileName(image.uri) + (settings.texture_ktx2 ? ".ktx2" : ".basis");
-			std::string basis_full_path = getFullPath(basis_path.c_str(), output_path);
+			std::string full_path = getFullPath(decodeUri(image.uri).c_str(), input_path);
+			std::string basis_uri = getFileName(image.uri) + (settings.texture_ktx2 ? ".ktx2" : ".basis");
+			std::string basis_full_path = getFullPath(decodeUri(basis_uri.c_str()).c_str(), output_path);
 
 			if (readFile(full_path.c_str(), img_data))
 			{
@@ -616,7 +629,7 @@ void writeImage(std::string& json, std::vector<BufferView>& views, const cgltf_i
 					if (writeFile(basis_full_path.c_str(), encoded))
 					{
 						append(json, "\"uri\":\"");
-						append(json, basis_path);
+						append(json, basis_uri);
 						append(json, "\"");
 					}
 					else


### PR DESCRIPTION
We now decode URIs before trying to read buffer or image files, which fixes conversion for files with whitespaces in image paths.

Also improve needsDummyBuffers to make sure that buffers referenced by images have data loaded by cgltf_load_buffers.

Fixes #138.