### PR TITLE
gltfpack: Add support for KHR_materials_{ior,specular}

### DIFF
--- a/gltf/gltfpack.cpp
+++ b/gltf/gltfpack.cpp
@@ -362,6 +362,8 @@ static void process(cgltf_data* data, const char* input_path, const char* output
 	bool ext_pbr_specular_glossiness = false;
 	bool ext_clearcoat = false;
 	bool ext_transmission = false;
+	bool ext_ior = false;
+	bool ext_specular = false;
 	bool ext_unlit = false;
 	bool ext_instancing = false;
 
@@ -420,6 +422,8 @@ static void process(cgltf_data* data, const char* input_path, const char* output
 		ext_pbr_specular_glossiness = ext_pbr_specular_glossiness || material.has_pbr_specular_glossiness;
 		ext_clearcoat = ext_clearcoat || material.has_clearcoat;
 		ext_transmission = ext_transmission || material.has_transmission;
+		ext_ior = ext_ior || material.has_ior;
+		ext_specular = ext_specular || material.has_specular;
 		ext_unlit = ext_unlit || material.unlit;
 	}
 
@@ -632,6 +636,8 @@ static void process(cgltf_data* data, const char* input_path, const char* output
 	    {"KHR_materials_pbrSpecularGlossiness", ext_pbr_specular_glossiness, false},
 	    {"KHR_materials_clearcoat", ext_clearcoat, false},
 	    {"KHR_materials_transmission", ext_transmission, false},
+	    {"KHR_materials_ior", ext_ior, false},
+	    {"KHR_materials_specular", ext_specular, false},
 	    {"KHR_materials_unlit", ext_unlit, false},
 	    {"KHR_lights_punctual", data->lights_count > 0, false},
 	    {"KHR_texture_basisu", !json_textures.empty() && settings.texture_ktx2, true},

--- a/gltf/image.cpp
+++ b/gltf/image.cpp
@@ -58,6 +58,22 @@ void analyzeImages(cgltf_data* data, std::vector<ImageInfo>& images)
 				images[pbr.diffuse_texture.texture->image - data->images].srgb = true;
 		}
 
+		if (material.has_clearcoat)
+		{
+			const cgltf_clearcoat& clearcoat = material.clearcoat;
+
+			if (clearcoat.clearcoat_normal_texture.texture && clearcoat.clearcoat_normal_texture.texture->image)
+				images[clearcoat.clearcoat_normal_texture.texture->image - data->images].normal_map = true;
+		}
+
+		if (material.has_specular)
+		{
+			const cgltf_specular& specular = material.specular;
+
+			if (specular.specular_texture.texture && specular.specular_texture.texture->image)
+				images[specular.specular_texture.texture->image - data->images].srgb = true;
+		}
+
 		if (material.emissive_texture.texture && material.emissive_texture.texture->image)
 			images[material.emissive_texture.texture->image - data->images].srgb = true;
 

--- a/gltf/material.cpp
+++ b/gltf/material.cpp
@@ -120,6 +120,28 @@ static bool areMaterialComponentsEqual(const cgltf_transmission& lhs, const cglt
 	return true;
 }
 
+static bool areMaterialComponentsEqual(const cgltf_ior& lhs, const cgltf_ior& rhs)
+{
+	if (lhs.ior != rhs.ior)
+		return false;
+
+	return true;
+}
+
+static bool areMaterialComponentsEqual(const cgltf_specular& lhs, const cgltf_specular& rhs)
+{
+	if (!areTextureViewsEqual(lhs.specular_texture, rhs.specular_texture))
+		return false;
+
+	if (memcmp(lhs.specular_color_factor, rhs.specular_color_factor, sizeof(cgltf_float) * 3) != 0)
+		return false;
+
+	if (lhs.specular_factor != rhs.specular_factor)
+		return false;
+
+	return true;
+}
+
 static bool areMaterialsEqual(cgltf_data* data, const cgltf_material& lhs, const cgltf_material& rhs, const Settings& settings)
 {
 	if (lhs.has_pbr_metallic_roughness != rhs.has_pbr_metallic_roughness)
@@ -144,6 +166,18 @@ static bool areMaterialsEqual(cgltf_data* data, const cgltf_material& lhs, const
 		return false;
 
 	if (lhs.has_transmission && !areMaterialComponentsEqual(lhs.transmission, rhs.transmission))
+		return false;
+
+	if (lhs.has_ior != rhs.has_ior)
+		return false;
+
+	if (lhs.has_ior && !areMaterialComponentsEqual(lhs.ior, rhs.ior))
+		return false;
+
+	if (lhs.has_specular != rhs.has_specular)
+		return false;
+
+	if (lhs.has_specular && !areMaterialComponentsEqual(lhs.specular, rhs.specular))
 		return false;
 
 	if (!areTextureViewsEqual(lhs.normal_texture, rhs.normal_texture))
@@ -266,6 +300,12 @@ bool usesTextureSet(const cgltf_material& material, int set)
 	if (material.has_transmission)
 	{
 		if (usesTextureSet(material.transmission.transmission_texture, set))
+			return true;
+	}
+
+	if (material.has_specular)
+	{
+		if (usesTextureSet(material.specular.specular_texture, set))
 			return true;
 	}
 

--- a/gltf/write.cpp
+++ b/gltf/write.cpp
@@ -161,7 +161,7 @@ static const char* compressionFilter(StreamFormat::Filter filter)
 	}
 }
 
-static void writeTextureInfo(std::string& json, const cgltf_data* data, const cgltf_texture_view& view, const QuantizationTexture* qt)
+static void writeTextureInfo(std::string& json, const cgltf_data* data, const cgltf_texture_view& view, const QuantizationTexture* qt, const char* scale = NULL)
 {
 	assert(view.texture);
 
@@ -188,6 +188,13 @@ static void writeTextureInfo(std::string& json, const cgltf_data* data, const cg
 	append(json, size_t(view.texture - data->textures));
 	append(json, ",\"texCoord\":");
 	append(json, size_t(view.texcoord));
+	if (scale && view.scale != 1)
+	{
+		append(json, ",\"");
+		append(json, scale);
+		append(json, "\":");
+		append(json, view.scale);
+	}
 	if (view.has_transform || qt)
 	{
 		append(json, ",\"extensions\":{\"KHR_texture_transform\":{");
@@ -326,7 +333,7 @@ static void writeMaterialComponent(std::string& json, const cgltf_data* data, co
 	{
 		comma(json);
 		append(json, "\"clearcoatNormalTexture\":");
-		writeTextureInfo(json, data, cc.clearcoat_normal_texture, qt);
+		writeTextureInfo(json, data, cc.clearcoat_normal_texture, qt, "scale");
 	}
 	if (cc.clearcoat_factor != 0)
 	{
@@ -423,14 +430,14 @@ void writeMaterial(std::string& json, const cgltf_data* data, const cgltf_materi
 	{
 		comma(json);
 		append(json, "\"normalTexture\":");
-		writeTextureInfo(json, data, material.normal_texture, qt);
+		writeTextureInfo(json, data, material.normal_texture, qt, "scale");
 	}
 
 	if (material.occlusion_texture.texture)
 	{
 		comma(json);
 		append(json, "\"occlusionTexture\":");
-		writeTextureInfo(json, data, material.occlusion_texture, qt);
+		writeTextureInfo(json, data, material.occlusion_texture, qt, "strength");
 	}
 
 	if (material.emissive_texture.texture)

--- a/gltf/write.cpp
+++ b/gltf/write.cpp
@@ -362,6 +362,48 @@ static void writeMaterialComponent(std::string& json, const cgltf_data* data, co
 	append(json, "}");
 }
 
+static void writeMaterialComponent(std::string& json, const cgltf_data* data, const cgltf_ior& tm, const QuantizationTexture* qt)
+{
+	(void)data;
+	(void)qt;
+
+	comma(json);
+	append(json, "\"KHR_materials_ior\":{");
+	append(json, "\"ior\":");
+	append(json, tm.ior);
+	append(json, "}");
+}
+
+static void writeMaterialComponent(std::string& json, const cgltf_data* data, const cgltf_specular& tm, const QuantizationTexture* qt)
+{
+	comma(json);
+	append(json, "\"KHR_materials_specular\":{");
+	if (tm.specular_texture.texture)
+	{
+		comma(json);
+		append(json, "\"specularTexture\":");
+		writeTextureInfo(json, data, tm.specular_texture, qt);
+	}
+	if (memcmp(tm.specular_color_factor, white, 16) != 0)
+	{
+		comma(json);
+		append(json, "\"specularColorFactor\":[");
+		append(json, tm.specular_color_factor[0]);
+		append(json, ",");
+		append(json, tm.specular_color_factor[1]);
+		append(json, ",");
+		append(json, tm.specular_color_factor[2]);
+		append(json, "]");
+	}
+	if (tm.specular_factor != 1)
+	{
+		comma(json);
+		append(json, "\"specularFactor\":");
+		append(json, tm.specular_factor);
+	}
+	append(json, "}");
+}
+
 void writeMaterial(std::string& json, const cgltf_data* data, const cgltf_material& material, const QuantizationTexture* qt)
 {
 	if (material.name && *material.name)
@@ -431,7 +473,7 @@ void writeMaterial(std::string& json, const cgltf_data* data, const cgltf_materi
 		append(json, "\"doubleSided\":true");
 	}
 
-	if (material.has_pbr_specular_glossiness || material.has_clearcoat || material.has_transmission || material.unlit)
+	if (material.has_pbr_specular_glossiness || material.has_clearcoat || material.has_transmission || material.has_ior || material.has_specular || material.unlit)
 	{
 		comma(json);
 		append(json, "\"extensions\":{");
@@ -449,6 +491,16 @@ void writeMaterial(std::string& json, const cgltf_data* data, const cgltf_materi
 		if (material.has_transmission)
 		{
 			writeMaterialComponent(json, data, material.transmission, qt);
+		}
+
+		if (material.has_ior)
+		{
+			writeMaterialComponent(json, data, material.ior, qt);
+		}
+
+		if (material.has_specular)
+		{
+			writeMaterialComponent(json, data, material.specular, qt);
 		}
 
 		if (material.unlit)


### PR DESCRIPTION
This change also fixes clearcoat normal texture handling for Basis encoding and introduces support for scale/strength for normal and occlusion textures that was omitted before.