### PR TITLE
gltfpack: Preserve scenes during processing

### DIFF
--- a/gltf/gltfpack.h
+++ b/gltf/gltfpack.h
@@ -39,6 +39,7 @@ struct Transform
 
 struct Mesh
 {
+	int scene;
 	std::vector<cgltf_node*> nodes;
 	std::vector<Transform> instances;
 
@@ -157,6 +158,8 @@ struct StreamFormat
 
 struct NodeInfo
 {
+	int scene;
+
 	bool keep;
 	bool animated;
 
@@ -261,6 +264,7 @@ std::string basisToKtx(const std::string& data, bool srgb, bool uastc);
 bool checkKtx(bool verbose);
 bool encodeKtx(const std::string& data, const char* mime_type, std::string& result, bool normal_map, bool srgb, int quality, float scale, bool pow2, bool uastc, bool verbose);
 
+void markScenes(cgltf_data* data, std::vector<NodeInfo>& nodes);
 void markAnimated(cgltf_data* data, std::vector<NodeInfo>& nodes, const std::vector<Animation>& animations);
 void markNeededNodes(cgltf_data* data, std::vector<NodeInfo>& nodes, const std::vector<Mesh>& meshes, const std::vector<Animation>& animations, const Settings& settings);
 void remapNodes(cgltf_data* data, std::vector<NodeInfo>& nodes, size_t& node_offset);
@@ -309,6 +313,7 @@ void writeLight(std::string& json, const cgltf_light& light);
 void writeArray(std::string& json, const char* name, const std::string& contents);
 void writeExtensions(std::string& json, const ExtensionInfo* extensions, size_t count);
 void writeExtras(std::string& json, const std::string& data, const cgltf_extras& extras);
+void writeScene(std::string& json, const cgltf_scene& scene, const std::string& roots);
 
 /**
  * Copyright (c) 2016-2020 Arseny Kapoulkine

--- a/gltf/mesh.cpp
+++ b/gltf/mesh.cpp
@@ -173,6 +173,9 @@ static bool canMergeMeshNodes(cgltf_node* lhs, cgltf_node* rhs, const Settings& 
 
 static bool canMergeMeshes(const Mesh& lhs, const Mesh& rhs, const Settings& settings)
 {
+	if (lhs.scene != rhs.scene)
+		return false;
+
 	if (lhs.nodes.size() != rhs.nodes.size())
 		return false;
 

--- a/gltf/node.cpp
+++ b/gltf/node.cpp
@@ -4,6 +4,32 @@
 #include <math.h>
 #include <string.h>
 
+void markScenes(cgltf_data* data, std::vector<NodeInfo>& nodes)
+{
+	for (size_t i = 0; i < nodes.size(); ++i)
+		nodes[i].scene = -1;
+
+	for (size_t i = 0; i < data->scenes_count; ++i)
+		for (size_t j = 0; j < data->scenes[i].nodes_count; ++j)
+		{
+			NodeInfo& ni = nodes[data->scenes[i].nodes[j] - data->nodes];
+
+			if (ni.scene >= 0)
+				ni.scene = -2; // multiple scenes
+			else
+				ni.scene = int(i);
+		}
+
+	for (size_t i = 0; i < data->nodes_count; ++i)
+	{
+		cgltf_node* root = &data->nodes[i];
+		while (root->parent)
+			root = root->parent;
+
+		 nodes[i].scene = nodes[root - data->nodes].scene;
+	}
+}
+
 void markAnimated(cgltf_data* data, std::vector<NodeInfo>& nodes, const std::vector<Animation>& animations)
 {
 	for (size_t i = 0; i < animations.size(); ++i)

--- a/gltf/node.cpp
+++ b/gltf/node.cpp
@@ -26,7 +26,7 @@ void markScenes(cgltf_data* data, std::vector<NodeInfo>& nodes)
 		while (root->parent)
 			root = root->parent;
 
-		 nodes[i].scene = nodes[root - data->nodes].scene;
+		nodes[i].scene = nodes[root - data->nodes].scene;
 	}
 }
 

--- a/gltf/parsegltf.cpp
+++ b/gltf/parsegltf.cpp
@@ -155,6 +155,8 @@ static void parseMeshesGltf(cgltf_data* data, std::vector<Mesh>& meshes, std::ve
 			meshes.push_back(Mesh());
 			Mesh& result = meshes.back();
 
+			result.scene = -1;
+
 			result.material = primitive.material;
 
 			result.type = primitive.type;

--- a/gltf/parseobj.cpp
+++ b/gltf/parseobj.cpp
@@ -86,6 +86,9 @@ static cgltf_data* parseSceneObj(fastObjMesh* obj)
 		}
 	}
 
+	data->scenes = (cgltf_scene*)calloc(1, sizeof(cgltf_scene));
+	data->scenes_count = 1;
+
 	return data;
 }
 

--- a/gltf/wasistubs.cpp
+++ b/gltf/wasistubs.cpp
@@ -14,27 +14,24 @@ extern "C" void* __cxa_allocate_exception(size_t thrown_size)
 	abort();
 }
 
-__wasi_errno_t __wasi_path_open32(__wasi_fd_t fd, __wasi_lookupflags_t dirflags, const char *path, size_t path_len, __wasi_oflags_t oflags, uint32_t fs_rights_base, uint32_t fs_rights_inherting, __wasi_fdflags_t fdflags, __wasi_fd_t *opened_fd)
-__attribute__((
-    __import_module__("wasi_snapshot_preview1"),
-    __import_name__("path_open32"),
-    __warn_unused_result__
-));
+__wasi_errno_t __wasi_path_open32(__wasi_fd_t fd, __wasi_lookupflags_t dirflags, const char* path, size_t path_len, __wasi_oflags_t oflags, uint32_t fs_rights_base, uint32_t fs_rights_inherting, __wasi_fdflags_t fdflags, __wasi_fd_t* opened_fd)
+    __attribute__((
+        __import_module__("wasi_snapshot_preview1"),
+        __import_name__("path_open32"),
+        __warn_unused_result__));
 
-__wasi_errno_t __wasi_path_open(__wasi_fd_t fd, __wasi_lookupflags_t dirflags, const char *path, size_t path_len, __wasi_oflags_t oflags, __wasi_rights_t fs_rights_base, __wasi_rights_t fs_rights_inherting, __wasi_fdflags_t fdflags, __wasi_fd_t *opened_fd)
+__wasi_errno_t __wasi_path_open(__wasi_fd_t fd, __wasi_lookupflags_t dirflags, const char* path, size_t path_len, __wasi_oflags_t oflags, __wasi_rights_t fs_rights_base, __wasi_rights_t fs_rights_inherting, __wasi_fdflags_t fdflags, __wasi_fd_t* opened_fd)
 {
 	return __wasi_path_open32(fd, dirflags, path, path_len, oflags, fs_rights_base, fs_rights_inherting, fdflags, opened_fd);
-
 }
 
-__wasi_errno_t __wasi_fd_seek32(__wasi_fd_t fd, int32_t offset, __wasi_whence_t whence, int32_t *newoffset)
- __attribute__((
-    __import_module__("wasi_snapshot_preview1"),
-    __import_name__("fd_seek32"),
-    __warn_unused_result__
-));
+__wasi_errno_t __wasi_fd_seek32(__wasi_fd_t fd, int32_t offset, __wasi_whence_t whence, int32_t* newoffset)
+    __attribute__((
+        __import_module__("wasi_snapshot_preview1"),
+        __import_name__("fd_seek32"),
+        __warn_unused_result__));
 
-__wasi_errno_t __wasi_fd_seek(__wasi_fd_t fd, __wasi_filedelta_t offset, __wasi_whence_t whence, __wasi_filesize_t *newoffset)
+__wasi_errno_t __wasi_fd_seek(__wasi_fd_t fd, __wasi_filedelta_t offset, __wasi_whence_t whence, __wasi_filesize_t* newoffset)
 {
 	int32_t newoffset32 = 0;
 	__wasi_errno_t result = __wasi_fd_seek32(fd, int32_t(offset), whence, &newoffset32);
@@ -46,7 +43,7 @@ extern "C" int system(const char* command)
 {
 	// WASI doesn't provide a system() equivalent; we highjack readlink here, the reasoning being that if we run against a real WASI implementation,
 	// the effect is more likely to be benign.
-	return  __wasi_path_readlink(-1, command, strlen(command), 0, 0, 0);
+	return __wasi_path_readlink(-1, command, strlen(command), 0, 0, 0);
 }
 
 #endif

--- a/gltf/write.cpp
+++ b/gltf/write.cpp
@@ -1453,3 +1453,23 @@ void writeExtras(std::string& json, const std::string& data, const cgltf_extras&
 	append(json, "\"extras\":");
 	appendJson(json, data.c_str() + extras.start_offset, data.c_str() + extras.end_offset);
 }
+
+void writeScene(std::string& json, const cgltf_scene& scene, const std::string& roots)
+{
+	comma(json);
+	append(json, "{");
+	if (scene.name && *scene.name)
+	{
+		append(json, "\"name\":\"");
+		append(json, scene.name);
+		append(json, "\"");
+	}
+	if (!roots.empty())
+	{
+		comma(json);
+		append(json, "\"nodes\":[");
+		append(json, roots);
+		append(json, "]");
+	}
+	append(json, "}");
+}


### PR DESCRIPTION
Before this change gltfack wasn't scene aware, and would process all
nodes regardless of which scene they come from.

With this change, we now output the same number of scenes that the input
file contained. When merging meshes and converting nodes to mesh instances,
the process is limited to cases where the mesh is not used in multiple
scenes.

Fixes #184