### PR TITLE
gltfpack: Implement support for toktx

### DIFF
--- a/gltf/gltfpack.cpp
+++ b/gltf/gltfpack.cpp
@@ -312,12 +312,12 @@ static void process(cgltf_data* data, const char* input_path, const char* output
 	{
 		const cgltf_image& image = data->images[i];
 
-		if (settings.verbose && settings.texture_basis)
+		if (settings.verbose == 1 && settings.texture_basis)
 		{
 			const char* uri = image.uri;
 			bool embedded = !uri || strncmp(uri, "data:", 5) == 0;
 
-			printf("image %d (%s) is being encoded with Basis\n", int(i), embedded ? "embedded" : uri);
+			printf("image %d (%s) is being encoded with %s\n", int(i), embedded ? "embedded" : uri, settings.texture_toktx ? "toktx" : "Basis");
 		}
 
 		comma(json_images);
@@ -721,10 +721,25 @@ int gltfpack(const char* input, const char* output, const Settings& settings)
 
 	if (data->images_count && settings.texture_basis)
 	{
-		if (!checkBasis(settings.verbose > 1))
+		if (settings.texture_ktx2)
 		{
-			fprintf(stderr, "Error: basisu is not present in PATH or BASISU_PATH is not set\n");
-			return 3;
+			if (checkKtx(settings.verbose > 1))
+			{
+				settings.texture_toktx = true;
+			}
+			else if (!checkBasis(settings.verbose > 1))
+			{
+				fprintf(stderr, "Error: toktx is not present in PATH or TOKTX_PATH is not set\n");
+				return 3;
+			}
+		}
+		else
+		{
+			if (!checkBasis(settings.verbose > 1))
+			{
+				fprintf(stderr, "Error: basisu is not present in PATH or BASISU_PATH is not set\n");
+				return 3;
+			}
 		}
 	}
 

--- a/gltf/gltfpack.cpp
+++ b/gltf/gltfpack.cpp
@@ -858,6 +858,7 @@ int main(int argc, char** argv)
 	settings.anim_freq = 30;
 	settings.simplify_threshold = 1.f;
 	settings.texture_quality = 50;
+	settings.texture_scale = 1.f;
 
 	const char* input = 0;
 	const char* output = 0;
@@ -962,6 +963,10 @@ int main(int argc, char** argv)
 		{
 			settings.texture_quality = atoi(argv[++i]);
 		}
+		else if (strcmp(arg, "-ts") == 0 && i + 1 < argc && isdigit(argv[i + 1][0]))
+		{
+			settings.texture_scale = float(atof(argv[++i]));
+		}
 		else if (strcmp(arg, "-noq") == 0)
 		{
 			settings.quantize = false;
@@ -1055,8 +1060,9 @@ int main(int argc, char** argv)
 			fprintf(stderr, "\t-te: embed all textures into main buffer (.bin or .glb)\n");
 			fprintf(stderr, "\t-tb: convert all textures to Basis Universal format (with basisu executable); will be removed in the future\n");
 			fprintf(stderr, "\t-tc: convert all textures to KTX2 with BasisU supercompression (using basisu executable)\n");
-			fprintf(stderr, "\t-tq N: set texture encoding quality (default: 50; N should be between 1 and 100\n");
 			fprintf(stderr, "\t-tu: use UASTC when encoding textures (much higher quality and much larger size)\n");
+			fprintf(stderr, "\t-tq N: set texture encoding quality (default: 50; N should be between 1 and 100\n");
+			fprintf(stderr, "\t-ts R: scale texture dimensions by the ratio R (default: 1; R should be between 0 and 1)\n");
 			fprintf(stderr, "\nSimplification:\n");
 			fprintf(stderr, "\t-si R: simplify meshes to achieve the ratio R (default: 1; R should be between 0 and 1)\n");
 			fprintf(stderr, "\t-sa: aggressively simplify to the target ratio disregarding quality\n");

--- a/gltf/gltfpack.cpp
+++ b/gltf/gltfpack.cpp
@@ -741,6 +741,12 @@ int gltfpack(const char* input, const char* output, const Settings& settings)
 				return 3;
 			}
 		}
+
+		if (settings.texture_scale < 1 && !settings.texture_toktx)
+		{
+			fprintf(stderr, "Error: -ts option is only supported by toktx\n");
+			return 3;
+		}
 	}
 
 	std::string json, bin, fallback;
