### PR TITLE
gltfpack: Implement new texture quality scale 1-10

### DIFF
--- a/gltf/gltfpack.cpp
+++ b/gltf/gltfpack.cpp
@@ -863,7 +863,7 @@ int main(int argc, char** argv)
 	settings.scl_bits = 16;
 	settings.anim_freq = 30;
 	settings.simplify_threshold = 1.f;
-	settings.texture_quality = 50;
+	settings.texture_quality = 8;
 	settings.texture_scale = 1.f;
 
 	const char* input = 0;
@@ -1067,7 +1067,7 @@ int main(int argc, char** argv)
 			fprintf(stderr, "\t-tb: convert all textures to Basis Universal format (with basisu executable); will be removed in the future\n");
 			fprintf(stderr, "\t-tc: convert all textures to KTX2 with BasisU supercompression (using basisu executable)\n");
 			fprintf(stderr, "\t-tu: use UASTC when encoding textures (much higher quality and much larger size)\n");
-			fprintf(stderr, "\t-tq N: set texture encoding quality (default: 50; N should be between 1 and 100\n");
+			fprintf(stderr, "\t-tq N: set texture encoding quality (default: 8; N should be between 1 and 10\n");
 			fprintf(stderr, "\t-ts R: scale texture dimensions by the ratio R (default: 1; R should be between 0 and 1)\n");
 			fprintf(stderr, "\nSimplification:\n");
 			fprintf(stderr, "\t-si R: simplify meshes to achieve the ratio R (default: 1; R should be between 0 and 1)\n");

--- a/gltf/image.cpp
+++ b/gltf/image.cpp
@@ -160,7 +160,7 @@ bool encodeBasis(const std::string& data, const char* mime_type, std::string& re
 	const char* basisu_path = readenv("BASISU_PATH");
 	std::string cmd = basisu_path ? basisu_path : "basisu";
 
-	const BasisSettings& bs = kBasisSettings[std::max(0, std::min(9, quality - 1))];
+	const BasisSettings& bs = kBasisSettings[quality <= 0 ? 0 : quality > 9 ? 9 : quality - 1];
 
 	cmd += " -mipmap";
 
@@ -228,7 +228,7 @@ bool encodeKtx(const std::string& data, const char* mime_type, std::string& resu
 	const char* toktx_path = readenv("TOKTX_PATH");
 	std::string cmd = toktx_path ? toktx_path : "toktx";
 
-	const BasisSettings& bs = kBasisSettings[std::max(0, std::min(9, quality - 1))];
+	const BasisSettings& bs = kBasisSettings[quality <= 0 ? 0 : quality > 9 ? 9 : quality - 1];
 
 	cmd += " --t2";
 	cmd += " --2d";


### PR DESCRIPTION
This change changes the texture quality control to use fewer levels,
1-10, with a remap into Basis encoding settings.

The default quality is 8; 9 & 10 are trying to preserve quality more
aggressively, lower levels lose more quality and 1 & 2 are trying to
minimize the size and the encode time as well.

Notably, for UASTC encoding this change enables RDO for all modes; it
does it with a very small RDO dictionary (1024 bytes) because anything
larger than 2048 isn't very practical for encode times.