### PR TITLE
gltfpack: Improve behavior of -kX flags

### DIFF
--- a/gltf/gltfpack.cpp
+++ b/gltf/gltfpack.cpp
@@ -182,7 +182,7 @@ static void process(cgltf_data* data, const char* input_path, const char* output
 			continue;
 
 		// note: when -kn is specified, we keep mesh-node attachment so that named nodes can be transformed
-		if (settings.keep_named)
+		if (settings.keep_nodes)
 			continue;
 
 		// we keep skinned meshes or meshes with morph targets as is
@@ -230,17 +230,7 @@ static void process(cgltf_data* data, const char* input_path, const char* output
 
 	std::vector<MaterialInfo> materials(data->materials_count);
 
-	if (settings.keep_materials)
-	{
-		for (size_t i = 0; i < materials.size(); ++i)
-		{
-			materials[i].keep = true;
-		}
-	}
-	else
-	{
-		markNeededMaterials(data, materials, meshes);
-	}
+	markNeededMaterials(data, materials, meshes, settings);
 
 #ifndef NDEBUG
 	std::vector<Mesh> debug_meshes;
@@ -886,15 +876,15 @@ int main(int argc, char** argv)
 		}
 		else if (strcmp(arg, "-kn") == 0)
 		{
-			settings.keep_named = true;
-		}
-		else if (strcmp(arg, "-ke") == 0)
-		{
-			settings.keep_extras = true;
+			settings.keep_nodes = true;
 		}
 		else if (strcmp(arg, "-km") == 0)
 		{
 			settings.keep_materials = true;
+		}
+		else if (strcmp(arg, "-ke") == 0)
+		{
+			settings.keep_extras = true;
 		}
 		else if (strcmp(arg, "-mm") == 0)
 		{
@@ -1054,8 +1044,8 @@ int main(int argc, char** argv)
 			fprintf(stderr, "\t-ac: keep constant animation tracks even if they don't modify the node transform\n");
 			fprintf(stderr, "\nScene:\n");
 			fprintf(stderr, "\t-kn: keep named nodes and meshes attached to named nodes so that named nodes can be transformed externally\n");
+			fprintf(stderr, "\t-km: keep named materials and disable named material merging\n");
 			fprintf(stderr, "\t-ke: keep extras data\n");
-			fprintf(stderr, "\t-km: keep unused materials\n");
 			fprintf(stderr, "\t-mm: merge instances of the same mesh together when possible\n");
 			fprintf(stderr, "\t-mi: use EXT_mesh_gpu_instancing when serializing multiple mesh instances\n");
 			fprintf(stderr, "\nMiscellaneous:\n");

--- a/gltf/gltfpack.cpp
+++ b/gltf/gltfpack.cpp
@@ -513,7 +513,7 @@ static void process(cgltf_data* data, const char* input_path, const char* output
 			append(json_roots, size_t(ni.remap));
 		}
 
-		writeNode(json_nodes, node, nodes, data);
+		writeNode(json_nodes, node, nodes, data, settings);
 	}
 
 	for (size_t i = 0; i < data->skins_count; ++i)

--- a/gltf/gltfpack.h
+++ b/gltf/gltfpack.h
@@ -298,7 +298,7 @@ size_t writeInstances(std::vector<BufferView>& views, std::string& json_accessor
 void writeMeshNode(std::string& json, size_t mesh_offset, cgltf_node* node, cgltf_skin* skin, cgltf_data* data, const QuantizationPosition* qp);
 void writeMeshNodeInstanced(std::string& json, size_t mesh_offset, size_t accr_offset);
 void writeSkin(std::string& json, const cgltf_skin& skin, size_t matrix_accr, const std::vector<NodeInfo>& nodes, cgltf_data* data);
-void writeNode(std::string& json, const cgltf_node& node, const std::vector<NodeInfo>& nodes, cgltf_data* data);
+void writeNode(std::string& json, const cgltf_node& node, const std::vector<NodeInfo>& nodes, cgltf_data* data, const Settings& settings);
 void writeAnimation(std::string& json, std::vector<BufferView>& views, std::string& json_accessors, size_t& accr_offset, const Animation& animation, size_t i, cgltf_data* data, const std::vector<NodeInfo>& nodes, const Settings& settings);
 void writeCamera(std::string& json, const cgltf_camera& camera);
 void writeLight(std::string& json, const cgltf_light& light);

--- a/gltf/gltfpack.h
+++ b/gltf/gltfpack.h
@@ -93,9 +93,9 @@ struct Settings
 	int anim_freq;
 	bool anim_const;
 
-	bool keep_named;
-	bool keep_extras;
+	bool keep_nodes;
 	bool keep_materials;
+	bool keep_extras;
 
 	bool mesh_merge;
 	bool mesh_instancing;
@@ -249,7 +249,7 @@ void filterEmptyMeshes(std::vector<Mesh>& meshes);
 
 bool usesTextureSet(const cgltf_material& material, int set);
 void mergeMeshMaterials(cgltf_data* data, std::vector<Mesh>& meshes, const Settings& settings);
-void markNeededMaterials(cgltf_data* data, std::vector<MaterialInfo>& materials, const std::vector<Mesh>& meshes);
+void markNeededMaterials(cgltf_data* data, std::vector<MaterialInfo>& materials, const std::vector<Mesh>& meshes, const Settings& settings);
 
 void analyzeImages(cgltf_data* data, std::vector<ImageInfo>& images);
 const char* inferMimeType(const char* path);

--- a/gltf/material.cpp
+++ b/gltf/material.cpp
@@ -168,8 +168,14 @@ void mergeMeshMaterials(cgltf_data* data, std::vector<Mesh>& meshes, const Setti
 		if (!mesh.material)
 			continue;
 
+		if (settings.keep_materials && mesh.material->name && *mesh.material->name)
+			continue;
+
 		for (int j = 0; j < mesh.material - data->materials; ++j)
 		{
+			if (settings.keep_materials && data->materials[j].name && *data->materials[j].name)
+				continue;
+
 			if (areMaterialsEqual(data, *mesh.material, data->materials[j], settings))
 			{
 				mesh.material = &data->materials[j];
@@ -179,7 +185,7 @@ void mergeMeshMaterials(cgltf_data* data, std::vector<Mesh>& meshes, const Setti
 	}
 }
 
-void markNeededMaterials(cgltf_data* data, std::vector<MaterialInfo>& materials, const std::vector<Mesh>& meshes)
+void markNeededMaterials(cgltf_data* data, std::vector<MaterialInfo>& materials, const std::vector<Mesh>& meshes, const Settings& settings)
 {
 	// mark all used materials as kept
 	for (size_t i = 0; i < meshes.size(); ++i)
@@ -191,6 +197,20 @@ void markNeededMaterials(cgltf_data* data, std::vector<MaterialInfo>& materials,
 			MaterialInfo& mi = materials[mesh.material - data->materials];
 
 			mi.keep = true;
+		}
+	}
+
+	// mark all named materials as kept if requested
+	if (settings.keep_materials)
+	{
+		for (size_t i = 0; i < data->materials_count; ++i)
+		{
+			cgltf_material& material = data->materials[i];
+
+			if (material.name && *material.name)
+			{
+				materials[i].keep = true;
+			}
 		}
 	}
 }

--- a/gltf/mesh.cpp
+++ b/gltf/mesh.cpp
@@ -157,7 +157,7 @@ static bool canMergeMeshNodes(cgltf_node* lhs, cgltf_node* rhs, const Settings& 
 	if (lhs_transform || rhs_transform)
 		return false;
 
-	if (settings.keep_named)
+	if (settings.keep_nodes)
 	{
 		if (lhs->name && *lhs->name)
 			return false;

--- a/gltf/node.cpp
+++ b/gltf/node.cpp
@@ -92,7 +92,7 @@ void markNeededNodes(cgltf_data* data, std::vector<NodeInfo>& nodes, const std::
 	}
 
 	// mark all named nodes as needed (if -kn is specified)
-	if (settings.keep_named)
+	if (settings.keep_nodes)
 	{
 		for (size_t i = 0; i < data->nodes_count; ++i)
 		{

--- a/gltf/write.cpp
+++ b/gltf/write.cpp
@@ -951,7 +951,7 @@ void writeSkin(std::string& json, const cgltf_skin& skin, size_t matrix_accr, co
 	append(json, "}");
 }
 
-void writeNode(std::string& json, const cgltf_node& node, const std::vector<NodeInfo>& nodes, cgltf_data* data)
+void writeNode(std::string& json, const cgltf_node& node, const std::vector<NodeInfo>& nodes, cgltf_data* data, const Settings& settings)
 {
 	const NodeInfo& ni = nodes[&node - data->nodes];
 
@@ -1044,6 +1044,8 @@ void writeNode(std::string& json, const cgltf_node& node, const std::vector<Node
 		append(json, size_t(node.light - data->lights));
 		append(json, "}}");
 	}
+	if (settings.keep_extras)
+		writeExtras(json, data, node.extras);
 	append(json, "}");
 }
 


### PR DESCRIPTION
This change reworks -kn and -km to explicitly assume naming - the behavior of kn is unchanged, but km now only keeps named materials, and also disables material merging for named materials to ensure that changing these materials at runtime is possible.

Additionally -ke now writes extras for nodes as well.

Follow-up to #143.
Fixes #144.
