### PR TITLE
simplify: Implement more robust open edge analysis

### DIFF
--- a/demo/tests.cpp
+++ b/demo/tests.cpp
@@ -689,6 +689,18 @@ static void simplifyStuck()
 
 	assert(meshopt_simplify(ib2, ib2, 9, vb2, 5, 12, 6, 1e-3f) == 6);
 	assert(meshopt_simplify(ib3, ib3, 9, vb2, 5, 12, 6, 1e-3f) == 9);
+
+	// 4-vertex quad with a locked corner can't be simplified due to border error-induced restriction
+	float vb4[] = {0, 0, 0, 1, 0, 0, 0, 1, 0, 1, 1, 0};
+	unsigned int ib4[] = {0, 1, 3, 0, 3, 2};
+
+	assert(meshopt_simplify(ib4, ib4, 6, vb4, 4, 12, 3, 1e-3f) == 6);
+
+	// 4-vertex quad with a locked corner can't be simplified due to border error-induced restriction
+	float vb5[] = {0, 0, 0, 1, 0, 0, 0, 1, 0, 1, 1, 0, 1, 1, 0};
+	unsigned int ib5[] = {0, 1, 4, 0, 3, 2};
+
+	assert(meshopt_simplify(ib5, ib5, 6, vb5, 5, 12, 3, 1e-3f) == 6);
 }
 
 static void simplifySloppyStuck()

--- a/src/meshoptimizer.h
+++ b/src/meshoptimizer.h
@@ -642,7 +642,7 @@ public:
 	}
 
 private:
-	void* blocks[16];
+	void* blocks[24];
 	size_t count;
 };
 

--- a/src/simplifier.cpp
+++ b/src/simplifier.cpp
@@ -1141,6 +1141,7 @@ static float interpolate(float y, float x0, float y0, float x1, float y1, float 
 #ifndef NDEBUG
 unsigned char* meshopt_simplifyDebugKind = 0;
 unsigned int* meshopt_simplifyDebugLoop = 0;
+unsigned int* meshopt_simplifyDebugLoopBack = 0;
 #endif
 
 size_t meshopt_simplify(unsigned int* destination, const unsigned int* indices, size_t index_count, const float* vertex_positions_data, size_t vertex_count, size_t vertex_positions_stride, size_t target_index_count, float target_error)
@@ -1290,6 +1291,9 @@ size_t meshopt_simplify(unsigned int* destination, const unsigned int* indices, 
 
 	if (meshopt_simplifyDebugLoop)
 		memcpy(meshopt_simplifyDebugLoop, loop, vertex_count * sizeof(unsigned int));
+
+	if (meshopt_simplifyDebugLoopBack)
+		memcpy(meshopt_simplifyDebugLoopBack, loopback, vertex_count * sizeof(unsigned int));
 #endif
 
 	return result_count;

--- a/src/simplifier.cpp
+++ b/src/simplifier.cpp
@@ -289,10 +289,10 @@ static void classifyVertices(unsigned char* result, unsigned int* loop, unsigned
 
 				// seam should have one open half-edge for each vertex, and the edges need to "connect" - point to the same vertex post-remap
 				if (openiv != ~0u && openiv != i && openov != ~0u && openov != i &&
-					openiw != ~0u && openiw != w && openow != ~0u && openow != w)
+				    openiw != ~0u && openiw != w && openow != ~0u && openow != w)
 				{
 					if (remap[openiv] == remap[openow] && remap[openov] == remap[openiw] &&
-						remap[openiw] == remap[openov] && remap[openow] == remap[openiv])
+					    remap[openiw] == remap[openov] && remap[openow] == remap[openiv])
 					{
 						result[i] = Kind_Seam;
 					}


### PR DESCRIPTION
Instead of only looking at the outgoing open edges during
classification, we now look at both incoming and outgoing edges.

This cleans up the classification results in some rare cases and opens
up doors for more robust analysis of borders and more opportunities for
collapsing, e.g. seam -> locked, in the future.

It also allows us to use the open edge data for edge quadrics - essentially we
now have a bidirectional edge loop structure instead of the unidirectional one.

This is implemented using just binary hasEdge operator which means we almost
don't need EdgeAdjacency anymore (but keeping it for now in case it proves useful).

Fixes #122 
Fixes #88 (or, well, it makes it better; there are still some problems in Lumberyard but it's a huge scene and it's hard to analyze - will need a better use case to make further progress there)