### PR TITLE
gltfpack: Implement support for KHR_materials_transmission

### DIFF
--- a/demo/GLTFLoader.js
+++ b/demo/GLTFLoader.js
@@ -1034,6 +1034,9 @@ THREE.GLTFLoader = ( function () {
 				THREE.Object3D.prototype.copy.call( instancedMesh, mesh );
 				THREE.Object3D.prototype.copy.call( instancedMesh, node );
 
+				// Reset frustumCulled back to false, since it was set to true by .copy above
+				instancedMesh.frustumCulled = false;
+
 				parser.assignFinalMaterial( instancedMesh );
 
 				return instancedMesh;

--- a/extern/cgltf.h
+++ b/extern/cgltf.h
@@ -1,7 +1,7 @@
 /**
  * cgltf - a single-file glTF 2.0 parser written in C99.
  *
- * Version: 1.5
+ * Version: 1.6
  *
  * Website: https://github.com/jkuhlmann/cgltf
  *
@@ -239,12 +239,19 @@ typedef struct cgltf_extras {
 	cgltf_size end_offset;
 } cgltf_extras;
 
+typedef struct cgltf_extension {
+	char* name;
+	char* data;
+} cgltf_extension;
+
 typedef struct cgltf_buffer
 {
 	cgltf_size size;
 	char* uri;
 	void* data; /* loaded by cgltf_load_buffers */
 	cgltf_extras extras;
+	cgltf_size extensions_count;
+	cgltf_extension* extensions;
 } cgltf_buffer;
 
 typedef struct cgltf_buffer_view
@@ -255,6 +262,8 @@ typedef struct cgltf_buffer_view
 	cgltf_size stride; /* 0 == automatically determined by accessor */
 	cgltf_buffer_view_type type;
 	cgltf_extras extras;
+	cgltf_size extensions_count;
+	cgltf_extension* extensions;
 } cgltf_buffer_view;
 
 typedef struct cgltf_accessor_sparse
@@ -268,6 +277,12 @@ typedef struct cgltf_accessor_sparse
 	cgltf_extras extras;
 	cgltf_extras indices_extras;
 	cgltf_extras values_extras;
+	cgltf_size extensions_count;
+	cgltf_extension* extensions;
+	cgltf_size indices_extensions_count;
+	cgltf_extension* indices_extensions;
+	cgltf_size values_extensions_count;
+	cgltf_extension* values_extensions;
 } cgltf_accessor_sparse;
 
 typedef struct cgltf_accessor
@@ -286,6 +301,8 @@ typedef struct cgltf_accessor
 	cgltf_bool is_sparse;
 	cgltf_accessor_sparse sparse;
 	cgltf_extras extras;
+	cgltf_size extensions_count;
+	cgltf_extension* extensions;
 } cgltf_accessor;
 
 typedef struct cgltf_attribute
@@ -303,6 +320,8 @@ typedef struct cgltf_image
 	cgltf_buffer_view* buffer_view;
 	char* mime_type;
 	cgltf_extras extras;
+	cgltf_size extensions_count;
+	cgltf_extension* extensions;
 } cgltf_image;
 
 typedef struct cgltf_sampler
@@ -312,6 +331,8 @@ typedef struct cgltf_sampler
 	cgltf_int wrap_s;
 	cgltf_int wrap_t;
 	cgltf_extras extras;
+	cgltf_size extensions_count;
+	cgltf_extension* extensions;
 } cgltf_sampler;
 
 typedef struct cgltf_texture
@@ -320,6 +341,8 @@ typedef struct cgltf_texture
 	cgltf_image* image;
 	cgltf_sampler* sampler;
 	cgltf_extras extras;
+	cgltf_size extensions_count;
+	cgltf_extension* extensions;
 } cgltf_texture;
 
 typedef struct cgltf_texture_transform
@@ -338,6 +361,8 @@ typedef struct cgltf_texture_view
 	cgltf_bool has_transform;
 	cgltf_texture_transform transform;
 	cgltf_extras extras;
+	cgltf_size extensions_count;
+	cgltf_extension* extensions;
 } cgltf_texture_view;
 
 typedef struct cgltf_pbr_metallic_roughness
@@ -372,15 +397,23 @@ typedef struct cgltf_clearcoat
 	cgltf_float clearcoat_roughness_factor;
 } cgltf_clearcoat;
 
