### PR TITLE
gltfpack: Substantiall reduce memory footprint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,7 @@ gltfpack.js: gltf/bin/gltfpack.js
 
 gltf/bin/gltfpack.js: ${LIBRARY_SOURCES} ${GLTFPACK_SOURCES} tools/meshloader.cpp
 	@mkdir -p gltf/bin
-	emcc $^ -o $@ -Os -DNDEBUG -s ALLOW_MEMORY_GROWTH=1 -s NODERAWFS=1
+	emcc $^ -o $@ -Os -DNDEBUG -s ALLOW_MEMORY_GROWTH=1 -s MAXIMUM_MEMORY=4GB -s NODERAWFS=1
 	sed -i '1s;^;#!/usr/bin/env node\n;' $@
 
 build/decoder_base.wasm: $(WASM_SOURCES)

--- a/gltf/gltfpack.cpp
+++ b/gltf/gltfpack.cpp
@@ -157,7 +157,7 @@ static void printAttributeStats(const std::vector<BufferView>& views, BufferView
 	}
 }
 
-static void process(cgltf_data* data, const char* input_path, const char* output_path, std::vector<Mesh>& meshes, std::vector<Animation>& animations, const Settings& settings, std::string& json, std::string& bin, std::string& fallback, size_t& fallback_size)
+static void process(cgltf_data* data, const char* input_path, const char* output_path, std::vector<Mesh>& meshes, std::vector<Animation>& animations, const std::string& extras, const Settings& settings, std::string& json, std::string& bin, std::string& fallback, size_t& fallback_size)
 {
 	if (settings.verbose)
 	{
@@ -348,7 +348,7 @@ static void process(cgltf_data* data, const char* input_path, const char* output
 		append(json_materials, "{");
 		writeMaterial(json_materials, data, material, settings.quantize ? &qt_materials[i] : NULL);
 		if (settings.keep_extras)
-			writeExtras(json_materials, data, material.extras);
+			writeExtras(json_materials, extras, material.extras);
 		append(json_materials, "}");
 
 		mi.remap = int(material_offset);
@@ -520,7 +520,7 @@ static void process(cgltf_data* data, const char* input_path, const char* output
 		append(json_nodes, "{");
 		writeNode(json_nodes, node, nodes, data);
 		if (settings.keep_extras)
-			writeExtras(json_nodes, data, node.extras);
+			writeExtras(json_nodes, extras, node.extras);
 		append(json_nodes, "}");
 	}
 
@@ -558,7 +558,7 @@ static void process(cgltf_data* data, const char* input_path, const char* output
 	append(json, "\"version\":\"2.0\",\"generator\":\"gltfpack ");
 	append(json, getVersion());
 	append(json, "\"");
-	writeExtras(json, data, data->asset.extras);
+	writeExtras(json, extras, data->asset.extras);
 	append(json, "}");
 
 	const ExtensionInfo extensions[] = {
@@ -684,13 +684,14 @@ int gltfpack(const char* input, const char* output, const Settings& settings)
 	cgltf_data* data = 0;
 	std::vector<Mesh> meshes;
 	std::vector<Animation> animations;
+	std::string extras;
 
 	const char* iext = strrchr(input, '.');
 
 	if (iext && (strcmp(iext, ".gltf") == 0 || strcmp(iext, ".GLTF") == 0 || strcmp(iext, ".glb") == 0 || strcmp(iext, ".GLB") == 0))
 	{
 		const char* error = 0;
-		data = parseGltf(input, meshes, animations, &error);
+		data = parseGltf(input, meshes, animations, extras, &error);
 
 		if (error)
 		{
@@ -726,7 +727,7 @@ int gltfpack(const char* input, const char* output, const Settings& settings)
 
 	std::string json, bin, fallback;
 	size_t fallback_size = 0;
-	process(data, input, output, meshes, animations, settings, json, bin, fallback, fallback_size);
+	process(data, input, output, meshes, animations, extras, settings, json, bin, fallback, fallback_size);
 
 	cgltf_free(data);
 

--- a/gltf/gltfpack.cpp
+++ b/gltf/gltfpack.cpp
@@ -21,40 +21,41 @@ std::string getVersion()
 	return result;
 }
 
-static void finalizeBufferViews(std::string& json, std::vector<BufferView>& views, std::string& bin, std::string& fallback)
+static void finalizeBufferViews(std::string& json, std::vector<BufferView>& views, std::string& bin, std::string* fallback, size_t& fallback_size)
 {
 	for (size_t i = 0; i < views.size(); ++i)
 	{
 		BufferView& view = views[i];
 
 		size_t bin_offset = bin.size();
-		size_t fallback_offset = fallback.size();
+		size_t fallback_offset = fallback_size;
 
 		size_t count = view.data.size() / view.stride;
 
-		switch (view.compression)
+		if (view.compression == BufferView::Compression_None)
 		{
-		case BufferView::Compression_None:
 			bin += view.data;
-			break;
+		}
+		else
+		{
+			switch (view.compression)
+			{
+			case BufferView::Compression_Attribute:
+				compressVertexStream(bin, view.data, count, view.stride);
+				break;
+			case BufferView::Compression_Index:
+				compressIndexStream(bin, view.data, count, view.stride);
+				break;
+			case BufferView::Compression_IndexSequence:
+				compressIndexSequence(bin, view.data, count, view.stride);
+				break;
+			default:
+				assert(!"Unknown compression type");
+			}
 
-		case BufferView::Compression_Attribute:
-			compressVertexStream(bin, view.data, count, view.stride);
-			fallback += view.data;
-			break;
-
-		case BufferView::Compression_Index:
-			compressIndexStream(bin, view.data, count, view.stride);
-			fallback += view.data;
-			break;
-
-		case BufferView::Compression_IndexSequence:
-			compressIndexSequence(bin, view.data, count, view.stride);
-			fallback += view.data;
-			break;
-
-		default:
-			assert(!"Unknown compression type");
+			if (fallback)
+				*fallback += view.data;
+			fallback_size += view.data.size();
 		}
 
 		size_t raw_offset = (view.compression != BufferView::Compression_None) ? fallback_offset : bin_offset;
@@ -67,7 +68,9 @@ static void finalizeBufferViews(std::string& json, std::vector<BufferView>& view
 
 		// align each bufferView by 4 bytes
 		bin.resize((bin.size() + 3) & ~3);
-		fallback.resize((fallback.size() + 3) & ~3);
+		if (fallback)
+			fallback->resize((fallback->size() + 3) & ~3);
+		fallback_size = (fallback_size + 3) & ~3;
 	}
 }
 
@@ -154,7 +157,7 @@ static void printAttributeStats(const std::vector<BufferView>& views, BufferView
 	}
 }
 
-static void process(cgltf_data* data, const char* input_path, const char* output_path, std::vector<Mesh>& meshes, std::vector<Animation>& animations, const Settings& settings, std::string& json, std::string& bin, std::string& fallback)
+static void process(cgltf_data* data, const char* input_path, const char* output_path, std::vector<Mesh>& meshes, std::vector<Animation>& animations, const Settings& settings, std::string& json, std::string& bin, std::string& fallback, size_t& fallback_size)
 {
 	if (settings.verbose)
 	{
@@ -568,7 +571,7 @@ static void process(cgltf_data* data, const char* input_path, const char* output
 	writeExtensions(json, extensions, sizeof(extensions) / sizeof(extensions[0]));
 
 	std::string json_views;
-	finalizeBufferViews(json_views, views, bin, fallback);
+	finalizeBufferViews(json_views, views, bin, settings.fallback ? &fallback : NULL, fallback_size);
 
 	writeArray(json, "bufferViews", json_views);
 	writeArray(json, "accessors", json_accessors);
@@ -717,7 +720,8 @@ int gltfpack(const char* input, const char* output, const Settings& settings)
 	}
 
 	std::string json, bin, fallback;
-	process(data, input, output, meshes, animations, settings, json, bin, fallback);
+	size_t fallback_size = 0;
+	process(data, input, output, meshes, animations, settings, json, bin, fallback, fallback_size);
 
 	cgltf_free(data);
 
@@ -745,7 +749,7 @@ int gltfpack(const char* input, const char* output, const Settings& settings)
 			return 4;
 		}
 
-		std::string bufferspec = getBufferSpec(getBaseName(binpath.c_str()), bin.size(), settings.fallback ? getBaseName(fbpath.c_str()) : NULL, fallback.size(), settings.compress);
+		std::string bufferspec = getBufferSpec(getBaseName(binpath.c_str()), bin.size(), settings.fallback ? getBaseName(fbpath.c_str()) : NULL, fallback_size, settings.compress);
 
 		fprintf(outjson, "{");
 		fwrite(bufferspec.c_str(), bufferspec.size(), 1, outjson);
@@ -776,7 +780,7 @@ int gltfpack(const char* input, const char* output, const Settings& settings)
 			return 4;
 		}
 
-		std::string bufferspec = getBufferSpec(NULL, bin.size(), settings.fallback ? getBaseName(fbpath.c_str()) : NULL, fallback.size(), settings.compress);
+		std::string bufferspec = getBufferSpec(NULL, bin.size(), settings.fallback ? getBaseName(fbpath.c_str()) : NULL, fallback_size, settings.compress);
 
 		json.insert(0, "{" + bufferspec + ",");
 		json.push_back('}');

--- a/gltf/gltfpack.cpp
+++ b/gltf/gltfpack.cpp
@@ -516,7 +516,12 @@ static void process(cgltf_data* data, const char* input_path, const char* output
 			append(json_roots, size_t(ni.remap));
 		}
 
-		writeNode(json_nodes, node, nodes, data, settings);
+		comma(json_nodes);
+		append(json_nodes, "{");
+		writeNode(json_nodes, node, nodes, data);
+		if (settings.keep_extras)
+			writeExtras(json_nodes, data, node.extras);
+		append(json_nodes, "}");
 	}
 
 	for (size_t i = 0; i < data->skins_count; ++i)

--- a/gltf/gltfpack.h
+++ b/gltf/gltfpack.h
@@ -233,7 +233,7 @@ bool readFile(const char* path, std::string& data);
 bool writeFile(const char* path, const std::string& data);
 
 cgltf_data* parseObj(const char* path, std::vector<Mesh>& meshes, const char** error);
-cgltf_data* parseGltf(const char* path, std::vector<Mesh>& meshes, std::vector<Animation>& animations, const char** error);
+cgltf_data* parseGltf(const char* path, std::vector<Mesh>& meshes, std::vector<Animation>& animations, std::string& extras, const char** error);
 
 void processAnimation(Animation& animation, const Settings& settings);
 void processMesh(Mesh& mesh, const Settings& settings);
@@ -304,7 +304,7 @@ void writeCamera(std::string& json, const cgltf_camera& camera);
 void writeLight(std::string& json, const cgltf_light& light);
 void writeArray(std::string& json, const char* name, const std::string& contents);
 void writeExtensions(std::string& json, const ExtensionInfo* extensions, size_t count);
-void writeExtras(std::string& json, const cgltf_data* data, const cgltf_extras& extras);
+void writeExtras(std::string& json, const std::string& data, const cgltf_extras& extras);
 
 /**
  * Copyright (c) 2016-2020 Arseny Kapoulkine

--- a/gltf/gltfpack.h
+++ b/gltf/gltfpack.h
@@ -298,7 +298,7 @@ size_t writeInstances(std::vector<BufferView>& views, std::string& json_accessor
 void writeMeshNode(std::string& json, size_t mesh_offset, cgltf_node* node, cgltf_skin* skin, cgltf_data* data, const QuantizationPosition* qp);
 void writeMeshNodeInstanced(std::string& json, size_t mesh_offset, size_t accr_offset);
 void writeSkin(std::string& json, const cgltf_skin& skin, size_t matrix_accr, const std::vector<NodeInfo>& nodes, cgltf_data* data);
-void writeNode(std::string& json, const cgltf_node& node, const std::vector<NodeInfo>& nodes, cgltf_data* data, const Settings& settings);
+void writeNode(std::string& json, const cgltf_node& node, const std::vector<NodeInfo>& nodes, cgltf_data* data);
 void writeAnimation(std::string& json, std::vector<BufferView>& views, std::string& json_accessors, size_t& accr_offset, const Animation& animation, size_t i, cgltf_data* data, const std::vector<NodeInfo>& nodes, const Settings& settings);
 void writeCamera(std::string& json, const cgltf_camera& camera);
 void writeLight(std::string& json, const cgltf_light& light);

--- a/gltf/parsegltf.cpp
+++ b/gltf/parsegltf.cpp
@@ -360,6 +360,39 @@ static bool needsDummyBuffers(cgltf_data* data)
 	return false;
 }
 
+static void evacuateExtras(cgltf_data* data, std::string& extras, cgltf_extras& item)
+{
+	size_t offset = extras.size();
+
+	extras.append(data->json + item.start_offset, item.end_offset - item.start_offset);
+
+	item.start_offset = offset;
+	item.end_offset = extras.size();
+}
+
+static void evacuateExtras(cgltf_data* data, std::string& extras)
+{
+	size_t size = 0;
+
+	size += data->asset.extras.end_offset - data->asset.extras.start_offset;
+
+	for (size_t i = 0; i < data->materials_count; ++i)
+		size += data->materials[i].extras.end_offset - data->materials[i].extras.start_offset;
+
+	for (size_t i = 0; i < data->nodes_count; ++i)
+		size += data->nodes[i].extras.end_offset - data->nodes[i].extras.start_offset;
+
+	extras.reserve(size);
+
+	evacuateExtras(data, extras, data->asset.extras);
+
+	for (size_t i = 0; i < data->materials_count; ++i)
+		evacuateExtras(data, extras, data->materials[i].extras);
+
+	for (size_t i = 0; i < data->nodes_count; ++i)
+		evacuateExtras(data, extras, data->nodes[i].extras);
+}
+
 static void freeUnusedBuffers(cgltf_data* data)
 {
 	std::vector<char> used(data->buffers_count);
@@ -398,12 +431,16 @@ static void freeUnusedBuffers(cgltf_data* data)
 	}
 }
 
-cgltf_data* parseGltf(const char* path, std::vector<Mesh>& meshes, std::vector<Animation>& animations, const char** error)
+cgltf_data* parseGltf(const char* path, std::vector<Mesh>& meshes, std::vector<Animation>& animations, std::string& extras, const char** error)
 {
 	cgltf_data* data = 0;
 
 	cgltf_options options = {};
 	cgltf_result result = cgltf_parse_file(&options, path, &data);
+
+	if (data)
+		evacuateExtras(data, extras);
+
 	result = (result == cgltf_result_success) ? cgltf_load_buffers(&options, data, path) : result;
 	result = (result == cgltf_result_success) ? cgltf_validate(data) : result;
 

--- a/gltf/parsegltf.cpp
+++ b/gltf/parsegltf.cpp
@@ -196,7 +196,7 @@ static void parseMeshesGltf(cgltf_data* data, std::vector<Mesh>& meshes)
 
 				if (attr.type == cgltf_attribute_type_color && attr.data->type == cgltf_type_vec3)
 				{
-					for (size_t i = 0; i < result.streams.back().data.size(); ++i)
+					for (size_t i = 0; i < s.data.size(); ++i)
 						s.data[i].f[3] = 1.0f;
 				}
 			}
@@ -462,11 +462,8 @@ cgltf_data* parseGltf(const char* path, std::vector<Mesh>& meshes, std::vector<A
 	{
 		evacuateExtras(data, extras);
 
-		if (data->json == data->file_data)
-		{
-			assert(!data->bin);
+		if (!data->bin)
 			freeFile(data);
-		}
 	}
 
 	result = (result == cgltf_result_success) ? cgltf_load_buffers(&options, data, path) : result;
@@ -495,11 +492,8 @@ cgltf_data* parseGltf(const char* path, std::vector<Mesh>& meshes, std::vector<A
 
 	bool free_bin = freeUnusedBuffers(data);
 
-	if (free_bin)
-	{
-		assert(data->bin);
+	if (data->bin && free_bin)
 		freeFile(data);
-	}
 
 	return data;
 }

--- a/gltf/parseobj.cpp
+++ b/gltf/parseobj.cpp
@@ -114,7 +114,6 @@ static void parseMeshesObj(fastObjMesh* obj, cgltf_data* data, std::vector<Mesh>
 		mesh_index[mi] = meshes.size();
 
 		meshes.push_back(Mesh());
-
 		Mesh& mesh = meshes.back();
 
 		if (data->materials_count)

--- a/gltf/write.cpp
+++ b/gltf/write.cpp
@@ -1295,12 +1295,15 @@ void writeExtensions(std::string& json, const ExtensionInfo* extensions, size_t 
 	}
 }
 
-void writeExtras(std::string& json, const cgltf_data* data, const cgltf_extras& extras)
+void writeExtras(std::string& json, const std::string& data, const cgltf_extras& extras)
 {
 	if (extras.start_offset == extras.end_offset)
 		return;
 
+	assert(extras.start_offset < data.size());
+	assert(extras.end_offset <= data.size());
+
 	comma(json);
 	append(json, "\"extras\":");
-	appendJson(json, data->json + extras.start_offset, data->json + extras.end_offset);
+	appendJson(json, data.c_str() + extras.start_offset, data.c_str() + extras.end_offset);
 }

--- a/gltf/write.cpp
+++ b/gltf/write.cpp
@@ -951,12 +951,10 @@ void writeSkin(std::string& json, const cgltf_skin& skin, size_t matrix_accr, co
 	append(json, "}");
 }
 
-void writeNode(std::string& json, const cgltf_node& node, const std::vector<NodeInfo>& nodes, cgltf_data* data, const Settings& settings)
+void writeNode(std::string& json, const cgltf_node& node, const std::vector<NodeInfo>& nodes, cgltf_data* data)
 {
 	const NodeInfo& ni = nodes[&node - data->nodes];
 
-	comma(json);
-	append(json, "{");
 	if (node.name && *node.name)
 	{
 		comma(json);
@@ -1044,9 +1042,6 @@ void writeNode(std::string& json, const cgltf_node& node, const std::vector<Node
 		append(json, size_t(node.light - data->lights));
 		append(json, "}}");
 	}
-	if (settings.keep_extras)
-		writeExtras(json, data, node.extras);
-	append(json, "}");
 }
 
 void writeAnimation(std::string& json, std::vector<BufferView>& views, std::string& json_accessors, size_t& accr_offset, const Animation& animation, size_t i, cgltf_data* data, const std::vector<NodeInfo>& nodes, const Settings& settings)


### PR DESCRIPTION
This change makes gltfpack more memory efficient when processing large scenes through a combination of being more efficient with memory allocations and freeing excess memory early:

- Mesh and animation parsing now doesn't reallocate vectors
- Buffers that aren't referenced by skin or image data are freed before scene processing
- Fallback buffer contents is not generated anymore unless requested
- GLTF JSON blob is now freed very early during parsing when processing .gltf inputs

As a result, a JSON-heavy scene goes from 121 MB to 75 MB of RSS for processing (-38%), and a mesh-heavy scene goes from 1390 MB to 810 MB (-42%); so it looks like we now need ~40% less memory on average.

Additionally, this change switches gltfpack.js to 4GB builds, so that with recent v8 it can use the full 32-bit address space.

Fixes #140.