### PR TITLE
gltfpack: Fix processing for .glb files with no images

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,7 +79,7 @@ jobs:
     - name: make
       run: make -j2 config=sanitize gltfpack
     - name: test
-      run: find glTF-Sample-Models/2.0/ -name *.gltf | xargs ./gltfpack -cc -test
+      run: find glTF-Sample-Models/2.0/ -name *.gltf -or -name *.glb | xargs ./gltfpack -cc -test
     - name: pack
       run: find glTF-Sample-Models/2.0/ -name *.gltf | grep -v glTF-Draco | xargs -I '{}' ./gltfpack -i '{}' -o '{}pack.gltf'
     - name: validate

--- a/gltf/parsegltf.cpp
+++ b/gltf/parsegltf.cpp
@@ -437,14 +437,11 @@ static bool freeUnusedBuffers(cgltf_data* data)
 		if (!used[i] && buffer.data)
 		{
 			if (buffer.data != data->bin)
-			{
 				free(buffer.data);
-				buffer.data = NULL;
-			}
 			else
-			{
 				free_bin = true;
-			}
+
+			buffer.data = NULL;
 		}
 	}
 


### PR DESCRIPTION
We would free the buffer that's backing the binary data since we don't
need it anymore but the buffer object would still point to the
deallocated memory, causing a crash when cgltf_free frees it later.

This is a regression from #147; it was missed because the CI didn't
test gltfpack on .glb files - well, now it does.