+typedef struct cgltf_transmission
+{
+	cgltf_texture_view transmission_texture;
+	cgltf_float transmission_factor;
+} cgltf_transmission;
+
 typedef struct cgltf_material
 {
 	char* name;
 	cgltf_bool has_pbr_metallic_roughness;
 	cgltf_bool has_pbr_specular_glossiness;
 	cgltf_bool has_clearcoat;
+	cgltf_bool has_transmission;
 	cgltf_pbr_metallic_roughness pbr_metallic_roughness;
 	cgltf_pbr_specular_glossiness pbr_specular_glossiness;
 	cgltf_clearcoat clearcoat;
+	cgltf_transmission transmission;
 	cgltf_texture_view normal_texture;
 	cgltf_texture_view occlusion_texture;
 	cgltf_texture_view emissive_texture;
@@ -390,6 +423,8 @@ typedef struct cgltf_material
 	cgltf_bool double_sided;
 	cgltf_bool unlit;
 	cgltf_extras extras;
+	cgltf_size extensions_count;
+	cgltf_extension* extensions;
 } cgltf_material;
 
 typedef struct cgltf_morph_target {
@@ -414,6 +449,8 @@ typedef struct cgltf_primitive {
 	cgltf_extras extras;
 	cgltf_bool has_draco_mesh_compression;
 	cgltf_draco_mesh_compression draco_mesh_compression;
+	cgltf_size extensions_count;
+	cgltf_extension* extensions;
 } cgltf_primitive;
 
 typedef struct cgltf_mesh {
@@ -425,6 +462,8 @@ typedef struct cgltf_mesh {
 	char** target_names;
 	cgltf_size target_names_count;
 	cgltf_extras extras;
+	cgltf_size extensions_count;
+	cgltf_extension* extensions;
 } cgltf_mesh;
 
 typedef struct cgltf_node cgltf_node;
@@ -436,6 +475,8 @@ typedef struct cgltf_skin {
 	cgltf_node* skeleton;
 	cgltf_accessor* inverse_bind_matrices;
 	cgltf_extras extras;
+	cgltf_size extensions_count;
+	cgltf_extension* extensions;
 } cgltf_skin;
 
 typedef struct cgltf_camera_perspective {
@@ -462,6 +503,8 @@ typedef struct cgltf_camera {
 		cgltf_camera_orthographic orthographic;
 	} data;
 	cgltf_extras extras;
+	cgltf_size extensions_count;
+	cgltf_extension* extensions;
 } cgltf_camera;
 
 typedef struct cgltf_light {
@@ -494,6 +537,8 @@ struct cgltf_node {
 	cgltf_float scale[3];
 	cgltf_float matrix[16];
 	cgltf_extras extras;
+	cgltf_size extensions_count;
+	cgltf_extension* extensions;
 };
 
 typedef struct cgltf_scene {
@@ -501,6 +546,8 @@ typedef struct cgltf_scene {
 	cgltf_node** nodes;
 	cgltf_size nodes_count;
 	cgltf_extras extras;
+	cgltf_size extensions_count;
+	cgltf_extension* extensions;
 } cgltf_scene;
 
 typedef struct cgltf_animation_sampler {
@@ -508,6 +555,8 @@ typedef struct cgltf_animation_sampler {
 	cgltf_accessor* output;
 	cgltf_interpolation_type interpolation;
 	cgltf_extras extras;
+	cgltf_size extensions_count;
+	cgltf_extension* extensions;
 } cgltf_animation_sampler;
 
 typedef struct cgltf_animation_channel {
@@ -515,6 +564,8 @@ typedef struct cgltf_animation_channel {
 	cgltf_node* target_node;
 	cgltf_animation_path_type target_path;
 	cgltf_extras extras;
+	cgltf_size extensions_count;
+	cgltf_extension* extensions;
 } cgltf_animation_channel;
 
 typedef struct cgltf_animation {
@@ -524,6 +575,8 @@ typedef struct cgltf_animation {
 	cgltf_animation_channel* channels;
 	cgltf_size channels_count;
 	cgltf_extras extras;
+	cgltf_size extensions_count;
+	cgltf_extension* extensions;
 } cgltf_animation;
 
 typedef struct cgltf_asset {
@@ -532,6 +585,8 @@ typedef struct cgltf_asset {
 	char* version;
 	char* min_version;
 	cgltf_extras extras;
+	cgltf_size extensions_count;
+	cgltf_extension* extensions;
 } cgltf_asset;
 
 typedef struct cgltf_data
@@ -586,6 +641,9 @@ typedef struct cgltf_data
 	cgltf_size animations_count;
 
 	cgltf_extras extras;
+
+	cgltf_size data_extensions_count;
+	cgltf_extension* data_extensions;
 
 	char** extensions_used;
 	cgltf_size extensions_used_count;
@@ -1466,6 +1524,16 @@ cgltf_result cgltf_copy_extras_json(const cgltf_data* data, const cgltf_extras* 
 	return cgltf_result_success;
 }
 
+void cgltf_free_extensions(cgltf_data* data, cgltf_extension* extensions, cgltf_size extensions_count)
+{
+	for (cgltf_size i = 0; i < extensions_count; ++i)
+	{
+		data->memory.free(data->memory.user_data, extensions[i].name);
+		data->memory.free(data->memory.user_data, extensions[i].data);
+	}
+	data->memory.free(data->memory.user_data, extensions);
+}
+
 void cgltf_free(cgltf_data* data)
 {
 	if (!data)
@@ -1480,7 +1548,24 @@ void cgltf_free(cgltf_data* data)
 	data->memory.free(data->memory.user_data, data->asset.version);
 	data->memory.free(data->memory.user_data, data->asset.min_version);
 
+	cgltf_free_extensions(data, data->asset.extensions, data->asset.extensions_count);
+
+	for (cgltf_size i = 0; i < data->accessors_count; ++i)
+	{
+		if(data->accessors[i].is_sparse)
+		{
+			cgltf_free_extensions(data, data->accessors[i].sparse.extensions, data->accessors[i].sparse.extensions_count);
+			cgltf_free_extensions(data, data->accessors[i].sparse.indices_extensions, data->accessors[i].sparse.indices_extensions_count);
+			cgltf_free_extensions(data, data->accessors[i].sparse.values_extensions, data->accessors[i].sparse.values_extensions_count);
+		}
+		cgltf_free_extensions(data, data->accessors[i].extensions, data->accessors[i].extensions_count);
+	}
 	data->memory.free(data->memory.user_data, data->accessors);
+
+	for (cgltf_size i = 0; i < data->buffer_views_count; ++i)
+	{
+		cgltf_free_extensions(data, data->buffer_views[i].extensions, data->buffer_views[i].extensions_count);
+	}
 	data->memory.free(data->memory.user_data, data->buffer_views);
 
 	for (cgltf_size i = 0; i < data->buffers_count; ++i)
@@ -1489,8 +1574,9 @@ void cgltf_free(cgltf_data* data)
 		{
 			file_release(&data->memory, &data->file, data->buffers[i].data);
 		}
-
 		data->memory.free(data->memory.user_data, data->buffers[i].uri);
+
+		cgltf_free_extensions(data, data->buffers[i].extensions, data->buffers[i].extensions_count);
 	}
 
 	data->memory.free(data->memory.user_data, data->buffers);
@@ -1529,6 +1615,8 @@ void cgltf_free(cgltf_data* data)
 
 				data->memory.free(data->memory.user_data, data->meshes[i].primitives[j].draco_mesh_compression.attributes);
 			}
+
+			cgltf_free_extensions(data, data->meshes[i].primitives[j].extensions, data->meshes[i].primitives[j].extensions_count);
 		}
 
 		data->memory.free(data->memory.user_data, data->meshes[i].primitives);
@@ -1539,6 +1627,8 @@ void cgltf_free(cgltf_data* data)
 			data->memory.free(data->memory.user_data, data->meshes[i].target_names[j]);
 		}
 
+		cgltf_free_extensions(data, data->meshes[i].extensions, data->meshes[i].extensions_count);
+
 		data->memory.free(data->memory.user_data, data->meshes[i].target_names);
 	}
 
@@ -1547,6 +1637,33 @@ void cgltf_free(cgltf_data* data)
 	for (cgltf_size i = 0; i < data->materials_count; ++i)
 	{
 		data->memory.free(data->memory.user_data, data->materials[i].name);
+
+		if(data->materials[i].has_pbr_metallic_roughness)
+		{
+			cgltf_free_extensions(data, data->materials[i].pbr_metallic_roughness.metallic_roughness_texture.extensions, data->materials[i].pbr_metallic_roughness.metallic_roughness_texture.extensions_count);
+			cgltf_free_extensions(data, data->materials[i].pbr_metallic_roughness.base_color_texture.extensions, data->materials[i].pbr_metallic_roughness.base_color_texture.extensions_count);
+		}
+		if(data->materials[i].has_pbr_specular_glossiness)
+		{
+			cgltf_free_extensions(data, data->materials[i].pbr_specular_glossiness.diffuse_texture.extensions, data->materials[i].pbr_specular_glossiness.diffuse_texture.extensions_count);
+			cgltf_free_extensions(data, data->materials[i].pbr_specular_glossiness.specular_glossiness_texture.extensions, data->materials[i].pbr_specular_glossiness.specular_glossiness_texture.extensions_count);
+		}
+		if(data->materials[i].has_clearcoat)
+		{
+			cgltf_free_extensions(data, data->materials[i].clearcoat.clearcoat_texture.extensions, data->materials[i].clearcoat.clearcoat_texture.extensions_count);
+			cgltf_free_extensions(data, data->materials[i].clearcoat.clearcoat_roughness_texture.extensions, data->materials[i].clearcoat.clearcoat_roughness_texture.extensions_count);
+			cgltf_free_extensions(data, data->materials[i].clearcoat.clearcoat_normal_texture.extensions, data->materials[i].clearcoat.clearcoat_normal_texture.extensions_count);
+		}
+		if(data->materials[i].has_transmission)
+		{
+			cgltf_free_extensions(data, data->materials[i].transmission.transmission_texture.extensions, data->materials[i].transmission.transmission_texture.extensions_count);
+		}
+
+		cgltf_free_extensions(data, data->materials[i].normal_texture.extensions, data->materials[i].normal_texture.extensions_count);
+		cgltf_free_extensions(data, data->materials[i].occlusion_texture.extensions, data->materials[i].occlusion_texture.extensions_count);
+		cgltf_free_extensions(data, data->materials[i].emissive_texture.extensions, data->materials[i].emissive_texture.extensions_count);
+
+		cgltf_free_extensions(data, data->materials[i].extensions, data->materials[i].extensions_count);
 	}
 
 	data->memory.free(data->memory.user_data, data->materials);
@@ -1556,6 +1673,8 @@ void cgltf_free(cgltf_data* data)
 		data->memory.free(data->memory.user_data, data->images[i].name);
 		data->memory.free(data->memory.user_data, data->images[i].uri);
 		data->memory.free(data->memory.user_data, data->images[i].mime_type);
+
+		cgltf_free_extensions(data, data->images[i].extensions, data->images[i].extensions_count);
 	}
 
 	data->memory.free(data->memory.user_data, data->images);
@@ -1563,9 +1682,15 @@ void cgltf_free(cgltf_data* data)
 	for (cgltf_size i = 0; i < data->textures_count; ++i)
 	{
 		data->memory.free(data->memory.user_data, data->textures[i].name);
+		cgltf_free_extensions(data, data->textures[i].extensions, data->textures[i].extensions_count);
 	}
 
 	data->memory.free(data->memory.user_data, data->textures);
+
+	for (cgltf_size i = 0; i < data->samplers_count; ++i)
+	{
+		cgltf_free_extensions(data, data->samplers[i].extensions, data->samplers[i].extensions_count);
+	}
 
 	data->memory.free(data->memory.user_data, data->samplers);
 
@@ -1573,6 +1698,8 @@ void cgltf_free(cgltf_data* data)
 	{
 		data->memory.free(data->memory.user_data, data->skins[i].name);
 		data->memory.free(data->memory.user_data, data->skins[i].joints);
+
+		cgltf_free_extensions(data, data->skins[i].extensions, data->skins[i].extensions_count);
 	}
 
 	data->memory.free(data->memory.user_data, data->skins);
@@ -1580,6 +1707,7 @@ void cgltf_free(cgltf_data* data)
 	for (cgltf_size i = 0; i < data->cameras_count; ++i)
 	{
 		data->memory.free(data->memory.user_data, data->cameras[i].name);
+		cgltf_free_extensions(data, data->cameras[i].extensions, data->cameras[i].extensions_count);
 	}
 
 	data->memory.free(data->memory.user_data, data->cameras);
@@ -1596,6 +1724,7 @@ void cgltf_free(cgltf_data* data)
 		data->memory.free(data->memory.user_data, data->nodes[i].name);
 		data->memory.free(data->memory.user_data, data->nodes[i].children);
 		data->memory.free(data->memory.user_data, data->nodes[i].weights);
+		cgltf_free_extensions(data, data->nodes[i].extensions, data->nodes[i].extensions_count);
 	}
 
 	data->memory.free(data->memory.user_data, data->nodes);
@@ -1604,6 +1733,8 @@ void cgltf_free(cgltf_data* data)
 	{
 		data->memory.free(data->memory.user_data, data->scenes[i].name);
 		data->memory.free(data->memory.user_data, data->scenes[i].nodes);
+
+		cgltf_free_extensions(data, data->scenes[i].extensions, data->scenes[i].extensions_count);
 	}
 
 	data->memory.free(data->memory.user_data, data->scenes);
@@ -1611,11 +1742,24 @@ void cgltf_free(cgltf_data* data)
 	for (cgltf_size i = 0; i < data->animations_count; ++i)
 	{
 		data->memory.free(data->memory.user_data, data->animations[i].name);
+		for (cgltf_size j = 0; j <  data->animations[i].samplers_count; ++j)
+		{
+			cgltf_free_extensions(data, data->animations[i].samplers[j].extensions, data->animations[i].samplers[j].extensions_count);
+		}
 		data->memory.free(data->memory.user_data, data->animations[i].samplers);
+
+		for (cgltf_size j = 0; j <  data->animations[i].channels_count; ++j)
+		{
+			cgltf_free_extensions(data, data->animations[i].channels[j].extensions, data->animations[i].channels[j].extensions_count);
+		}
 		data->memory.free(data->memory.user_data, data->animations[i].channels);
+
+		cgltf_free_extensions(data, data->animations[i].extensions, data->animations[i].extensions_count);
 	}
 
 	data->memory.free(data->memory.user_data, data->animations);
+
+	cgltf_free_extensions(data, data->data_extensions, data->data_extensions_count);
 
 	for (cgltf_size i = 0; i < data->extensions_used_count; ++i)
 	{
@@ -2241,6 +2385,77 @@ static int cgltf_parse_json_extras(jsmntok_t const* tokens, int i, const uint8_t
 	return i;
 }
 
+static int cgltf_parse_json_unprocessed_extension(cgltf_options* options, jsmntok_t const* tokens, int i, const uint8_t* json_chunk, cgltf_extension* out_extension)
+{
+	CGLTF_CHECK_TOKTYPE(tokens[i], JSMN_STRING);
+	CGLTF_CHECK_TOKTYPE(tokens[i+1], JSMN_OBJECT);
+	if (out_extension->name)
+	{
+		return CGLTF_ERROR_JSON;
+	}
+
+	cgltf_size name_length = tokens[i].end - tokens[i].start;
+	out_extension->name = (char*)options->memory.alloc(options->memory.user_data, name_length + 1);
+	if (!out_extension->name)
+	{
+		return CGLTF_ERROR_NOMEM;
+	}
+	strncpy(out_extension->name, (const char*)json_chunk + tokens[i].start, name_length);
+	out_extension->name[name_length] = 0;
+	i++;
+
+	size_t start = tokens[i].start;
+	size_t size = tokens[i].end - start;
+	out_extension->data = (char*)options->memory.alloc(options->memory.user_data, size + 1);
+	if (!out_extension->data)
+	{
+		return CGLTF_ERROR_NOMEM;
+	}
+	strncpy(out_extension->data, (const char*)json_chunk + start, size);
+	out_extension->data[size] = '\0';
+
+	i = cgltf_skip_json(tokens, i);
+
+	return i;
+}
+
+static int cgltf_parse_json_unprocessed_extensions(cgltf_options* options, jsmntok_t const* tokens, int i, const uint8_t* json_chunk, cgltf_size* out_extensions_count, cgltf_extension** out_extensions)
+{
+	++i;
+
+	CGLTF_CHECK_TOKTYPE(tokens[i], JSMN_OBJECT);
+	if(*out_extensions)
+	{
+		return CGLTF_ERROR_JSON;
+	}
+
+	int extensions_size = tokens[i].size;
+	*out_extensions_count = 0;
+	*out_extensions = (cgltf_extension*)cgltf_calloc(options, sizeof(cgltf_extension), extensions_size);
+
+	if (!*out_extensions)
+	{
+		return CGLTF_ERROR_NOMEM;
+	}
+
+	++i;
+
+	for (int j = 0; j < extensions_size; ++j)
+	{
+		CGLTF_CHECK_KEY(tokens[i]);
+
+		cgltf_size extension_index = (*out_extensions_count)++;
+		cgltf_extension* extension = &((*out_extensions)[extension_index]);
+		i = cgltf_parse_json_unprocessed_extension(options, tokens, i, json_chunk, extension);
+
+		if (i < 0)
+		{
+			return i;
+		}
+	}
+	return i;
+}
+
 static int cgltf_parse_json_draco_mesh_compression(cgltf_options* options, jsmntok_t const* tokens, int i, const uint8_t* json_chunk, cgltf_draco_mesh_compression* out_draco_mesh_compression)
 {
 	CGLTF_CHECK_TOKTYPE(tokens[i], JSMN_OBJECT);
@@ -2330,10 +2545,21 @@ static int cgltf_parse_json_primitive(cgltf_options* options, jsmntok_t const* t
 			++i;
 
 			CGLTF_CHECK_TOKTYPE(tokens[i], JSMN_OBJECT);
+			if(out_prim->extensions)
+			{
+				return CGLTF_ERROR_JSON;
+			}
 
 			int extensions_size = tokens[i].size;
-			++i;
+			out_prim->extensions_count = 0;
+			out_prim->extensions = (cgltf_extension*)cgltf_calloc(options, sizeof(cgltf_extension), extensions_size);
 
+			if (!out_prim->extensions)
+			{
+				return CGLTF_ERROR_NOMEM;
+			}
+
+			++i;
 			for (int k = 0; k < extensions_size; ++k)
 			{
 				CGLTF_CHECK_KEY(tokens[i]);
@@ -2345,7 +2571,7 @@ static int cgltf_parse_json_primitive(cgltf_options* options, jsmntok_t const* t
 				}
 				else
 				{
-					i = cgltf_skip_json(tokens, i+1);
+					i = cgltf_parse_json_unprocessed_extension(options, tokens, i, json_chunk, &(out_prim->extensions[out_prim->extensions_count++]));
 				}
 
 				if (i < 0)
@@ -2446,6 +2672,10 @@ static int cgltf_parse_json_mesh(cgltf_options* options, jsmntok_t const* tokens
 				i = cgltf_skip_json(tokens, i);
 			}
 		}
+		else if (cgltf_json_strcmp(tokens + i, json_chunk, "extensions") == 0)
+		{
+			i = cgltf_parse_json_unprocessed_extensions(options, tokens, i, json_chunk, &out_mesh->extensions_count, &out_mesh->extensions);
+		}
 		else
 		{
 			i = cgltf_skip_json(tokens, i+1);
@@ -2502,7 +2732,7 @@ static cgltf_component_type cgltf_json_to_component_type(jsmntok_t const* tok, c
 	}
 }
 
-static int cgltf_parse_json_accessor_sparse(jsmntok_t const* tokens, int i, const uint8_t* json_chunk, cgltf_accessor_sparse* out_sparse)
+static int cgltf_parse_json_accessor_sparse(cgltf_options* options, jsmntok_t const* tokens, int i, const uint8_t* json_chunk, cgltf_accessor_sparse* out_sparse)
 {
 	CGLTF_CHECK_TOKTYPE(tokens[i], JSMN_OBJECT);
 
@@ -2553,6 +2783,10 @@ static int cgltf_parse_json_accessor_sparse(jsmntok_t const* tokens, int i, cons
 				{
 					i = cgltf_parse_json_extras(tokens, i + 1, json_chunk, &out_sparse->indices_extras);
 				}
+				else if (cgltf_json_strcmp(tokens + i, json_chunk, "extensions") == 0)
+				{
+					i = cgltf_parse_json_unprocessed_extensions(options, tokens, i, json_chunk, &out_sparse->indices_extensions_count, &out_sparse->indices_extensions);
+				}
 				else
 				{
 					i = cgltf_skip_json(tokens, i+1);
@@ -2592,6 +2826,10 @@ static int cgltf_parse_json_accessor_sparse(jsmntok_t const* tokens, int i, cons
 				{
 					i = cgltf_parse_json_extras(tokens, i + 1, json_chunk, &out_sparse->values_extras);
 				}
+				else if (cgltf_json_strcmp(tokens + i, json_chunk, "extensions") == 0)
+				{
+					i = cgltf_parse_json_unprocessed_extensions(options, tokens, i, json_chunk, &out_sparse->values_extensions_count, &out_sparse->values_extensions);
+				}
 				else
 				{
 					i = cgltf_skip_json(tokens, i+1);
@@ -2607,6 +2845,10 @@ static int cgltf_parse_json_accessor_sparse(jsmntok_t const* tokens, int i, cons
 		{
 			i = cgltf_parse_json_extras(tokens, i + 1, json_chunk, &out_sparse->extras);
 		}
+		else if (cgltf_json_strcmp(tokens + i, json_chunk, "extensions") == 0)
+		{
+			i = cgltf_parse_json_unprocessed_extensions(options, tokens, i, json_chunk, &out_sparse->extensions_count, &out_sparse->extensions);
+		}
 		else
 		{
 			i = cgltf_skip_json(tokens, i+1);
@@ -2621,7 +2863,7 @@ static int cgltf_parse_json_accessor_sparse(jsmntok_t const* tokens, int i, cons
 	return i;
 }
 
-static int cgltf_parse_json_accessor(jsmntok_t const* tokens, int i, const uint8_t* json_chunk, cgltf_accessor* out_accessor)
+static int cgltf_parse_json_accessor(cgltf_options* options, jsmntok_t const* tokens, int i, const uint8_t* json_chunk, cgltf_accessor* out_accessor)
 {
 	CGLTF_CHECK_TOKTYPE(tokens[i], JSMN_OBJECT);
 
@@ -2716,11 +2958,15 @@ static int cgltf_parse_json_accessor(jsmntok_t const* tokens, int i, const uint8
 		else if (cgltf_json_strcmp(tokens + i, json_chunk, "sparse") == 0)
 		{
 			out_accessor->is_sparse = 1;
-			i = cgltf_parse_json_accessor_sparse(tokens, i + 1, json_chunk, &out_accessor->sparse);
+			i = cgltf_parse_json_accessor_sparse(options, tokens, i + 1, json_chunk, &out_accessor->sparse);
 		}
 		else if (cgltf_json_strcmp(tokens + i, json_chunk, "extras") == 0)
 		{
 			i = cgltf_parse_json_extras(tokens, i + 1, json_chunk, &out_accessor->extras);
+		}
+		else if (cgltf_json_strcmp(tokens + i, json_chunk, "extensions") == 0)
+		{
+			i = cgltf_parse_json_unprocessed_extensions(options, tokens, i, json_chunk, &out_accessor->extensions_count, &out_accessor->extensions);
 		}
 		else
 		{
@@ -2781,7 +3027,7 @@ static int cgltf_parse_json_texture_transform(jsmntok_t const* tokens, int i, co
 	return i;
 }
 
-static int cgltf_parse_json_texture_view(jsmntok_t const* tokens, int i, const uint8_t* json_chunk, cgltf_texture_view* out_texture_view)
+static int cgltf_parse_json_texture_view(cgltf_options* options, jsmntok_t const* tokens, int i, const uint8_t* json_chunk, cgltf_texture_view* out_texture_view)
 {
 	CGLTF_CHECK_TOKTYPE(tokens[i], JSMN_OBJECT);
 
@@ -2828,8 +3074,20 @@ static int cgltf_parse_json_texture_view(jsmntok_t const* tokens, int i, const u
 			++i;
 
 			CGLTF_CHECK_TOKTYPE(tokens[i], JSMN_OBJECT);
+			if(out_texture_view->extensions)
+			{
+				return CGLTF_ERROR_JSON;
+			}
 
 			int extensions_size = tokens[i].size;
+			out_texture_view->extensions_count = 0;
+			out_texture_view->extensions = (cgltf_extension*)cgltf_calloc(options, sizeof(cgltf_extension), extensions_size);
+
+			if (!out_texture_view->extensions)
+			{
+				return CGLTF_ERROR_NOMEM;
+			}
+
 			++i;
 
 			for (int k = 0; k < extensions_size; ++k)
@@ -2843,7 +3101,7 @@ static int cgltf_parse_json_texture_view(jsmntok_t const* tokens, int i, const u
 				}
 				else
 				{
-					i = cgltf_skip_json(tokens, i+1);
+					i = cgltf_parse_json_unprocessed_extension(options, tokens, i, json_chunk, &(out_texture_view->extensions[out_texture_view->extensions_count++]));
 				}
 
 				if (i < 0)
@@ -2866,7 +3124,7 @@ static int cgltf_parse_json_texture_view(jsmntok_t const* tokens, int i, const u
 	return i;
 }
 
-static int cgltf_parse_json_pbr_metallic_roughness(jsmntok_t const* tokens, int i, const uint8_t* json_chunk, cgltf_pbr_metallic_roughness* out_pbr)
+static int cgltf_parse_json_pbr_metallic_roughness(cgltf_options* options, jsmntok_t const* tokens, int i, const uint8_t* json_chunk, cgltf_pbr_metallic_roughness* out_pbr)
 {
 	CGLTF_CHECK_TOKTYPE(tokens[i], JSMN_OBJECT);
 
@@ -2897,12 +3155,12 @@ static int cgltf_parse_json_pbr_metallic_roughness(jsmntok_t const* tokens, int 
 		}
 		else if (cgltf_json_strcmp(tokens+i, json_chunk, "baseColorTexture") == 0)
 		{
-			i = cgltf_parse_json_texture_view(tokens, i + 1, json_chunk,
+			i = cgltf_parse_json_texture_view(options, tokens, i + 1, json_chunk,
 				&out_pbr->base_color_texture);
 		}
 		else if (cgltf_json_strcmp(tokens + i, json_chunk, "metallicRoughnessTexture") == 0)
 		{
-			i = cgltf_parse_json_texture_view(tokens, i + 1, json_chunk,
+			i = cgltf_parse_json_texture_view(options, tokens, i + 1, json_chunk,
 				&out_pbr->metallic_roughness_texture);
 		}
 		else if (cgltf_json_strcmp(tokens + i, json_chunk, "extras") == 0)
@@ -2923,7 +3181,7 @@ static int cgltf_parse_json_pbr_metallic_roughness(jsmntok_t const* tokens, int 
 	return i;
 }
 
-static int cgltf_parse_json_pbr_specular_glossiness(jsmntok_t const* tokens, int i, const uint8_t* json_chunk, cgltf_pbr_specular_glossiness* out_pbr)
+static int cgltf_parse_json_pbr_specular_glossiness(cgltf_options* options, jsmntok_t const* tokens, int i, const uint8_t* json_chunk, cgltf_pbr_specular_glossiness* out_pbr)
 {
 	CGLTF_CHECK_TOKTYPE(tokens[i], JSMN_OBJECT);
 	int size = tokens[i].size;
@@ -2949,11 +3207,11 @@ static int cgltf_parse_json_pbr_specular_glossiness(jsmntok_t const* tokens, int
 		}
 		else if (cgltf_json_strcmp(tokens+i, json_chunk, "diffuseTexture") == 0)
 		{
-			i = cgltf_parse_json_texture_view(tokens, i + 1, json_chunk, &out_pbr->diffuse_texture);
+			i = cgltf_parse_json_texture_view(options, tokens, i + 1, json_chunk, &out_pbr->diffuse_texture);
 		}
 		else if (cgltf_json_strcmp(tokens+i, json_chunk, "specularGlossinessTexture") == 0)
 		{
-			i = cgltf_parse_json_texture_view(tokens, i + 1, json_chunk, &out_pbr->specular_glossiness_texture);
+			i = cgltf_parse_json_texture_view(options, tokens, i + 1, json_chunk, &out_pbr->specular_glossiness_texture);
 		}
 		else
 		{
@@ -2969,7 +3227,7 @@ static int cgltf_parse_json_pbr_specular_glossiness(jsmntok_t const* tokens, int
 	return i;
 }
 
-static int cgltf_parse_json_clearcoat(jsmntok_t const* tokens, int i, const uint8_t* json_chunk, cgltf_clearcoat* out_clearcoat)
+static int cgltf_parse_json_clearcoat(cgltf_options* options, jsmntok_t const* tokens, int i, const uint8_t* json_chunk, cgltf_clearcoat* out_clearcoat)
 {
 	CGLTF_CHECK_TOKTYPE(tokens[i], JSMN_OBJECT);
 	int size = tokens[i].size;
@@ -2993,15 +3251,49 @@ static int cgltf_parse_json_clearcoat(jsmntok_t const* tokens, int i, const uint
 		}
 		else if (cgltf_json_strcmp(tokens+i, json_chunk, "clearcoatTexture") == 0)
 		{
-			i = cgltf_parse_json_texture_view(tokens, i + 1, json_chunk, &out_clearcoat->clearcoat_texture);
+			i = cgltf_parse_json_texture_view(options, tokens, i + 1, json_chunk, &out_clearcoat->clearcoat_texture);
 		}
 		else if (cgltf_json_strcmp(tokens+i, json_chunk, "clearcoatRoughnessTexture") == 0)
 		{
-			i = cgltf_parse_json_texture_view(tokens, i + 1, json_chunk, &out_clearcoat->clearcoat_roughness_texture);
+			i = cgltf_parse_json_texture_view(options, tokens, i + 1, json_chunk, &out_clearcoat->clearcoat_roughness_texture);
 		}
 		else if (cgltf_json_strcmp(tokens+i, json_chunk, "clearcoatNormalTexture") == 0)
 		{
-			i = cgltf_parse_json_texture_view(tokens, i + 1, json_chunk, &out_clearcoat->clearcoat_normal_texture);
+			i = cgltf_parse_json_texture_view(options, tokens, i + 1, json_chunk, &out_clearcoat->clearcoat_normal_texture);
+		}
+		else
+		{
+			i = cgltf_skip_json(tokens, i+1);
+		}
+
+		if (i < 0)
+		{
+			return i;
+		}
+	}
+
+	return i;
+}
+
+static int cgltf_parse_json_transmission(cgltf_options* options, jsmntok_t const* tokens, int i, const uint8_t* json_chunk, cgltf_transmission* out_transmission)
+{
+	CGLTF_CHECK_TOKTYPE(tokens[i], JSMN_OBJECT);
+	int size = tokens[i].size;
+	++i;
+
+	for (int j = 0; j < size; ++j)
+	{
+		CGLTF_CHECK_KEY(tokens[i]);
+
+		if (cgltf_json_strcmp(tokens+i, json_chunk, "transmissionFactor") == 0)
+		{
+			++i;
+			out_transmission->transmission_factor = cgltf_json_to_float(tokens + i, json_chunk);
+			++i;
+		}
+		else if (cgltf_json_strcmp(tokens+i, json_chunk, "transmissionTexture") == 0)
+		{
+			i = cgltf_parse_json_texture_view(options, tokens, i + 1, json_chunk, &out_transmission->transmission_texture);
 		}
 		else
 		{
@@ -3049,6 +3341,10 @@ static int cgltf_parse_json_image(cgltf_options* options, jsmntok_t const* token
 		else if (cgltf_json_strcmp(tokens + i, json_chunk, "extras") == 0)
 		{
 			i = cgltf_parse_json_extras(tokens, i + 1, json_chunk, &out_image->extras);
+		}
+		else if (cgltf_json_strcmp(tokens + i, json_chunk, "extensions") == 0)
+		{
+			i = cgltf_parse_json_unprocessed_extensions(options, tokens, i, json_chunk, &out_image->extensions_count, &out_image->extensions);
 		}
 		else
 		{
@@ -3111,6 +3407,10 @@ static int cgltf_parse_json_sampler(cgltf_options* options, jsmntok_t const* tok
 		{
 			i = cgltf_parse_json_extras(tokens, i + 1, json_chunk, &out_sampler->extras);
 		}
+		else if (cgltf_json_strcmp(tokens + i, json_chunk, "extensions") == 0)
+		{
+			i = cgltf_parse_json_unprocessed_extensions(options, tokens, i, json_chunk, &out_sampler->extensions_count, &out_sampler->extensions);
+		}
 		else
 		{
 			i = cgltf_skip_json(tokens, i + 1);
@@ -3124,7 +3424,6 @@ static int cgltf_parse_json_sampler(cgltf_options* options, jsmntok_t const* tok
 
 	return i;
 }
-
 
 static int cgltf_parse_json_texture(cgltf_options* options, jsmntok_t const* tokens, int i, const uint8_t* json_chunk, cgltf_texture* out_texture)
 {
@@ -3156,6 +3455,10 @@ static int cgltf_parse_json_texture(cgltf_options* options, jsmntok_t const* tok
 		else if (cgltf_json_strcmp(tokens + i, json_chunk, "extras") == 0)
 		{
 			i = cgltf_parse_json_extras(tokens, i + 1, json_chunk, &out_texture->extras);
+		}
+		else if (cgltf_json_strcmp(tokens + i, json_chunk, "extensions") == 0)
+		{
+			i = cgltf_parse_json_unprocessed_extensions(options, tokens, i, json_chunk, &out_texture->extensions_count, &out_texture->extensions);
 		}
 		else
 		{
@@ -3199,7 +3502,7 @@ static int cgltf_parse_json_material(cgltf_options* options, jsmntok_t const* to
 		else if (cgltf_json_strcmp(tokens+i, json_chunk, "pbrMetallicRoughness") == 0)
 		{
 			out_material->has_pbr_metallic_roughness = 1;
-			i = cgltf_parse_json_pbr_metallic_roughness(tokens, i + 1, json_chunk, &out_material->pbr_metallic_roughness);
+			i = cgltf_parse_json_pbr_metallic_roughness(options, tokens, i + 1, json_chunk, &out_material->pbr_metallic_roughness);
 		}
 		else if (cgltf_json_strcmp(tokens+i, json_chunk, "emissiveFactor") == 0)
 		{
@@ -3207,17 +3510,17 @@ static int cgltf_parse_json_material(cgltf_options* options, jsmntok_t const* to
 		}
 		else if (cgltf_json_strcmp(tokens + i, json_chunk, "normalTexture") == 0)
 		{
-			i = cgltf_parse_json_texture_view(tokens, i + 1, json_chunk,
+			i = cgltf_parse_json_texture_view(options, tokens, i + 1, json_chunk,
 				&out_material->normal_texture);
 		}
 		else if (cgltf_json_strcmp(tokens + i, json_chunk, "occlusionTexture") == 0)
 		{
-			i = cgltf_parse_json_texture_view(tokens, i + 1, json_chunk,
+			i = cgltf_parse_json_texture_view(options, tokens, i + 1, json_chunk,
 				&out_material->occlusion_texture);
 		}
 		else if (cgltf_json_strcmp(tokens + i, json_chunk, "emissiveTexture") == 0)
 		{
-			i = cgltf_parse_json_texture_view(tokens, i + 1, json_chunk,
+			i = cgltf_parse_json_texture_view(options, tokens, i + 1, json_chunk,
 				&out_material->emissive_texture);
 		}
 		else if (cgltf_json_strcmp(tokens + i, json_chunk, "alphaMode") == 0)
@@ -3259,9 +3562,20 @@ static int cgltf_parse_json_material(cgltf_options* options, jsmntok_t const* to
 			++i;
 
 			CGLTF_CHECK_TOKTYPE(tokens[i], JSMN_OBJECT);
+			if(out_material->extensions)
+			{
+				return CGLTF_ERROR_JSON;
+			}
 
 			int extensions_size = tokens[i].size;
 			++i;
+			out_material->extensions = (cgltf_extension*)cgltf_calloc(options, sizeof(cgltf_extension), extensions_size);
+			out_material->extensions_count= 0;
+
+			if (!out_material->extensions)
+			{
+				return CGLTF_ERROR_NOMEM;
+			}
 
 			for (int k = 0; k < extensions_size; ++k)
 			{
@@ -3270,7 +3584,7 @@ static int cgltf_parse_json_material(cgltf_options* options, jsmntok_t const* to
 				if (cgltf_json_strcmp(tokens+i, json_chunk, "KHR_materials_pbrSpecularGlossiness") == 0)
 				{
 					out_material->has_pbr_specular_glossiness = 1;
-					i = cgltf_parse_json_pbr_specular_glossiness(tokens, i + 1, json_chunk, &out_material->pbr_specular_glossiness);
+					i = cgltf_parse_json_pbr_specular_glossiness(options, tokens, i + 1, json_chunk, &out_material->pbr_specular_glossiness);
 				}
 				else if (cgltf_json_strcmp(tokens+i, json_chunk, "KHR_materials_unlit") == 0)
 				{
@@ -3280,11 +3594,16 @@ static int cgltf_parse_json_material(cgltf_options* options, jsmntok_t const* to
 				else if (cgltf_json_strcmp(tokens+i, json_chunk, "KHR_materials_clearcoat") == 0)
 				{
 					out_material->has_clearcoat = 1;
-					i = cgltf_parse_json_clearcoat(tokens, i + 1, json_chunk, &out_material->clearcoat);
+					i = cgltf_parse_json_clearcoat(options, tokens, i + 1, json_chunk, &out_material->clearcoat);
+				}
+				else if (cgltf_json_strcmp(tokens+i, json_chunk, "KHR_materials_transmission") == 0)
+				{
+					out_material->has_transmission = 1;
+					i = cgltf_parse_json_transmission(options, tokens, i + 1, json_chunk, &out_material->transmission);
 				}
 				else
 				{
-					i = cgltf_skip_json(tokens, i+1);
+					i = cgltf_parse_json_unprocessed_extension(options, tokens, i, json_chunk, &(out_material->extensions[out_material->extensions_count++]));
 				}
 
 				if (i < 0)
@@ -3317,7 +3636,7 @@ static int cgltf_parse_json_accessors(cgltf_options* options, jsmntok_t const* t
 
 	for (cgltf_size j = 0; j < out_data->accessors_count; ++j)
 	{
-		i = cgltf_parse_json_accessor(tokens, i, json_chunk, &out_data->accessors[j]);
+		i = cgltf_parse_json_accessor(options, tokens, i, json_chunk, &out_data->accessors[j]);
 		if (i < 0)
 		{
 			return i;
@@ -3402,7 +3721,7 @@ static int cgltf_parse_json_samplers(cgltf_options* options, jsmntok_t const* to
 	return i;
 }
 
-static int cgltf_parse_json_buffer_view(jsmntok_t const* tokens, int i, const uint8_t* json_chunk, cgltf_buffer_view* out_buffer_view)
+static int cgltf_parse_json_buffer_view(cgltf_options* options, jsmntok_t const* tokens, int i, const uint8_t* json_chunk, cgltf_buffer_view* out_buffer_view)
 {
 	CGLTF_CHECK_TOKTYPE(tokens[i], JSMN_OBJECT);
 
@@ -3463,6 +3782,10 @@ static int cgltf_parse_json_buffer_view(jsmntok_t const* tokens, int i, const ui
 		{
 			i = cgltf_parse_json_extras(tokens, i + 1, json_chunk, &out_buffer_view->extras);
 		}
+		else if (cgltf_json_strcmp(tokens + i, json_chunk, "extensions") == 0)
+		{
+			i = cgltf_parse_json_unprocessed_extensions(options, tokens, i, json_chunk, &out_buffer_view->extensions_count, &out_buffer_view->extensions);
+		}
 		else
 		{
 			i = cgltf_skip_json(tokens, i+1);
@@ -3487,7 +3810,7 @@ static int cgltf_parse_json_buffer_views(cgltf_options* options, jsmntok_t const
 
 	for (cgltf_size j = 0; j < out_data->buffer_views_count; ++j)
 	{
-		i = cgltf_parse_json_buffer_view(tokens, i, json_chunk, &out_data->buffer_views[j]);
+		i = cgltf_parse_json_buffer_view(options, tokens, i, json_chunk, &out_data->buffer_views[j]);
 		if (i < 0)
 		{
 			return i;
@@ -3521,6 +3844,10 @@ static int cgltf_parse_json_buffer(cgltf_options* options, jsmntok_t const* toke
 		else if (cgltf_json_strcmp(tokens + i, json_chunk, "extras") == 0)
 		{
 			i = cgltf_parse_json_extras(tokens, i + 1, json_chunk, &out_buffer->extras);
+		}
+		else if (cgltf_json_strcmp(tokens + i, json_chunk, "extensions") == 0)
+		{
+			i = cgltf_parse_json_unprocessed_extensions(options, tokens, i, json_chunk, &out_buffer->extensions_count, &out_buffer->extensions);
 		}
 		else
 		{
@@ -3601,6 +3928,10 @@ static int cgltf_parse_json_skin(cgltf_options* options, jsmntok_t const* tokens
 		else if (cgltf_json_strcmp(tokens + i, json_chunk, "extras") == 0)
 		{
 			i = cgltf_parse_json_extras(tokens, i + 1, json_chunk, &out_skin->extras);
+		}
+		else if (cgltf_json_strcmp(tokens + i, json_chunk, "extensions") == 0)
+		{
+			i = cgltf_parse_json_unprocessed_extensions(options, tokens, i, json_chunk, &out_skin->extensions_count, &out_skin->extensions);
 		}
 		else
 		{
@@ -3774,6 +4105,10 @@ static int cgltf_parse_json_camera(cgltf_options* options, jsmntok_t const* toke
 		else if (cgltf_json_strcmp(tokens + i, json_chunk, "extras") == 0)
 		{
 			i = cgltf_parse_json_extras(tokens, i + 1, json_chunk, &out_camera->extras);
+		}
+		else if (cgltf_json_strcmp(tokens + i, json_chunk, "extensions") == 0)
+		{
+			i = cgltf_parse_json_unprocessed_extensions(options, tokens, i, json_chunk, &out_camera->extensions_count, &out_camera->extensions);
 		}
 		else
 		{
@@ -4023,8 +4358,20 @@ static int cgltf_parse_json_node(cgltf_options* options, jsmntok_t const* tokens
 			++i;
 
 			CGLTF_CHECK_TOKTYPE(tokens[i], JSMN_OBJECT);
+			if(out_node->extensions)
+			{
+				return CGLTF_ERROR_JSON;
+			}
 
 			int extensions_size = tokens[i].size;
+			out_node->extensions_count= 0;
+			out_node->extensions = (cgltf_extension*)cgltf_calloc(options, sizeof(cgltf_extension), extensions_size);
+
+			if (!out_node->extensions)
+			{
+				return CGLTF_ERROR_NOMEM;
+			}
+
 			++i;
 
 			for (int k = 0; k < extensions_size; ++k)
@@ -4064,7 +4411,7 @@ static int cgltf_parse_json_node(cgltf_options* options, jsmntok_t const* tokens
 				}
 				else
 				{
-					i = cgltf_skip_json(tokens, i+1);
+					i = cgltf_parse_json_unprocessed_extension(options, tokens, i, json_chunk, &(out_node->extensions[out_node->extensions_count++]));
 				}
 
 				if (i < 0)
@@ -4138,6 +4485,10 @@ static int cgltf_parse_json_scene(cgltf_options* options, jsmntok_t const* token
 		else if (cgltf_json_strcmp(tokens + i, json_chunk, "extras") == 0)
 		{
 			i = cgltf_parse_json_extras(tokens, i + 1, json_chunk, &out_scene->extras);
+		}
+		else if (cgltf_json_strcmp(tokens + i, json_chunk, "extensions") == 0)
+		{
+			i = cgltf_parse_json_unprocessed_extensions(options, tokens, i, json_chunk, &out_scene->extensions_count, &out_scene->extensions);
 		}
 		else
 		{
@@ -4217,6 +4568,10 @@ static int cgltf_parse_json_animation_sampler(cgltf_options* options, jsmntok_t 
 		{
 			i = cgltf_parse_json_extras(tokens, i + 1, json_chunk, &out_sampler->extras);
 		}
+		else if (cgltf_json_strcmp(tokens + i, json_chunk, "extensions") == 0)
+		{
+			i = cgltf_parse_json_unprocessed_extensions(options, tokens, i, json_chunk, &out_sampler->extensions_count, &out_sampler->extensions);
+		}
 		else
 		{
 			i = cgltf_skip_json(tokens, i+1);
@@ -4292,6 +4647,10 @@ static int cgltf_parse_json_animation_channel(cgltf_options* options, jsmntok_t 
 				else if (cgltf_json_strcmp(tokens + i, json_chunk, "extras") == 0)
 				{
 					i = cgltf_parse_json_extras(tokens, i + 1, json_chunk, &out_channel->extras);
+				}
+				else if (cgltf_json_strcmp(tokens + i, json_chunk, "extensions") == 0)
+				{
+					i = cgltf_parse_json_unprocessed_extensions(options, tokens, i, json_chunk, &out_channel->extensions_count, &out_channel->extensions);
 				}
 				else
 				{
@@ -4371,6 +4730,10 @@ static int cgltf_parse_json_animation(cgltf_options* options, jsmntok_t const* t
 		{
 			i = cgltf_parse_json_extras(tokens, i + 1, json_chunk, &out_animation->extras);
 		}
+		else if (cgltf_json_strcmp(tokens + i, json_chunk, "extensions") == 0)
+		{
+			i = cgltf_parse_json_unprocessed_extensions(options, tokens, i, json_chunk, &out_animation->extensions_count, &out_animation->extensions);
+		}
 		else
 		{
 			i = cgltf_skip_json(tokens, i+1);
@@ -4434,6 +4797,10 @@ static int cgltf_parse_json_asset(cgltf_options* options, jsmntok_t const* token
 		else if (cgltf_json_strcmp(tokens + i, json_chunk, "extras") == 0)
 		{
 			i = cgltf_parse_json_extras(tokens, i + 1, json_chunk, &out_asset->extras);
+		}
+		else if (cgltf_json_strcmp(tokens + i, json_chunk, "extensions") == 0)
+		{
+			i = cgltf_parse_json_unprocessed_extensions(options, tokens, i, json_chunk, &out_asset->extensions_count, &out_asset->extensions);
 		}
 		else
 		{
@@ -4592,8 +4959,20 @@ static int cgltf_parse_json_root(cgltf_options* options, jsmntok_t const* tokens
 			++i;
 
 			CGLTF_CHECK_TOKTYPE(tokens[i], JSMN_OBJECT);
+			if(out_data->data_extensions)
+			{
+				return CGLTF_ERROR_JSON;
+			}
 
 			int extensions_size = tokens[i].size;
+			out_data->data_extensions_count = 0;
+			out_data->data_extensions = (cgltf_extension*)cgltf_calloc(options, sizeof(cgltf_extension), extensions_size);
+
+			if (!out_data->data_extensions)
+			{
+				return CGLTF_ERROR_NOMEM;
+			}
+
 			++i;
 
 			for (int k = 0; k < extensions_size; ++k)
@@ -4630,7 +5009,7 @@ static int cgltf_parse_json_root(cgltf_options* options, jsmntok_t const* tokens
 				}
 				else
 				{
-					i = cgltf_skip_json(tokens, i + 1);
+					i = cgltf_parse_json_unprocessed_extension(options, tokens, i, json_chunk, &(out_data->data_extensions[out_data->data_extensions_count++]));
 				}
 
 				if (i < 0)
@@ -4820,6 +5199,8 @@ static int cgltf_fixup_pointers(cgltf_data* data)
 		CGLTF_PTRFIXUP(data->materials[i].clearcoat.clearcoat_texture.texture, data->textures, data->textures_count);
 		CGLTF_PTRFIXUP(data->materials[i].clearcoat.clearcoat_roughness_texture.texture, data->textures, data->textures_count);
 		CGLTF_PTRFIXUP(data->materials[i].clearcoat.clearcoat_normal_texture.texture, data->textures, data->textures_count);
+
+		CGLTF_PTRFIXUP(data->materials[i].transmission.transmission_texture.texture, data->textures, data->textures_count);
 	}
 
 	for (cgltf_size i = 0; i < data->buffer_views_count; ++i)

--- a/gltf/gltfpack.cpp
+++ b/gltf/gltfpack.cpp
@@ -299,6 +299,7 @@ static void process(cgltf_data* data, const char* input_path, const char* output
 
 	bool ext_pbr_specular_glossiness = false;
 	bool ext_clearcoat = false;
+	bool ext_transmission = false;
 	bool ext_unlit = false;
 	bool ext_instancing = false;
 
@@ -356,6 +357,7 @@ static void process(cgltf_data* data, const char* input_path, const char* output
 
 		ext_pbr_specular_glossiness = ext_pbr_specular_glossiness || material.has_pbr_specular_glossiness;
 		ext_clearcoat = ext_clearcoat || material.has_clearcoat;
+		ext_transmission = ext_transmission || material.has_transmission;
 		ext_unlit = ext_unlit || material.unlit;
 	}
 
@@ -567,6 +569,7 @@ static void process(cgltf_data* data, const char* input_path, const char* output
 	    {"KHR_texture_transform", settings.quantize && !json_textures.empty(), false},
 	    {"KHR_materials_pbrSpecularGlossiness", ext_pbr_specular_glossiness, false},
 	    {"KHR_materials_clearcoat", ext_clearcoat, false},
+	    {"KHR_materials_transmission", ext_transmission, false},
 	    {"KHR_materials_unlit", ext_unlit, false},
 	    {"KHR_lights_punctual", data->lights_count > 0, false},
 	    {"KHR_texture_basisu", !json_textures.empty() && settings.texture_ktx2, true},

--- a/gltf/material.cpp
+++ b/gltf/material.cpp
@@ -109,6 +109,17 @@ static bool areMaterialComponentsEqual(const cgltf_clearcoat& lhs, const cgltf_c
 	return true;
 }
 
+static bool areMaterialComponentsEqual(const cgltf_transmission& lhs, const cgltf_transmission& rhs)
+{
+	if (!areTextureViewsEqual(lhs.transmission_texture, rhs.transmission_texture))
+		return false;
+
+	if (lhs.transmission_factor != rhs.transmission_factor)
+		return false;
+
+	return true;
+}
+
 static bool areMaterialsEqual(cgltf_data* data, const cgltf_material& lhs, const cgltf_material& rhs, const Settings& settings)
 {
 	if (lhs.has_pbr_metallic_roughness != rhs.has_pbr_metallic_roughness)
@@ -127,6 +138,12 @@ static bool areMaterialsEqual(cgltf_data* data, const cgltf_material& lhs, const
 		return false;
 
 	if (lhs.has_clearcoat && !areMaterialComponentsEqual(lhs.clearcoat, rhs.clearcoat))
+		return false;
+
+	if (lhs.has_transmission != rhs.has_transmission)
+		return false;
+
+	if (lhs.has_transmission && !areMaterialComponentsEqual(lhs.transmission, rhs.transmission))
 		return false;
 
 	if (!areTextureViewsEqual(lhs.normal_texture, rhs.normal_texture))
@@ -236,6 +253,22 @@ bool usesTextureSet(const cgltf_material& material, int set)
 			return true;
 
 		if (pbr.specular_glossiness_texture.texture && pbr.specular_glossiness_texture.texcoord == set)
+			return true;
+	}
+
+	if (material.has_clearcoat)
+	{
+		const cgltf_clearcoat& clearcoat = material.clearcoat;
+
+		if (clearcoat.clearcoat_texture.texture && clearcoat.clearcoat_texture.texcoord == set)
+			return true;
+	}
+
+	if (material.has_transmission)
+	{
+		const cgltf_transmission& transmission = material.transmission;
+
+		if (transmission.transmission_texture.texture && transmission.transmission_texture.texcoord == set)
 			return true;
 	}
 

--- a/gltf/material.cpp
+++ b/gltf/material.cpp
@@ -232,53 +232,50 @@ void markNeededMaterials(cgltf_data* data, std::vector<MaterialInfo>& materials,
 	}
 }
 
+static bool usesTextureSet(const cgltf_texture_view& view, int set)
+{
+	return view.texture && view.texcoord == set;
+}
+
 bool usesTextureSet(const cgltf_material& material, int set)
 {
 	if (material.has_pbr_metallic_roughness)
 	{
-		const cgltf_pbr_metallic_roughness& pbr = material.pbr_metallic_roughness;
-
-		if (pbr.base_color_texture.texture && pbr.base_color_texture.texcoord == set)
+		if (usesTextureSet(material.pbr_metallic_roughness.base_color_texture, set))
 			return true;
 
-		if (pbr.metallic_roughness_texture.texture && pbr.metallic_roughness_texture.texcoord == set)
+		if (usesTextureSet(material.pbr_metallic_roughness.metallic_roughness_texture, set))
 			return true;
 	}
 
 	if (material.has_pbr_specular_glossiness)
 	{
-		const cgltf_pbr_specular_glossiness& pbr = material.pbr_specular_glossiness;
-
-		if (pbr.diffuse_texture.texture && pbr.diffuse_texture.texcoord == set)
+		if (usesTextureSet(material.pbr_specular_glossiness.diffuse_texture, set))
 			return true;
 
-		if (pbr.specular_glossiness_texture.texture && pbr.specular_glossiness_texture.texcoord == set)
+		if (usesTextureSet(material.pbr_specular_glossiness.specular_glossiness_texture, set))
 			return true;
 	}
 
 	if (material.has_clearcoat)
 	{
-		const cgltf_clearcoat& clearcoat = material.clearcoat;
-
-		if (clearcoat.clearcoat_texture.texture && clearcoat.clearcoat_texture.texcoord == set)
+		if (usesTextureSet(material.clearcoat.clearcoat_texture, set))
 			return true;
 	}
 
 	if (material.has_transmission)
 	{
-		const cgltf_transmission& transmission = material.transmission;
-
-		if (transmission.transmission_texture.texture && transmission.transmission_texture.texcoord == set)
+		if (usesTextureSet(material.transmission.transmission_texture, set))
 			return true;
 	}
 
-	if (material.normal_texture.texture && material.normal_texture.texcoord == set)
+	if (usesTextureSet(material.normal_texture, set))
 		return true;
 
-	if (material.occlusion_texture.texture && material.occlusion_texture.texcoord == set)
+	if (usesTextureSet(material.occlusion_texture, set))
 		return true;
 
-	if (material.emissive_texture.texture && material.emissive_texture.texcoord == set)
+	if (usesTextureSet(material.emissive_texture, set))
 		return true;
 
 	return false;

--- a/gltf/write.cpp
+++ b/gltf/write.cpp
@@ -343,6 +343,25 @@ static void writeMaterialComponent(std::string& json, const cgltf_data* data, co
 	append(json, "}");
 }
 
+static void writeMaterialComponent(std::string& json, const cgltf_data* data, const cgltf_transmission& tm, const QuantizationTexture* qt)
+{
+	comma(json);
+	append(json, "\"KHR_materials_transmission\":{");
+	if (tm.transmission_texture.texture)
+	{
+		comma(json);
+		append(json, "\"transmissionTexture\":");
+		writeTextureInfo(json, data, tm.transmission_texture, qt);
+	}
+	if (tm.transmission_factor != 0)
+	{
+		comma(json);
+		append(json, "\"transmissionFactor\":");
+		append(json, tm.transmission_factor);
+	}
+	append(json, "}");
+}
+
 void writeMaterial(std::string& json, const cgltf_data* data, const cgltf_material& material, const QuantizationTexture* qt)
 {
 	if (material.name && *material.name)
@@ -412,7 +431,7 @@ void writeMaterial(std::string& json, const cgltf_data* data, const cgltf_materi
 		append(json, "\"doubleSided\":true");
 	}
 
-	if (material.has_pbr_specular_glossiness || material.has_clearcoat || material.unlit)
+	if (material.has_pbr_specular_glossiness || material.has_clearcoat || material.has_transmission || material.unlit)
 	{
 		comma(json);
 		append(json, "\"extensions\":{");
@@ -425,6 +444,11 @@ void writeMaterial(std::string& json, const cgltf_data* data, const cgltf_materi
 		if (material.has_clearcoat)
 		{
 			writeMaterialComponent(json, data, material.clearcoat, qt);
+		}
+
+		if (material.has_transmission)
+		{
+			writeMaterialComponent(json, data, material.transmission, qt);
 		}
 
 		if (material.unlit)


### PR DESCRIPTION
This change simply propagates KHR_materials_transmission parameters
through, supporting material merging as well.

It also fixes a problem with texture set filtering, where we ignored
texture sets that might have only been used in clearcoat layer.

Also contains an unrelated fix to frustum culling in GLTFLoader.js, might as well submit it with this.