@@ -1100,6 +1106,12 @@ int main(int argc, char** argv)
 			fprintf(stderr, "\nRun gltfpack -h to display a full list of options\n");
 		}
 
+		return 1;
+	}
+
+	if (settings.texture_scale < 1 && !settings.texture_ktx2)
+	{
+		fprintf(stderr, "Option -ts is only supported when -tc is set as well\n");
 		return 1;
 	}
 

--- a/gltf/gltfpack.h
+++ b/gltf/gltfpack.h
@@ -106,10 +106,12 @@ struct Settings
 
 	int meshlet_debug;
 
+	// TODO: Remove texture_basis and texture_toktx
 	bool texture_embed;
 	bool texture_basis;
 	bool texture_ktx2;
 	bool texture_uastc;
+	mutable bool texture_toktx;
 
 	int texture_quality;
 
@@ -256,6 +258,8 @@ const char* inferMimeType(const char* path);
 bool checkBasis(bool verbose);
 bool encodeBasis(const std::string& data, const char* mime_type, std::string& result, bool normal_map, bool srgb, int quality, bool uastc, bool verbose);
 std::string basisToKtx(const std::string& data, bool srgb, bool uastc);
+bool checkKtx(bool verbose);
+bool encodeKtx(const std::string& data, const char* mime_type, std::string& result, bool normal_map, bool srgb, int quality, bool uastc, bool verbose);
 
 void markAnimated(cgltf_data* data, std::vector<NodeInfo>& nodes, const std::vector<Animation>& animations);
 void markNeededNodes(cgltf_data* data, std::vector<NodeInfo>& nodes, const std::vector<Mesh>& meshes, const std::vector<Animation>& animations, const Settings& settings);

--- a/gltf/gltfpack.h
+++ b/gltf/gltfpack.h
@@ -114,6 +114,7 @@ struct Settings
 	mutable bool texture_toktx;
 
 	int texture_quality;
+	float texture_scale;
 
 	bool quantize;
 
