### PR TITLE
gltfpack: Implement mesh instancing

### DIFF
--- a/demo/GLTFLoader.js
+++ b/demo/GLTFLoader.js
@@ -208,6 +208,10 @@ THREE.GLTFLoader = ( function () {
 							extensions[ extensionName ] = new GLTFMeshQuantizationExtension();
 							break;
 
+						case EXTENSIONS.EXT_MESH_GPU_INSTANCING:
+							extensions[ extensionName ] = new GLTFMeshGPUInstancingExtension( json );
+							break;
+
 						case EXTENSIONS.MESHOPT_COMPRESSION:
 							extensions[ extensionName ] = new GLTFMeshoptCompressionExtension( this.meshoptDecoder );
 							break;
@@ -291,6 +295,7 @@ THREE.GLTFLoader = ( function () {
 		KHR_TEXTURE_TRANSFORM: 'KHR_texture_transform',
 		KHR_MESH_QUANTIZATION: 'KHR_mesh_quantization',
 		MSFT_TEXTURE_DDS: 'MSFT_texture_dds',
+		EXT_MESH_GPU_INSTANCING: 'EXT_mesh_gpu_instancing',
 		MESHOPT_COMPRESSION: 'MESHOPT_compression',
 	};
 
@@ -927,6 +932,110 @@ THREE.GLTFLoader = ( function () {
 	}
 
 	/**
+	 * Instancing Extension
+	 *
+	 * Specification: https://github.com/KhronosGroup/glTF/pull/1691
+	 */
+	function GLTFMeshGPUInstancingExtension() {
+
+		this.name = EXTENSIONS.EXT_MESH_GPU_INSTANCING;
+
+	}
+
+	GLTFMeshGPUInstancingExtension.prototype.createInstancedMesh = function ( parser, nodeDef, node ) {
+
+		var extensionDef = nodeDef.extensions[ this.name ];
+		var pending = [];
+
+		// If present, extensionDef.mesh overrides nodeDef.mesh.
+		var meshIndex = extensionDef.mesh !== undefined ? extensionDef.mesh : nodeDef.mesh;
+		var meshPromise = parser.getDependency( 'mesh', meshIndex );
+
+		// Load buffers for instance TRS properties. All are optional.
+		var translationPromise = extensionDef.attributes.TRANSLATION !== undefined
+			? parser.getDependency( 'accessor', extensionDef.attributes.TRANSLATION )
+			: null;
+		var rotationPromise = extensionDef.attributes.ROTATION !== undefined
+			? parser.getDependency( 'accessor', extensionDef.attributes.ROTATION )
+			: null;
+		var scalePromise = extensionDef.attributes.SCALE !== undefined
+			? parser.getDependency( 'accessor', extensionDef.attributes.SCALE )
+			: null;
+
+		pending.push( meshPromise, translationPromise, rotationPromise, scalePromise );
+
+		// Load custom instance attributes.
+		var customAttributeNames = [];
+		for ( var attributeName in extensionDef.attributes ) {
+
+			if ( attributeName[ 0 ] === '_' ) {
+
+				customAttributeNames.push( attributeName.toLowerCase() );
+
+				pending.push( parser.getDependency( 'accessor', extensionDef.attributes[ attributeName ] ) );
+
+			}
+
+		}
+
+		return Promise.all( pending )
+			.then( function ( dependencies ) {
+
+				var mesh = dependencies[ 0 ];
+				var translation = dependencies[ 1 ];
+				var rotation = dependencies[ 2 ];
+				var scale = dependencies[ 3 ];
+
+				var template = translation || rotation || scale || dependencies[ 4 ];
+
+				// Geometry must be cloned here, before we modify it. Material will be cloned if
+				// necessary, when assignFinalMaterial() is called below.
+				var instancedMesh = new THREE.InstancedMesh( mesh.geometry.clone(), mesh.material, template.count );
+				var matrix = new THREE.Matrix4();
+
+				var t = new THREE.Vector3( 0, 0, 0 );
+				var r = new THREE.Quaternion( 0, 0, 0, 1 );
+				var s = new THREE.Vector3( 1, 1, 1 );
+
+				// Set instance transforms.
+				for ( var i = 0; i < template.count; i ++ ) {
+
+					if ( translation ) t.fromBufferAttribute( translation, i );
+					if ( rotation ) quaternionFromBufferAttribute( r, rotation, i );
+					if ( scale ) s.fromBufferAttribute( scale, i );
+
+					instancedMesh.setMatrixAt( i, matrix.compose( t, r, s ) );
+
+				}
+
+				// Set custom instance attributes.
+				for ( var i = 0; i < customAttributeNames.length; i ++ ) {
+
+					var attributeSource = dependencies[ 4 + i ];
+
+					instancedMesh.geometry.setAttribute( customAttributeNames[ i ], new THREE.InstancedBufferAttribute(
+
+						attributeSource.array,
+						attributeSource.itemSize,
+						attributeSource.normalized
+
+					) );
+
+				}
+
+				// Copy mesh properties first, then node properties. These may be the same object.
+				THREE.Object3D.prototype.copy.call( instancedMesh, mesh );
+				THREE.Object3D.prototype.copy.call( instancedMesh, node );
+
+				parser.assignFinalMaterial( instancedMesh );
+
+				return instancedMesh;
+
+			} );
+
+	}
+
+	/**
 	 * meshoptimizer Compression Extension
 	 */
 	function GLTFMeshoptCompressionExtension( meshoptDecoder ) {
@@ -1381,6 +1490,19 @@ THREE.GLTFLoader = ( function () {
 		}
 
 		return attributesKey;
+
+	}
+
+	function quaternionFromBufferAttribute( quaternion, attribute, index ) {
+
+		return quaternion.set(
+
+			attribute.getX( index ),
+			attribute.getY( index ),
+			attribute.getZ( index ),
+			attribute.getW( index )
+
+		);
 
 	}
 
@@ -2027,6 +2149,7 @@ THREE.GLTFLoader = ( function () {
 		var useVertexColors = geometry.attributes.color !== undefined;
 		var useFlatShading = geometry.attributes.normal === undefined;
 		var useSkinning = mesh.isSkinnedMesh === true;
+		var useInstancing = mesh.isInstancedMesh === true;
 		var useMorphTargets = Object.keys( geometry.morphAttributes ).length > 0;
 		var useMorphNormals = useMorphTargets && geometry.morphAttributes.normal !== undefined;
 
@@ -2071,12 +2194,13 @@ THREE.GLTFLoader = ( function () {
 		}
 
 		// Clone the material if it will be modified
-		if ( useVertexTangents || useVertexColors || useFlatShading || useSkinning || useMorphTargets ) {
+		if ( useVertexTangents || useVertexColors || useFlatShading || useSkinning || useInstancing || useMorphTargets ) {
 
 			var cacheKey = 'ClonedMaterial:' + material.uuid + ':';
 
 			if ( material.isGLTFSpecularGlossinessMaterial ) cacheKey += 'specular-glossiness:';
 			if ( useSkinning ) cacheKey += 'skinning:';
+			if ( useInstancing ) cacheKey += 'instancing:';
 			if ( useVertexTangents ) cacheKey += 'vertex-tangents:';
 			if ( useVertexColors ) cacheKey += 'vertex-colors:';
 			if ( useFlatShading ) cacheKey += 'flat-shading:';
@@ -3138,6 +3262,20 @@ THREE.GLTFLoader = ( function () {
 					node.scale.fromArray( nodeDef.scale );
 
 				}
+
+			}
+
+			// Apply instancing last, as it requires asynchronous resources.
+			if ( nodeDef.extensions && nodeDef.extensions[ EXTENSIONS.EXT_MESH_GPU_INSTANCING ] !== undefined ) {
+
+				if ( ! node.isMesh && node.children.length > 0 ) {
+
+					console.warn( 'THREE.GLTFLoader: Multi-primitive instanced meshes not yet supported.' );
+					return node;
+
+				}
+
+				return extensions[ EXTENSIONS.EXT_MESH_GPU_INSTANCING ].createInstancedMesh( parser, nodeDef, node );
 
 			}
 

--- a/demo/GLTFLoader.js
+++ b/demo/GLTFLoader.js
@@ -990,7 +990,9 @@ THREE.GLTFLoader = ( function () {
 
 				// Geometry must be cloned here, before we modify it. Material will be cloned if
 				// necessary, when assignFinalMaterial() is called below.
-				var instancedMesh = new THREE.InstancedMesh( mesh.geometry.clone(), mesh.material, template.count );
+				var instancedGeometry = customAttributeNames.length > 0 ? mesh.geometry.clone() : mesh.geometry;
+
+				var instancedMesh = new THREE.InstancedMesh( instancedGeometry, mesh.material, template.count );
 				var matrix = new THREE.Matrix4();
 
 				var t = new THREE.Vector3( 0, 0, 0 );
@@ -1013,7 +1015,7 @@ THREE.GLTFLoader = ( function () {
 
 					var attributeSource = dependencies[ 4 + i ];
 
-					instancedMesh.geometry.setAttribute( customAttributeNames[ i ], new THREE.InstancedBufferAttribute(
+					instancedGeometry.setAttribute( customAttributeNames[ i ], new THREE.InstancedBufferAttribute(
 
 						attributeSource.array,
 						attributeSource.itemSize,
@@ -1495,12 +1497,14 @@ THREE.GLTFLoader = ( function () {
 
 	function quaternionFromBufferAttribute( quaternion, attribute, index ) {
 
+		var scale = attribute.normalized ? 1 / 32767 : 1;
+
 		return quaternion.set(
 
-			attribute.getX( index ),
-			attribute.getY( index ),
-			attribute.getZ( index ),
-			attribute.getW( index )
+			attribute.getX( index ) * scale,
+			attribute.getY( index ) * scale,
+			attribute.getZ( index ) * scale,
+			attribute.getW( index ) * scale
 
 		);
 

--- a/gltf/gltfpack.cpp
+++ b/gltf/gltfpack.cpp
@@ -796,6 +796,14 @@ int main(int argc, char** argv)
 		{
 			settings.keep_extras = true;
 		}
+		else if (strcmp(arg, "-mm") == 0)
+		{
+			settings.mesh_merge = true;
+		}
+		else if (strcmp(arg, "-mi") == 0)
+		{
+			settings.mesh_instancing = true;
+		}
 		else if (strcmp(arg, "-si") == 0 && i + 1 < argc && isdigit(argv[i + 1][0]))
 		{
 			settings.simplify_threshold = float(atof(argv[++i]));
@@ -937,6 +945,8 @@ int main(int argc, char** argv)
 			fprintf(stderr, "\nScene:\n");
 			fprintf(stderr, "\t-kn: keep named nodes and meshes attached to named nodes so that named nodes can be transformed externally\n");
 			fprintf(stderr, "\t-ke: keep extras data\n");
+			fprintf(stderr, "\t-mm: merge instances of the same mesh together when possible\n");
+			fprintf(stderr, "\t-mi: use EXT_mesh_gpu_instancing when serializing multiple mesh instances\n");
 			fprintf(stderr, "\nMiscellaneous:\n");
 			fprintf(stderr, "\t-cf: produce compressed gltf/glb files with fallback for loaders that don't support compression\n");
 			fprintf(stderr, "\t-noq: disable quantization; produces much larger glTF files with no extensions\n");

--- a/gltf/gltfpack.cpp
+++ b/gltf/gltfpack.cpp
@@ -75,6 +75,7 @@ static void printMeshStats(const std::vector<Mesh>& meshes, const char* name)
 {
 	size_t triangles = 0;
 	size_t vertices = 0;
+	size_t instanced = 0;
 
 	for (size_t i = 0; i < meshes.size(); ++i)
 	{
@@ -82,9 +83,11 @@ static void printMeshStats(const std::vector<Mesh>& meshes, const char* name)
 
 		triangles += mesh.indices.size() / 3;
 		vertices += mesh.streams.empty() ? 0 : mesh.streams[0].data.size();
+
+		instanced += mesh.indices.size() / 3 * std::max(size_t(1), mesh.nodes.size());
 	}
 
-	printf("%s: %d triangles, %d vertices\n", name, int(triangles), int(vertices));
+	printf("%s: %d triangles (%lld instanced), %d vertices\n", name, int(triangles), (long long)instanced, int(vertices));
 }
 
 static void printSceneStats(const std::vector<BufferView>& views, const std::vector<Mesh>& meshes, size_t node_offset, size_t mesh_offset, size_t material_offset, size_t json_size, size_t bin_size)

--- a/gltf/gltfpack.h
+++ b/gltf/gltfpack.h
@@ -253,6 +253,7 @@ std::string basisToKtx(const std::string& data, bool srgb, bool uastc);
 void markAnimated(cgltf_data* data, std::vector<NodeInfo>& nodes, const std::vector<Animation>& animations);
 void markNeededNodes(cgltf_data* data, std::vector<NodeInfo>& nodes, const std::vector<Mesh>& meshes, const std::vector<Animation>& animations, const Settings& settings);
 void remapNodes(cgltf_data* data, std::vector<NodeInfo>& nodes, size_t& node_offset);
+void decomposeTransform(float translation[3], float rotation[4], float scale[3], const float* transform);
 
 QuantizationPosition prepareQuantizationPosition(const std::vector<Mesh>& meshes, const Settings& settings);
 void prepareQuantizationTexture(cgltf_data* data, std::vector<QuantizationTexture>& result, const std::vector<Mesh>& meshes, const Settings& settings);
@@ -286,7 +287,9 @@ void writeTexture(std::string& json, const cgltf_texture& texture, cgltf_data* d
 void writeMeshAttributes(std::string& json, std::vector<BufferView>& views, std::string& json_accessors, size_t& accr_offset, const Mesh& mesh, int target, const QuantizationPosition& qp, const QuantizationTexture& qt, const Settings& settings);
 size_t writeMeshIndices(std::vector<BufferView>& views, std::string& json_accessors, size_t& accr_offset, const Mesh& mesh, const Settings& settings);
 size_t writeJointBindMatrices(std::vector<BufferView>& views, std::string& json_accessors, size_t& accr_offset, const cgltf_skin& skin, const QuantizationPosition& qp, const Settings& settings);
+size_t writeInstances(std::vector<BufferView>& views, std::string& json_accessors, size_t& accr_offset, const std::vector<Transform>& transforms, const QuantizationPosition& qp, const Settings& settings);
 void writeMeshNode(std::string& json, size_t mesh_offset, cgltf_node* node, cgltf_skin* skin, cgltf_data* data, const QuantizationPosition* qp);
+void writeMeshNodeInstanced(std::string& json, size_t mesh_offset, size_t accr_offset);
 void writeSkin(std::string& json, const cgltf_skin& skin, size_t matrix_accr, const std::vector<NodeInfo>& nodes, cgltf_data* data);
 void writeNode(std::string& json, const cgltf_node& node, const std::vector<NodeInfo>& nodes, cgltf_data* data);
 void writeAnimation(std::string& json, std::vector<BufferView>& views, std::string& json_accessors, size_t& accr_offset, const Animation& animation, size_t i, cgltf_data* data, const std::vector<NodeInfo>& nodes, const Settings& settings);

--- a/gltf/gltfpack.h
+++ b/gltf/gltfpack.h
@@ -32,9 +32,15 @@ struct Stream
 	std::vector<Attr> data;
 };
 
+struct Transform
+{
+	float data[16];
+};
+
 struct Mesh
 {
 	std::vector<cgltf_node*> nodes;
+	std::vector<Transform> instances;
 
 	cgltf_material* material;
 	cgltf_skin* skin;
@@ -184,6 +190,7 @@ struct BufferView
 		Kind_Skin,
 		Kind_Time,
 		Kind_Keyframe,
+		Kind_Instance,
 		Kind_Image,
 		Kind_Count
 	};

--- a/gltf/gltfpack.h
+++ b/gltf/gltfpack.h
@@ -90,6 +90,9 @@ struct Settings
 	bool keep_named;
 	bool keep_extras;
 
+	bool mesh_merge;
+	bool mesh_instancing;
+
 	float simplify_threshold;
 	bool simplify_aggressive;
 

--- a/gltf/gltfpack.h
+++ b/gltf/gltfpack.h
@@ -227,9 +227,9 @@ cgltf_data* parseGltf(const char* path, std::vector<Mesh>& meshes, std::vector<A
 void processAnimation(Animation& animation, const Settings& settings);
 void processMesh(Mesh& mesh, const Settings& settings);
 
-void transformMesh(Mesh& mesh, const cgltf_node* node);
 bool compareMeshTargets(const Mesh& lhs, const Mesh& rhs);
 bool compareMeshNodes(const Mesh& lhs, const Mesh& rhs);
+void mergeMeshInstances(Mesh& mesh);
 void mergeMeshes(std::vector<Mesh>& meshes, const Settings& settings);
 void filterEmptyMeshes(std::vector<Mesh>& meshes);
 

--- a/gltf/gltfpack.h
+++ b/gltf/gltfpack.h
@@ -34,7 +34,7 @@ struct Stream
 
 struct Mesh
 {
-	cgltf_node* node;
+	std::vector<cgltf_node*> nodes;
 
 	cgltf_material* material;
 	cgltf_skin* skin;
@@ -226,6 +226,7 @@ void processMesh(Mesh& mesh, const Settings& settings);
 
 void transformMesh(Mesh& mesh, const cgltf_node* node);
 bool compareMeshTargets(const Mesh& lhs, const Mesh& rhs);
+bool compareMeshNodes(const Mesh& lhs, const Mesh& rhs);
 void mergeMeshes(std::vector<Mesh>& meshes, const Settings& settings);
 void filterEmptyMeshes(std::vector<Mesh>& meshes);
 
@@ -275,7 +276,7 @@ void writeTexture(std::string& json, const cgltf_texture& texture, cgltf_data* d
 void writeMeshAttributes(std::string& json, std::vector<BufferView>& views, std::string& json_accessors, size_t& accr_offset, const Mesh& mesh, int target, const QuantizationPosition& qp, const QuantizationTexture& qt, const Settings& settings);
 size_t writeMeshIndices(std::vector<BufferView>& views, std::string& json_accessors, size_t& accr_offset, const Mesh& mesh, const Settings& settings);
 size_t writeJointBindMatrices(std::vector<BufferView>& views, std::string& json_accessors, size_t& accr_offset, const cgltf_skin& skin, const QuantizationPosition& qp, const Settings& settings);
-void writeMeshNode(std::string& json, size_t mesh_offset, const Mesh& mesh, cgltf_data* data, const QuantizationPosition* qp);
+void writeMeshNode(std::string& json, size_t mesh_offset, cgltf_node* node, cgltf_skin* skin, cgltf_data* data, const QuantizationPosition* qp);
 void writeSkin(std::string& json, const cgltf_skin& skin, size_t matrix_accr, const std::vector<NodeInfo>& nodes, cgltf_data* data);
 void writeNode(std::string& json, const cgltf_node& node, const std::vector<NodeInfo>& nodes, cgltf_data* data);
 void writeAnimation(std::string& json, std::vector<BufferView>& views, std::string& json_accessors, size_t& accr_offset, const Animation& animation, size_t i, cgltf_data* data, const std::vector<NodeInfo>& nodes, const Settings& settings);

--- a/gltf/mesh.cpp
+++ b/gltf/mesh.cpp
@@ -39,18 +39,18 @@ static float inverseTranspose(float* result, const float* transform)
 	return det;
 }
 
-static void transformPosition(float* ptr, const float* transform)
+static void transformPosition(float* res, const float* ptr, const float* transform)
 {
 	float x = ptr[0] * transform[0] + ptr[1] * transform[4] + ptr[2] * transform[8] + transform[12];
 	float y = ptr[0] * transform[1] + ptr[1] * transform[5] + ptr[2] * transform[9] + transform[13];
 	float z = ptr[0] * transform[2] + ptr[1] * transform[6] + ptr[2] * transform[10] + transform[14];
 
-	ptr[0] = x;
-	ptr[1] = y;
-	ptr[2] = z;
+	res[0] = x;
+	res[1] = y;
+	res[2] = z;
 }
 
-static void transformNormal(float* ptr, const float* transform)
+static void transformNormal(float* res, const float* ptr, const float* transform)
 {
 	float x = ptr[0] * transform[0] + ptr[1] * transform[4] + ptr[2] * transform[8];
 	float y = ptr[0] * transform[1] + ptr[1] * transform[5] + ptr[2] * transform[9];
@@ -59,13 +59,17 @@ static void transformNormal(float* ptr, const float* transform)
 	float l = sqrtf(x * x + y * y + z * z);
 	float s = (l == 0.f) ? 0.f : 1 / l;
 
-	ptr[0] = x * s;
-	ptr[1] = y * s;
-	ptr[2] = z * s;
+	res[0] = x * s;
+	res[1] = y * s;
+	res[2] = z * s;
 }
 
-void transformMesh(Mesh& mesh, const cgltf_node* node)
+// assumes mesh & target are structurally identical
+static void transformMesh(Mesh& target, const Mesh& mesh, const cgltf_node* node)
 {
+	assert(target.streams.size() == mesh.streams.size());
+	assert(target.indices.size() == mesh.indices.size());
+
 	float transform[16];
 	cgltf_node_transform_world(node, transform);
 
@@ -74,30 +78,34 @@ void transformMesh(Mesh& mesh, const cgltf_node* node)
 
 	for (size_t si = 0; si < mesh.streams.size(); ++si)
 	{
-		Stream& stream = mesh.streams[si];
+		const Stream& source = mesh.streams[si];
+		Stream& stream = target.streams[si];
+
+		assert(source.type == stream.type);
+		assert(source.data.size() == stream.data.size());
 
 		if (stream.type == cgltf_attribute_type_position)
 		{
 			for (size_t i = 0; i < stream.data.size(); ++i)
-				transformPosition(stream.data[i].f, transform);
+				transformPosition(stream.data[i].f, source.data[i].f, transform);
 		}
 		else if (stream.type == cgltf_attribute_type_normal)
 		{
 			for (size_t i = 0; i < stream.data.size(); ++i)
-				transformNormal(stream.data[i].f, transforminvt);
+				transformNormal(stream.data[i].f, source.data[i].f, transforminvt);
 		}
 		else if (stream.type == cgltf_attribute_type_tangent)
 		{
 			for (size_t i = 0; i < stream.data.size(); ++i)
-				transformNormal(stream.data[i].f, transform);
+				transformNormal(stream.data[i].f, source.data[i].f, transform);
 		}
 	}
 
 	if (det < 0 && mesh.type == cgltf_primitive_type_triangles)
 	{
 		// negative scale means we need to flip face winding
-		for (size_t i = 0; i < mesh.indices.size(); i += 3)
-			std::swap(mesh.indices[i + 0], mesh.indices[i + 1]);
+		for (size_t i = 0; i < target.indices.size(); i += 3)
+			std::swap(target.indices[i + 0], target.indices[i + 1]);
 	}
 }
 
@@ -213,6 +221,40 @@ static void mergeMeshes(Mesh& target, const Mesh& mesh)
 
 	for (size_t i = 0; i < index_count; ++i)
 		target.indices[index_offset + i] = unsigned(vertex_offset + mesh.indices[i]);
+}
+
+void mergeMeshInstances(Mesh& mesh)
+{
+	if (mesh.nodes.empty())
+		return;
+
+	// fast-path: for single instance meshes we transform in-place
+	if (mesh.nodes.size() == 1)
+	{
+		transformMesh(mesh, mesh, mesh.nodes[0]);
+		mesh.nodes.clear();
+		return;
+	}
+
+	Mesh base = mesh;
+	Mesh transformed = base;
+
+	for (size_t i = 0; i < mesh.streams.size(); ++i)
+	{
+		mesh.streams[i].data.clear();
+		mesh.streams[i].data.reserve(base.streams[i].data.size() * mesh.nodes.size());
+	}
+
+	mesh.indices.clear();
+	mesh.indices.reserve(base.indices.size() * mesh.nodes.size());
+
+	for (size_t i = 0; i < mesh.nodes.size(); ++i)
+	{
+		transformMesh(transformed, base, mesh.nodes[i]);
+		mergeMeshes(mesh, transformed);
+	}
+
+	mesh.nodes.clear();
 }
 
 void mergeMeshes(std::vector<Mesh>& meshes, const Settings& settings)

--- a/gltf/mesh.cpp
+++ b/gltf/mesh.cpp
@@ -180,6 +180,9 @@ static bool canMergeMeshes(const Mesh& lhs, const Mesh& rhs, const Settings& set
 		if (!canMergeMeshNodes(lhs.nodes[i], rhs.nodes[i], settings))
 			return false;
 
+	if (lhs.instances.size() || rhs.instances.size())
+		return false;
+
 	if (lhs.material != rhs.material)
 		return false;
 

--- a/gltf/mesh.cpp
+++ b/gltf/mesh.cpp
@@ -302,6 +302,7 @@ void mergeMeshes(std::vector<Mesh>& meshes, const Settings& settings)
 				mesh.streams.clear();
 				mesh.indices.clear();
 				mesh.nodes.clear();
+				mesh.instances.clear();
 			}
 		}
 

--- a/gltf/node.cpp
+++ b/gltf/node.cpp
@@ -142,9 +142,9 @@ void decomposeTransform(float translation[3], float rotation[4], float scale[3],
 	translation[2] = m[3][2];
 
 	float det =
-	m[0][0] * (m[1][1] * m[2][2] - m[2][1] * m[1][2]) -
-	m[0][1] * (m[1][0] * m[2][2] - m[1][2] * m[2][0]) +
-	m[0][2] * (m[1][0] * m[2][1] - m[1][1] * m[2][0]);
+	    m[0][0] * (m[1][1] * m[2][2] - m[2][1] * m[1][2]) -
+	    m[0][1] * (m[1][0] * m[2][2] - m[1][2] * m[2][0]) +
+	    m[0][2] * (m[1][0] * m[2][1] - m[1][1] * m[2][0]);
 
 	float sign = (det < 0.f) ? -1.f : 1.f;
 
@@ -156,44 +156,44 @@ void decomposeTransform(float translation[3], float rotation[4], float scale[3],
 	float rsy = (scale[1] == 0.f) ? 0.f : 1.f / scale[1];
 	float rsz = (scale[2] == 0.f) ? 0.f : 1.f / scale[2];
 
-	float q00 = m[0][0] * rsx, q10 = m[1][0] * rsx, q20 = m[2][0] * rsx;
-	float q01 = m[0][1] * rsy, q11 = m[1][1] * rsy, q21 = m[2][1] * rsy;
-	float q02 = m[0][2] * rsz, q12 = m[1][2] * rsz, q22 = m[2][2] * rsz;
+	float r00 = m[0][0] * rsx, r10 = m[1][0] * rsx, r20 = m[2][0] * rsx;
+	float r01 = m[0][1] * rsy, r11 = m[1][1] * rsy, r21 = m[2][1] * rsy;
+	float r02 = m[0][2] * rsz, r12 = m[1][2] * rsz, r22 = m[2][2] * rsz;
 
 	float qt = 1.f;
 
-	if (q22 < 0)
+	if (r22 < 0)
 	{
-		if (q00 > q11)
+		if (r00 > r11)
 		{
-			rotation[0] = qt = 1.f + q00 - q11 - q22;
-			rotation[1] = q01+q10;
-			rotation[2] = q20+q02;
-			rotation[3] = q12-q21;
+			rotation[0] = qt = 1.f + r00 - r11 - r22;
+			rotation[1] = r01 + r10;
+			rotation[2] = r20 + r02;
+			rotation[3] = r12 - r21;
 		}
 		else
 		{
-			rotation[0] = q01+q10;
-			rotation[1] = qt = 1.f - q00 + q11 - q22;
-			rotation[2] = q12+q21;
-			rotation[3] = q20-q02;
+			rotation[0] = r01 + r10;
+			rotation[1] = qt = 1.f - r00 + r11 - r22;
+			rotation[2] = r12 + r21;
+			rotation[3] = r20 - r02;
 		}
 	}
 	else
 	{
-		if (q00 < -q11)
+		if (r00 < -r11)
 		{
-			rotation[0] = q20+q02;
-			rotation[1] = q12+q21;
-			rotation[2] = qt = 1.f - q00 - q11 + q22;
-			rotation[3] = q01-q10;
+			rotation[0] = r20 + r02;
+			rotation[1] = r12 + r21;
+			rotation[2] = qt = 1.f - r00 - r11 + r22;
+			rotation[3] = r01 - r10;
 		}
 		else
 		{
-			rotation[0] = q12-q21;
-			rotation[1] = q20-q02;
-			rotation[2] = q01-q10;
-			rotation[3] = qt = 1.f + q00 + q11 + q22;
+			rotation[0] = r12 - r21;
+			rotation[1] = r20 - r02;
+			rotation[2] = r01 - r10;
+			rotation[3] = qt = 1.f + r00 + r11 + r22;
 		}
 	}
 

--- a/gltf/node.cpp
+++ b/gltf/node.cpp
@@ -1,6 +1,9 @@
 // This file is part of gltfpack; see gltfpack.h for version/license details
 #include "gltfpack.h"
 
+#include <math.h>
+#include <string.h>
+
 void markAnimated(cgltf_data* data, std::vector<NodeInfo>& nodes, const std::vector<Animation>& animations)
 {
 	for (size_t i = 0; i < animations.size(); ++i)
@@ -127,4 +130,77 @@ void remapNodes(cgltf_data* data, std::vector<NodeInfo>& nodes, size_t& node_off
 			node_offset++;
 		}
 	}
+}
+
+void decomposeTransform(float translation[3], float rotation[4], float scale[3], const float* transform)
+{
+	float m[4][4] = {};
+	memcpy(m, transform, 16 * sizeof(float));
+
+	translation[0] = m[3][0];
+	translation[1] = m[3][1];
+	translation[2] = m[3][2];
+
+	float det =
+	m[0][0] * (m[1][1] * m[2][2] - m[2][1] * m[1][2]) -
+	m[0][1] * (m[1][0] * m[2][2] - m[1][2] * m[2][0]) +
+	m[0][2] * (m[1][0] * m[2][1] - m[1][1] * m[2][0]);
+
+	float sign = (det < 0.f) ? -1.f : 1.f;
+
+	scale[0] = sqrtf(m[0][0] * m[0][0] + m[1][0] * m[1][0] + m[2][0] * m[2][0]) * sign;
+	scale[1] = sqrtf(m[0][1] * m[0][1] + m[1][1] * m[1][1] + m[2][1] * m[2][1]) * sign;
+	scale[2] = sqrtf(m[0][2] * m[0][2] + m[1][2] * m[1][2] + m[2][2] * m[2][2]) * sign;
+
+	float rsx = (scale[0] == 0.f) ? 0.f : 1.f / scale[0];
+	float rsy = (scale[1] == 0.f) ? 0.f : 1.f / scale[1];
+	float rsz = (scale[2] == 0.f) ? 0.f : 1.f / scale[2];
+
+	float q00 = m[0][0] * rsx, q10 = m[1][0] * rsx, q20 = m[2][0] * rsx;
+	float q01 = m[0][1] * rsy, q11 = m[1][1] * rsy, q21 = m[2][1] * rsy;
+	float q02 = m[0][2] * rsz, q12 = m[1][2] * rsz, q22 = m[2][2] * rsz;
+
+	float qt = 1.f;
+
+	if (q22 < 0)
+	{
+		if (q00 > q11)
+		{
+			rotation[0] = qt = 1.f + q00 - q11 - q22;
+			rotation[1] = q01+q10;
+			rotation[2] = q20+q02;
+			rotation[3] = q12-q21;
+		}
+		else
+		{
+			rotation[0] = q01+q10;
+			rotation[1] = qt = 1.f - q00 + q11 - q22;
+			rotation[2] = q12+q21;
+			rotation[3] = q20-q02;
+		}
+	}
+	else
+	{
+		if (q00 < -q11)
+		{
+			rotation[0] = q20+q02;
+			rotation[1] = q12+q21;
+			rotation[2] = qt = 1.f - q00 - q11 + q22;
+			rotation[3] = q01-q10;
+		}
+		else
+		{
+			rotation[0] = q12-q21;
+			rotation[1] = q20-q02;
+			rotation[2] = q01-q10;
+			rotation[3] = qt = 1.f + q00 + q11 + q22;
+		}
+	}
+
+	float qs = 0.5f / sqrtf(qt);
+
+	rotation[0] *= qs;
+	rotation[1] *= qs;
+	rotation[2] *= qs;
+	rotation[3] *= qs;
 }

--- a/gltf/node.cpp
+++ b/gltf/node.cpp
@@ -69,9 +69,9 @@ void markNeededNodes(cgltf_data* data, std::vector<NodeInfo>& nodes, const std::
 	{
 		const Mesh& mesh = meshes[i];
 
-		if (mesh.node)
+		for (size_t j = 0; j < mesh.nodes.size(); ++j)
 		{
-			NodeInfo& ni = nodes[mesh.node - data->nodes];
+			NodeInfo& ni = nodes[mesh.nodes[j] - data->nodes];
 
 			ni.keep = true;
 		}

--- a/gltf/parsegltf.cpp
+++ b/gltf/parsegltf.cpp
@@ -149,7 +149,7 @@ static void parseMeshesGltf(cgltf_data* data, std::vector<Mesh>& meshes)
 
 			Mesh result = {};
 
-			result.node = &node;
+			result.nodes.push_back(&node);
 
 			result.material = primitive.material;
 			result.skin = node.skin;

--- a/gltf/write.cpp
+++ b/gltf/write.cpp
@@ -839,12 +839,16 @@ size_t writeInstances(std::vector<BufferView>& views, std::string& json_accessor
 
 		if (settings.quantize)
 		{
-			position[i].f[0] += qp.offset[0];
-			position[i].f[1] += qp.offset[1];
-			position[i].f[2] += qp.offset[2];
+			const float* transform = transforms[i].data;
 
 			float node_scale = qp.scale / float((1 << qp.bits) - 1);
 
+			// pos_offset has to be applied first, thus it results in an offset rotated by the instance matrix
+			position[i].f[0] += qp.offset[0] * transform[0] + qp.offset[1] * transform[4] + qp.offset[2] * transform[8];
+			position[i].f[1] += qp.offset[0] * transform[1] + qp.offset[1] * transform[5] + qp.offset[2] * transform[9];
+			position[i].f[2] += qp.offset[0] * transform[2] + qp.offset[1] * transform[6] + qp.offset[2] * transform[10];
+
+			// node_scale will be applied before the rotation/scale from transform
 			scale[i].f[0] *= node_scale;
 			scale[i].f[1] *= node_scale;
 			scale[i].f[2] *= node_scale;

--- a/gltf/write.cpp
+++ b/gltf/write.cpp
@@ -811,6 +811,55 @@ size_t writeJointBindMatrices(std::vector<BufferView>& views, std::string& json_
 	return matrix_accr;
 }
 
+static void writeInstanceData(std::vector<BufferView>& views, std::string& json_accessors, cgltf_animation_path_type type, const std::vector<Attr>& data, const Settings& settings)
+{
+	BufferView::Compression compression = settings.compress ? BufferView::Compression_Attribute : BufferView::Compression_None;
+
+	std::string scratch;
+	StreamFormat format = writeKeyframeStream(scratch, type, data, settings);
+
+	size_t view = getBufferView(views, BufferView::Kind_Instance, format.filter, compression, format.stride, type);
+	size_t offset = views[view].data.size();
+	views[view].data += scratch;
+
+	comma(json_accessors);
+	writeAccessor(json_accessors, view, offset, format.type, format.component_type, format.normalized, data.size());
+}
+
+size_t writeInstances(std::vector<BufferView>& views, std::string& json_accessors, size_t& accr_offset, const std::vector<Transform>& transforms, const QuantizationPosition& qp, const Settings& settings)
+{
+	std::vector<Attr> position, rotation, scale;
+	position.resize(transforms.size());
+	rotation.resize(transforms.size());
+	scale.resize(transforms.size());
+
+	for (size_t i = 0; i < transforms.size(); ++i)
+	{
+		decomposeTransform(position[i].f, rotation[i].f, scale[i].f, transforms[i].data);
+
+		if (settings.quantize)
+		{
+			position[i].f[0] += qp.offset[0];
+			position[i].f[1] += qp.offset[1];
+			position[i].f[2] += qp.offset[2];
+
+			float node_scale = qp.scale / float((1 << qp.bits) - 1);
+
+			scale[i].f[0] *= node_scale;
+			scale[i].f[1] *= node_scale;
+			scale[i].f[2] *= node_scale;
+		}
+	}
+
+	writeInstanceData(views, json_accessors, cgltf_animation_path_type_translation, position, settings);
+	writeInstanceData(views, json_accessors, cgltf_animation_path_type_rotation, rotation, settings);
+	writeInstanceData(views, json_accessors, cgltf_animation_path_type_scale, scale, settings);
+
+	size_t result = accr_offset;
+	accr_offset += 3;
+	return result;
+}
+
 void writeMeshNode(std::string& json, size_t mesh_offset, cgltf_node* node, cgltf_skin* skin, cgltf_data* data, const QuantizationPosition* qp)
 {
 	comma(json);
@@ -850,6 +899,29 @@ void writeMeshNode(std::string& json, size_t mesh_offset, cgltf_node* node, cglt
 		}
 		append(json, "]");
 	}
+	append(json, "}");
+}
+
+void writeMeshNodeInstanced(std::string& json, size_t mesh_offset, size_t accr_offset)
+{
+	comma(json);
+	append(json, "{\"mesh\":");
+	append(json, mesh_offset);
+	append(json, ",\"extensions\":{\"EXT_mesh_gpu_instancing\":{\"attributes\":{");
+
+	comma(json);
+	append(json, "\"TRANSLATION\":");
+	append(json, accr_offset + 0);
+
+	comma(json);
+	append(json, "\"ROTATION\":");
+	append(json, accr_offset + 1);
+
+	comma(json);
+	append(json, "\"SCALE\":");
+	append(json, accr_offset + 2);
+
+	append(json, "}}}");
 	append(json, "}");
 }
 

--- a/gltf/write.cpp
+++ b/gltf/write.cpp
@@ -811,16 +811,16 @@ size_t writeJointBindMatrices(std::vector<BufferView>& views, std::string& json_
 	return matrix_accr;
 }
 
-void writeMeshNode(std::string& json, size_t mesh_offset, const Mesh& mesh, cgltf_data* data, const QuantizationPosition* qp)
+void writeMeshNode(std::string& json, size_t mesh_offset, cgltf_node* node, cgltf_skin* skin, cgltf_data* data, const QuantizationPosition* qp)
 {
 	comma(json);
 	append(json, "{\"mesh\":");
 	append(json, mesh_offset);
-	if (mesh.skin)
+	if (skin)
 	{
 		comma(json);
 		append(json, "\"skin\":");
-		append(json, size_t(mesh.skin - data->skins));
+		append(json, size_t(skin - data->skins));
 	}
 	if (qp)
 	{
@@ -840,13 +840,13 @@ void writeMeshNode(std::string& json, size_t mesh_offset, const Mesh& mesh, cglt
 		append(json, node_scale);
 		append(json, "]");
 	}
-	if (mesh.node && mesh.node->weights_count)
+	if (node && node->weights_count)
 	{
 		append(json, ",\"weights\":[");
-		for (size_t j = 0; j < mesh.node->weights_count; ++j)
+		for (size_t j = 0; j < node->weights_count; ++j)
 		{
 			comma(json);
-			append(json, mesh.node->weights[j]);
+			append(json, node->weights[j]);
 		}
 		append(json, "]");
 	}


### PR DESCRIPTION
This change reworks the gltfpack mesh processing pipeline to be instancing-friendly: instead of duplicating all mesh instances during parsing, we keep the instance data if possible throughout the pipeline.

By default gltfpack no longer merges multiple instances of the same mesh together; this behavior can be changed using `-mm` command-line switch (which usually generates fewer draw calls for scenes with duplicate geometry, at the expense of using more memory).

This change also implements experimental support for EXT_mesh_gpu_instancing, which can be activated using `-mi` switch. The instance data is saved in the same format as animation keyframes, which doesn't fully match the current spec draft.