### PR TITLE
gltfpack: Implement Basis support in node.js builds

### DIFF
--- a/gltf/README.md
+++ b/gltf/README.md
@@ -26,7 +26,7 @@ When using `-c` option, gltfpack outputs compressed `.glb`/`.gltf` files that us
 
 For better compression, you can use `-cc` option which applies additional compression; additionally make sure that your content delivery method is configured to use deflate (gzip) - meshoptimizer codecs are designed to produce output that can be compressed further with general purpose compressors.
 
-gltfpack can also compress textures using Basis Universal format, either storing .basis images directly (`-tb` flag, supported by three.js) or using KTX2 container (`-tc` flag, requires support for `KHR_image_ktx2`). Compression is performed using `basisu` executable and is thus only available in native builds.
+gltfpack can also compress textures using Basis Universal format, either storing .basis images directly (`-tb` flag, supported by three.js) or using KTX2 container (`-tc` flag, requires support for `KHR_image_ktx2`). Compression is performed using `basisu` executable that must be available in `PATH`; alternatively the path to the executable can be specified via `BASISU_PATH` environment variable.
 
 When using compressed files, [js/meshopt_decoder.js](https://github.com/zeux/meshoptimizer/blob/master/js/meshopt_decoder.js) needs to be loaded to provide the WebAssembly decoder module like this:
 

--- a/gltf/fileio.cpp
+++ b/gltf/fileio.cpp
@@ -14,11 +14,15 @@
 TempFile::TempFile(const char* suffix)
     : fd(-1)
 {
-#ifdef _WIN32
+#if defined(_WIN32)
 	const char* temp_dir = getenv("TEMP");
 	path = temp_dir ? temp_dir : ".";
 	path += "\\gltfpack-XXXXXX";
 	(void)_mktemp(&path[0]);
+	path += suffix;
+#elif defined(__EMSCRIPTEN__)
+	path = "gltfpack-XXXXXX";
+	(void)mktemp(&path[0]);
 	path += suffix;
 #else
 	path = "/tmp/gltfpack-XXXXXX";

--- a/gltf/gltfpack.cpp
+++ b/gltf/gltfpack.cpp
@@ -718,7 +718,7 @@ int gltfpack(const char* input, const char* output, const Settings& settings)
 
 	if (data->images_count && settings.texture_basis)
 	{
-		if (!checkBasis())
+		if (!checkBasis(settings.verbose > 1))
 		{
 			fprintf(stderr, "Error: basisu is not present in PATH or BASISU_PATH is not set\n");
 			return 3;

--- a/gltf/gltfpack.h
+++ b/gltf/gltfpack.h
@@ -253,8 +253,8 @@ void markNeededMaterials(cgltf_data* data, std::vector<MaterialInfo>& materials,
 
 void analyzeImages(cgltf_data* data, std::vector<ImageInfo>& images);
 const char* inferMimeType(const char* path);
-bool checkBasis();
-bool encodeBasis(const std::string& data, const char* mime_type, std::string& result, bool normal_map, bool srgb, int quality, bool uastc);
+bool checkBasis(bool verbose);
+bool encodeBasis(const std::string& data, const char* mime_type, std::string& result, bool normal_map, bool srgb, int quality, bool uastc, bool verbose);
 std::string basisToKtx(const std::string& data, bool srgb, bool uastc);
 
 void markAnimated(cgltf_data* data, std::vector<NodeInfo>& nodes, const std::vector<Animation>& animations);

--- a/gltf/image.cpp
+++ b/gltf/image.cpp
@@ -78,6 +78,14 @@ EM_JS(int, execute, (const char* cmd, bool ignore_stdout, bool ignore_stderr), {
 	var ret = cp.spawnSync(UTF8ToString(cmd), [], {shell:true, stdio:stdio });
 	return ret.status == null ? 256 : ret.status;
 });
+
+EM_JS(const char*, readenv, (const char* name), {
+	var val = process.env[UTF8ToString(name)];
+	if (!val) return 0;
+	var ret = _malloc(lengthBytesUTF8(val) + 1);
+	stringToUTF8(val, ret, lengthBytesUTF8(val) + 1);
+	return ret;
+});
 #else
 static int execute(const char* cmd_, bool ignore_stdout, bool ignore_stderr)
 {
@@ -96,11 +104,16 @@ static int execute(const char* cmd_, bool ignore_stdout, bool ignore_stderr)
 
 	return system(cmd.c_str());
 }
+
+static const char* readenv(const char* name)
+{
+	return getenv(name);
+}
 #endif
 
 bool checkBasis()
 {
-	const char* basisu_path = getenv("BASISU_PATH");
+	const char* basisu_path = readenv("BASISU_PATH");
 	std::string cmd = basisu_path ? basisu_path : "basisu";
 
 	cmd += " -version";
@@ -118,7 +131,7 @@ bool encodeBasis(const std::string& data, const char* mime_type, std::string& re
 	if (!writeFile(temp_input.path.c_str(), data))
 		return false;
 
-	const char* basisu_path = getenv("BASISU_PATH");
+	const char* basisu_path = readenv("BASISU_PATH");
 	std::string cmd = basisu_path ? basisu_path : "basisu";
 
 	char ql[16];

--- a/gltf/image.cpp
+++ b/gltf/image.cpp
@@ -111,7 +111,7 @@ static const char* readenv(const char* name)
 }
 #endif
 
-bool checkBasis()
+bool checkBasis(bool verbose)
 {
 	const char* basisu_path = readenv("BASISU_PATH");
 	std::string cmd = basisu_path ? basisu_path : "basisu";
@@ -119,11 +119,13 @@ bool checkBasis()
 	cmd += " -version";
 
 	int rc = execute(cmd.c_str(), /* ignore_stdout= */ true, /* ignore_stderr= */ true);
+	if (verbose)
+		printf("%s => %d\n", cmd.c_str(), rc);
 
 	return rc == 0;
 }
 
-bool encodeBasis(const std::string& data, const char* mime_type, std::string& result, bool normal_map, bool srgb, int quality, bool uastc)
+bool encodeBasis(const std::string& data, const char* mime_type, std::string& result, bool normal_map, bool srgb, int quality, bool uastc, bool verbose)
 {
 	TempFile temp_input(mimeExtension(mime_type));
 	TempFile temp_output(".basis");
@@ -163,6 +165,8 @@ bool encodeBasis(const std::string& data, const char* mime_type, std::string& re
 	cmd += temp_output.path;
 
 	int rc = execute(cmd.c_str(), /* ignore_stdout= */ true, /* ignore_stderr= */ false);
+	if (verbose)
+		printf("%s => %d\n", cmd.c_str(), rc);
 
 	return rc == 0 && readFile(temp_output.path.c_str(), result);
 }

--- a/gltf/write.cpp
+++ b/gltf/write.cpp
@@ -592,7 +592,7 @@ void writeImage(std::string& json, std::vector<BufferView>& views, const cgltf_i
 		{
 			std::string encoded;
 
-			if (encodeBasis(img_data, mime_type.c_str(), encoded, info.normal_map, info.srgb, settings.texture_quality, settings.texture_uastc))
+			if (encodeBasis(img_data, mime_type.c_str(), encoded, info.normal_map, info.srgb, settings.texture_quality, settings.texture_uastc, settings.verbose > 1))
 			{
 				if (settings.texture_ktx2)
 					encoded = basisToKtx(encoded, info.srgb, settings.texture_uastc);
@@ -621,7 +621,7 @@ void writeImage(std::string& json, std::vector<BufferView>& views, const cgltf_i
 			{
 				std::string encoded;
 
-				if (encodeBasis(img_data, mime_type.c_str(), encoded, info.normal_map, info.srgb, settings.texture_quality, settings.texture_uastc))
+				if (encodeBasis(img_data, mime_type.c_str(), encoded, info.normal_map, info.srgb, settings.texture_quality, settings.texture_uastc, settings.verbose > 1))
 				{
 					if (settings.texture_ktx2)
 						encoded = basisToKtx(encoded, info.srgb, settings.texture_uastc);


### PR DESCRIPTION
There were several things that made it so that Basis encoding for gltfpack.js only worked in Linux/macOS hosts and only if basisu was available via PATH.

This change fixes the issues by using a custom system() implementation to suppress stdout/stderr, a different way to generate temp paths under Emscripten, and a custom getenv() replacement to support BASISU_PATH.

Fixes #137.