### PR TITLE
gltfpack: Implement image resize for block and power of two rounding

### DIFF
--- a/gltf/gltfpack.cpp
+++ b/gltf/gltfpack.cpp
@@ -973,6 +973,10 @@ int main(int argc, char** argv)
 		{
 			settings.texture_scale = float(atof(argv[++i]));
 		}
+		else if (strcmp(arg, "-tp") == 0)
+		{
+			settings.texture_pow2 = true;
+		}
 		else if (strcmp(arg, "-noq") == 0)
 		{
 			settings.quantize = false;
@@ -1069,6 +1073,7 @@ int main(int argc, char** argv)
 			fprintf(stderr, "\t-tu: use UASTC when encoding textures (much higher quality and much larger size)\n");
 			fprintf(stderr, "\t-tq N: set texture encoding quality (default: 8; N should be between 1 and 10\n");
 			fprintf(stderr, "\t-ts R: scale texture dimensions by the ratio R (default: 1; R should be between 0 and 1)\n");
+			fprintf(stderr, "\t-tp: resize textures to nearest power of 2 to conform to WebGL1 restrictions\n");
 			fprintf(stderr, "\nSimplification:\n");
 			fprintf(stderr, "\t-si R: simplify meshes to achieve the ratio R (default: 1; R should be between 0 and 1)\n");
 			fprintf(stderr, "\t-sa: aggressively simplify to the target ratio disregarding quality\n");
@@ -1112,6 +1117,12 @@ int main(int argc, char** argv)
 	if (settings.texture_scale < 1 && !settings.texture_ktx2)
 	{
 		fprintf(stderr, "Option -ts is only supported when -tc is set as well\n");
+		return 1;
+	}
+
+	if (settings.texture_pow2 && !settings.texture_ktx2)
+	{
+		fprintf(stderr, "Option -tp is only supported when -tc is set as well\n");
 		return 1;
 	}
 

--- a/gltf/gltfpack.h
+++ b/gltf/gltfpack.h
@@ -115,6 +115,7 @@ struct Settings
 
 	int texture_quality;
 	float texture_scale;
+	bool texture_pow2;
 
 	bool quantize;
 
@@ -257,10 +258,10 @@ void markNeededMaterials(cgltf_data* data, std::vector<MaterialInfo>& materials,
 void analyzeImages(cgltf_data* data, std::vector<ImageInfo>& images);
 const char* inferMimeType(const char* path);
 bool checkBasis(bool verbose);
-bool encodeBasis(const std::string& data, const char* mime_type, std::string& result, bool normal_map, bool srgb, int quality, float scale, bool uastc, bool verbose);
+bool encodeBasis(const std::string& data, const char* mime_type, std::string& result, bool normal_map, bool srgb, int quality, float scale, bool pow2, bool uastc, bool verbose);
 std::string basisToKtx(const std::string& data, bool srgb, bool uastc);
 bool checkKtx(bool verbose);
-bool encodeKtx(const std::string& data, const char* mime_type, std::string& result, bool normal_map, bool srgb, int quality, float scale, bool uastc, bool verbose);
+bool encodeKtx(const std::string& data, const char* mime_type, std::string& result, bool normal_map, bool srgb, int quality, float scale, bool pow2, bool uastc, bool verbose);
 
 void markAnimated(cgltf_data* data, std::vector<NodeInfo>& nodes, const std::vector<Animation>& animations);
 void markNeededNodes(cgltf_data* data, std::vector<NodeInfo>& nodes, const std::vector<Mesh>& meshes, const std::vector<Animation>& animations, const Settings& settings);

--- a/gltf/image.cpp
+++ b/gltf/image.cpp
@@ -147,9 +147,10 @@ bool checkBasis(bool verbose)
 	return rc == 0;
 }
 
-bool encodeBasis(const std::string& data, const char* mime_type, std::string& result, bool normal_map, bool srgb, int quality, float scale, bool uastc, bool verbose)
+bool encodeBasis(const std::string& data, const char* mime_type, std::string& result, bool normal_map, bool srgb, int quality, float scale, bool pow2, bool uastc, bool verbose)
 {
 	(void)scale;
+	(void)pow2;
 
 	TempFile temp_input(mimeExtension(mime_type));
 	TempFile temp_output(".basis");
@@ -217,8 +218,10 @@ bool checkKtx(bool verbose)
 	return rc == 0;
 }
 
-bool encodeKtx(const std::string& data, const char* mime_type, std::string& result, bool normal_map, bool srgb, int quality, float scale, bool uastc, bool verbose)
+bool encodeKtx(const std::string& data, const char* mime_type, std::string& result, bool normal_map, bool srgb, int quality, float scale, bool pow2, bool uastc, bool verbose)
 {
+	(void)pow2;
+
 	TempFile temp_input(mimeExtension(mime_type));
 	TempFile temp_output(".ktx2");
 

--- a/gltf/write.cpp
+++ b/gltf/write.cpp
@@ -670,7 +670,7 @@ void writeImage(std::string& json, std::vector<BufferView>& views, const cgltf_i
 	if (image.mime_type)
 		mime_type = image.mime_type;
 
-	bool (*encodeImage)(const std::string& data, const char* mime_type, std::string& result, bool normal_map, bool srgb, int quality, float scale, bool uastc, bool verbose) =
+	bool (*encodeImage)(const std::string& data, const char* mime_type, std::string& result, bool normal_map, bool srgb, int quality, float scale, bool pow2, bool uastc, bool verbose) =
 	    settings.texture_toktx ? encodeKtx : encodeBasis;
 
 	if (!img_data.empty())
@@ -679,7 +679,7 @@ void writeImage(std::string& json, std::vector<BufferView>& views, const cgltf_i
 		{
 			std::string encoded;
 
-			if (encodeImage(img_data, mime_type.c_str(), encoded, info.normal_map, info.srgb, settings.texture_quality, settings.texture_scale, settings.texture_uastc, settings.verbose > 1))
+			if (encodeImage(img_data, mime_type.c_str(), encoded, info.normal_map, info.srgb, settings.texture_quality, settings.texture_scale, settings.texture_pow2, settings.texture_uastc, settings.verbose > 1))
 			{
 				if (settings.texture_ktx2 && !settings.texture_toktx)
 					encoded = basisToKtx(encoded, info.srgb, settings.texture_uastc);
@@ -708,7 +708,7 @@ void writeImage(std::string& json, std::vector<BufferView>& views, const cgltf_i
 			{
 				std::string encoded;
 
-				if (encodeImage(img_data, mime_type.c_str(), encoded, info.normal_map, info.srgb, settings.texture_quality, settings.texture_scale, settings.texture_uastc, settings.verbose > 1))
+				if (encodeImage(img_data, mime_type.c_str(), encoded, info.normal_map, info.srgb, settings.texture_quality, settings.texture_scale, settings.texture_pow2, settings.texture_uastc, settings.verbose > 1))
 				{
 					if (settings.texture_ktx2 && !settings.texture_toktx)
 						encoded = basisToKtx(encoded, info.srgb, settings.texture_uastc);


### PR DESCRIPTION
When using -tc to compress textures, gltfpack will now compute the target image size and pass it to `toktx` using `--resize` command line argument.

The target size is computed by scaling the source size and rounding it to the next block boundary by default, which is a necessary restriction for Direct3D and WebGL; when `-tp` is passed (which is currently required for transcoding to BCn formats in WebGL, although this restriction is going to be lifted in WebGL 2 as per https://github.com/KhronosGroup/WebGL/issues/3117), we round to the nearest power of two.

To compute the source image sizes we need to parse PNG or JPEG headers manually.