### PR TITLE
demo: Use this.name for looking up glTF extensions

### DIFF
--- a/demo/THREE.EXT_meshopt_compression.js
+++ b/demo/THREE.EXT_meshopt_compression.js
@@ -1,10 +1,8 @@
 /* three.js extension for EXT_meshopt_compression; requires three.js r118 */
 /* loader.register(function (parser) { return new EXT_meshopt_compression(parser, MeshoptDecoder); }); */
 var EXT_meshopt_compression = (function () {
-	var NAME = "EXT_meshopt_compression";
-
     function EXT_meshopt_compression(parser, decoder) {
-        this.name = NAME;
+        this.name = "EXT_meshopt_compression";
         this._parser = parser;
         this._decoder = decoder;
     }
@@ -12,8 +10,8 @@ var EXT_meshopt_compression = (function () {
     EXT_meshopt_compression.prototype.loadBufferView = function (index) {
     	var bufferView = this._parser.json.bufferViews[index];
 
-        if (bufferView.extensions && bufferView.extensions[NAME]) {
-            var extensionDef = bufferView.extensions[NAME];
+        if (bufferView.extensions && bufferView.extensions[this.name]) {
+            var extensionDef = bufferView.extensions[this.name];
 
             var buffer = this._parser.getDependency('buffer', extensionDef.buffer);
             var decoder = this._decoder;

--- a/demo/babylon.EXT_meshopt_compression.js
+++ b/demo/babylon.EXT_meshopt_compression.js
@@ -1,11 +1,10 @@
 /* Babylon.js extension for EXT_meshopt_compression; requires Babylon.js 4.1 */
 /* BABYLON.GLTF2.GLTFLoader.RegisterExtension("EXT_meshopt_compression", (loader) => new EXT_meshopt_compression(loader, MeshoptDecoder)); */
 var EXT_meshopt_compression = /** @class */ (function () {
-    var NAME = "EXT_meshopt_compression";
     /** @hidden */
     function EXT_meshopt_compression(loader, decoder) {
         /** The name of this extension. */
-        this.name = NAME;
+        this.name = "EXT_meshopt_compression";
         /** Defines whether this extension is enabled. */
         this.enabled = true;
         this._loader = loader;
@@ -17,8 +16,8 @@ var EXT_meshopt_compression = /** @class */ (function () {
     };
     /** @hidden */
     EXT_meshopt_compression.prototype.loadBufferViewAsync = function (context, bufferView) {
-        if (bufferView.extensions && bufferView.extensions[NAME]) {
-            var extensionDef = bufferView.extensions[NAME];
+        if (bufferView.extensions && bufferView.extensions[this.name]) {
+            var extensionDef = bufferView.extensions[this.name];
             if (extensionDef._decoded) {
                 return extensionDef._decoded;
             }


### PR DESCRIPTION
This allows overriding the name post-construction externally to work
with legacy files, for example

    loader.register(function (parser) {
        var res = new EXT_meshopt_compression(parser, MeshoptDecoder);
        res.name = "MESHOPT_compression";
        return res;
    });