### PR TITLE
Add gltfpack installation instructions to main readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,19 @@ Alternatively you can [download the .zip archive from GitHub](https://github.com
 
 The library is available as a Linux package in some distributions ([ArchLinux](https://aur.archlinux.org/packages/meshoptimizer/)).
 
+### Installing gltfpack
+
+`gltfpack` is a CLI tool for optimizing meshes using meshoptimizer.
+
+You can download a pre-built binary for gltfpack on Releases page, or install npm package as follows:
+```
+npm install -g gltfpack
+```
+
+You can also find prebuilt binaries of `gltfpack` built from master by going to https://github.com/zeux/meshoptimizer/actions, opening the latest run, and downloading the artifact for your platform. It will give you a binary file you can place into your `$PATH`.
+
+[Learn more about gltfpack](./gltf/README.md)
+
 ## Building
 
 meshoptimizer is distributed as a set of C++ source files. To include it into your project, you can use one of the two options:

--- a/README.md
+++ b/README.md
@@ -24,12 +24,13 @@ The library is available as a Linux package in some distributions ([ArchLinux](h
 
 `gltfpack` is a CLI tool for optimizing meshes using meshoptimizer.
 
-You can download a pre-built binary for gltfpack on Releases page, or install npm package as follows:
+You can download a pre-built binary for gltfpack on [Releases page](https://github.com/zeux/meshoptimizer/releases), or install [npm package](https://www.npmjs.com/package/gltfpack) as follows:
+
 ```
 npm install -g gltfpack
 ```
 
-You can also find prebuilt binaries of `gltfpack` built from master by going to https://github.com/zeux/meshoptimizer/actions, opening the latest run, and downloading the artifact for your platform. It will give you a binary file you can place into your `$PATH`.
+You can also find prebuilt binaries of `gltfpack` built from master on [Actions page](https://github.com/zeux/meshoptimizer/actions).
 
 [Learn more about gltfpack](./gltf/README.md)
 


### PR DESCRIPTION
I wanted to update to the latest version of `gltfpack` but it took me a minute to remember that `gltfpack` is in the `gltf` folder and to figure out the correct options to compile it with CMake. 

Then I read through recent issues and saw you posted a link to the the Actions page which contains binaries in the build artifacts

Probably a good number of people come to this repo to install gltfpack itself, so I figured it'd be helpful to mention on the main readme