@@ -256,10 +257,10 @@ void markNeededMaterials(cgltf_data* data, std::vector<MaterialInfo>& materials,
 void analyzeImages(cgltf_data* data, std::vector<ImageInfo>& images);
 const char* inferMimeType(const char* path);
 bool checkBasis(bool verbose);
-bool encodeBasis(const std::string& data, const char* mime_type, std::string& result, bool normal_map, bool srgb, int quality, bool uastc, bool verbose);
+bool encodeBasis(const std::string& data, const char* mime_type, std::string& result, bool normal_map, bool srgb, int quality, float scale, bool uastc, bool verbose);
 std::string basisToKtx(const std::string& data, bool srgb, bool uastc);
 bool checkKtx(bool verbose);
-bool encodeKtx(const std::string& data, const char* mime_type, std::string& result, bool normal_map, bool srgb, int quality, bool uastc, bool verbose);
+bool encodeKtx(const std::string& data, const char* mime_type, std::string& result, bool normal_map, bool srgb, int quality, float scale, bool uastc, bool verbose);
 
 void markAnimated(cgltf_data* data, std::vector<NodeInfo>& nodes, const std::vector<Animation>& animations);
 void markNeededNodes(cgltf_data* data, std::vector<NodeInfo>& nodes, const std::vector<Mesh>& meshes, const std::vector<Animation>& animations, const Settings& settings);

--- a/gltf/image.cpp
+++ b/gltf/image.cpp
@@ -198,10 +198,10 @@ bool encodeKtx(const std::string& data, const char* mime_type, std::string& resu
 	const char* toktx_path = readenv("TOKTX_PATH");
 	std::string cmd = toktx_path ? toktx_path : "toktx";
 
-	cmd += " --2d";
 	cmd += " --t2";
-
+	cmd += " --2d";
 	cmd += " --automipmap";
+	cmd += " --nowarn";
 
 	if (scale < 1)
 	{

--- a/gltf/image.cpp
+++ b/gltf/image.cpp
@@ -125,8 +125,10 @@ bool checkBasis(bool verbose)
 	return rc == 0;
 }
 
-bool encodeBasis(const std::string& data, const char* mime_type, std::string& result, bool normal_map, bool srgb, int quality, bool uastc, bool verbose)
+bool encodeBasis(const std::string& data, const char* mime_type, std::string& result, bool normal_map, bool srgb, int quality, float scale, bool uastc, bool verbose)
 {
+	(void)scale;
+
 	TempFile temp_input(mimeExtension(mime_type));
 	TempFile temp_output(".basis");
 
@@ -185,7 +187,7 @@ bool checkKtx(bool verbose)
 	return rc == 0;
 }
 
-bool encodeKtx(const std::string& data, const char* mime_type, std::string& result, bool normal_map, bool srgb, int quality, bool uastc, bool verbose)
+bool encodeKtx(const std::string& data, const char* mime_type, std::string& result, bool normal_map, bool srgb, int quality, float scale, bool uastc, bool verbose)
 {
 	TempFile temp_input(mimeExtension(mime_type));
 	TempFile temp_output(".ktx2");
@@ -198,6 +200,17 @@ bool encodeKtx(const std::string& data, const char* mime_type, std::string& resu
 
 	cmd += " --2d";
 	cmd += " --t2";
+
+	cmd += " --automipmap";
+
+	if (scale < 1)
+	{
+		char sl[128];
+		sprintf(sl, "%g", scale);
+
+		cmd += " --scale ";
+		cmd += sl;
+	}
 
 	if (uastc)
 	{
@@ -216,8 +229,6 @@ bool encodeKtx(const std::string& data, const char* mime_type, std::string& resu
 		if (normal_map)
 			cmd += " --normal_map";
 	}
-
-	cmd += " --automipmap";
 
 	if (srgb)
 		cmd += " --srgb";

--- a/gltf/image.cpp
+++ b/gltf/image.cpp
@@ -236,7 +236,7 @@ bool encodeKtx(const std::string& data, const char* mime_type, std::string& resu
 	else
 		cmd += " --linear";
 
-	cmd += " ";
+	cmd += " -- ";
 	cmd += temp_output.path;
 	cmd += " ";
 	cmd += temp_input.path;

--- a/gltf/image.cpp
+++ b/gltf/image.cpp
@@ -215,6 +215,7 @@ bool encodeKtx(const std::string& data, const char* mime_type, std::string& resu
 	if (uastc)
 	{
 		cmd += " --uastc 2";
+		cmd += " --zcmp 9";
 	}
 	else
 	{

--- a/gltf/write.cpp
+++ b/gltf/write.cpp
@@ -688,7 +688,7 @@ void writeImage(std::string& json, std::vector<BufferView>& views, const cgltf_i
 			}
 			else
 			{
-				fprintf(stderr, "Warning: unable to encode image %d with Basis, skipping\n", int(index));
+				fprintf(stderr, "Warning: unable to encode image %d, skipping\n", int(index));
 			}
 		}
 		else
@@ -721,12 +721,12 @@ void writeImage(std::string& json, std::vector<BufferView>& views, const cgltf_i
 					}
 					else
 					{
-						fprintf(stderr, "Warning: unable to save Basis image %s, skipping\n", image.uri);
+						fprintf(stderr, "Warning: unable to save encoded image %s, skipping\n", image.uri);
 					}
 				}
 				else
 				{
-					fprintf(stderr, "Warning: unable to encode image %s with Basis, skipping\n", image.uri);
+					fprintf(stderr, "Warning: unable to encode image %s, skipping\n", image.uri);
 				}
 			}
 			else

--- a/gltf/write.cpp
+++ b/gltf/write.cpp
@@ -670,7 +670,7 @@ void writeImage(std::string& json, std::vector<BufferView>& views, const cgltf_i
 	if (image.mime_type)
 		mime_type = image.mime_type;
 
-	bool (*encodeImage)(const std::string& data, const char* mime_type, std::string& result, bool normal_map, bool srgb, int quality, bool uastc, bool verbose) =
+	bool (*encodeImage)(const std::string& data, const char* mime_type, std::string& result, bool normal_map, bool srgb, int quality, float scale, bool uastc, bool verbose) =
 	    settings.texture_toktx ? encodeKtx : encodeBasis;
 
 	if (!img_data.empty())
@@ -679,7 +679,7 @@ void writeImage(std::string& json, std::vector<BufferView>& views, const cgltf_i
 		{
 			std::string encoded;
 
-			if (encodeImage(img_data, mime_type.c_str(), encoded, info.normal_map, info.srgb, settings.texture_quality, settings.texture_uastc, settings.verbose > 1))
+			if (encodeImage(img_data, mime_type.c_str(), encoded, info.normal_map, info.srgb, settings.texture_quality, settings.texture_scale, settings.texture_uastc, settings.verbose > 1))
 			{
 				if (settings.texture_ktx2 && !settings.texture_toktx)
 					encoded = basisToKtx(encoded, info.srgb, settings.texture_uastc);
@@ -708,7 +708,7 @@ void writeImage(std::string& json, std::vector<BufferView>& views, const cgltf_i
 			{
 				std::string encoded;
 
-				if (encodeImage(img_data, mime_type.c_str(), encoded, info.normal_map, info.srgb, settings.texture_quality, settings.texture_uastc, settings.verbose > 1))
+				if (encodeImage(img_data, mime_type.c_str(), encoded, info.normal_map, info.srgb, settings.texture_quality, settings.texture_scale, settings.texture_uastc, settings.verbose > 1))
 				{
 					if (settings.texture_ktx2 && !settings.texture_toktx)
 						encoded = basisToKtx(encoded, info.srgb, settings.texture_uastc);

--- a/gltf/write.cpp
+++ b/gltf/write.cpp
@@ -670,15 +670,18 @@ void writeImage(std::string& json, std::vector<BufferView>& views, const cgltf_i
 	if (image.mime_type)
 		mime_type = image.mime_type;
 
+	bool (*encodeImage)(const std::string& data, const char* mime_type, std::string& result, bool normal_map, bool srgb, int quality, bool uastc, bool verbose) =
+	    settings.texture_toktx ? encodeKtx : encodeBasis;
+
 	if (!img_data.empty())
 	{
 		if (settings.texture_basis)
 		{
 			std::string encoded;
 
-			if (encodeBasis(img_data, mime_type.c_str(), encoded, info.normal_map, info.srgb, settings.texture_quality, settings.texture_uastc, settings.verbose > 1))
+			if (encodeImage(img_data, mime_type.c_str(), encoded, info.normal_map, info.srgb, settings.texture_quality, settings.texture_uastc, settings.verbose > 1))
 			{
-				if (settings.texture_ktx2)
+				if (settings.texture_ktx2 && !settings.texture_toktx)
 					encoded = basisToKtx(encoded, info.srgb, settings.texture_uastc);
 
 				writeEmbeddedImage(json, views, encoded.c_str(), encoded.size(), settings.texture_ktx2 ? "image/ktx2" : "image/basis");
@@ -705,9 +708,9 @@ void writeImage(std::string& json, std::vector<BufferView>& views, const cgltf_i
 			{
 				std::string encoded;
 
-				if (encodeBasis(img_data, mime_type.c_str(), encoded, info.normal_map, info.srgb, settings.texture_quality, settings.texture_uastc, settings.verbose > 1))
+				if (encodeImage(img_data, mime_type.c_str(), encoded, info.normal_map, info.srgb, settings.texture_quality, settings.texture_uastc, settings.verbose > 1))
 				{
-					if (settings.texture_ktx2)
+					if (settings.texture_ktx2 && !settings.texture_toktx)
 						encoded = basisToKtx(encoded, info.srgb, settings.texture_uastc);
 
 					if (writeFile(basis_full_path.c_str(), encoded))


### PR DESCRIPTION
This change implements support for using toktx when compressing images to KTX2 via `-tc`.
This allows us to use zstd compression for UASTC images, and also sets us up to remove direct Basis support at some point in the future.

When toktx is not available, we fall back to basisu (if available) as before, so this shouldn't break any existing usage patterns.

This also implements a new option, `-ts`, that can rescale the textures by a given amount; toktx supports this via --scale.

Fixes #134.