### PR TITLE
gltfpack: Provide a CLI and library version of gltfpack

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -86,6 +86,25 @@ jobs:
       env:
         VALIDATOR: https://github.com/KhronosGroup/glTF-Validator/releases/download/2.0.0-dev.3.2/gltf_validator-2.0.0-dev.3.2-linux64.tar.xz
 
+  gltfpackjs:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - uses: actions/setup-node@v1
+      with:
+        node-version: '14.x'
+    - name: install wasi
+      run: |
+        curl -sL https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-$VERSION/wasi-sdk-$VERSION.0-linux.tar.gz | tar xz
+        curl -sL https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-$VERSION/libclang_rt.builtins-wasm32-wasi-$VERSION.0.tar.gz | tar xz -C wasi-sdk-$VERSION.0
+        curl -sL https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-$VERSION/wasi-sysroot-$VERSION.0.tar.gz | tar xz
+      env:
+        VERSION: 11
+    - name: build
+      run: make -B WASMCC=wasi-sdk-11.0/bin/clang++ WASI_SDK=./wasi-sysroot gltf/library.wasm
+    - name: test
+      run: node gltf/cli.js -i demo/pirate.obj -o pirate.glb -v
+
   arm64:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -104,6 +104,12 @@ jobs:
       run: make -B WASMCC=wasi-sdk-11.0/bin/clang++ WASI_SDK=./wasi-sysroot gltf/library.wasm
     - name: test
       run: node gltf/cli.js -i demo/pirate.obj -o pirate.glb -v
+    - name: npm pack
+      run: cd gltf && npm pack
+    - uses: actions/upload-artifact@v2
+      with:
+        name: gltfpack-npm
+        path: gltf/gltfpack-*.tgz
 
   arm64:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 /build/
 /data/
-/gltf/bin/gltfpack.wasm
+/gltf/library.wasm

--- a/Makefile
+++ b/Makefile
@@ -84,11 +84,10 @@ format:
 gltfpack: $(GLTFPACK_OBJECTS) $(LIBRARY)
 	$(CXX) $^ $(LDFLAGS) -o $@
 
-gltfpack.wasm: gltf/bin/gltfpack.wasm
+gltfpack.wasm: gltf/library.wasm
 
-gltf/bin/gltfpack.wasm: ${LIBRARY_SOURCES} ${GLTFPACK_SOURCES} tools/meshloader.cpp
-	@mkdir -p gltf/lib
-	$(WASMCC) $^ -o $@ -Os -DNDEBUG --target=wasm32-wasi --sysroot=$(WASI_SDK)
+gltf/library.wasm: ${LIBRARY_SOURCES} ${GLTFPACK_SOURCES} tools/meshloader.cpp
+	$(WASMCC) $^ -o $@ -Os -DNDEBUG --target=wasm32-wasi --sysroot=$(WASI_SDK) -nostartfiles -Wl,--no-entry -Wl,--export=pack -Wl,--export=malloc -Wl,--export=free -Wl,--export=__wasm_call_ctors -Wl,-s
 
 build/decoder_base.wasm: $(WASM_SOURCES)
 	@mkdir -p build

--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,7 @@ gltfpack: $(GLTFPACK_OBJECTS) $(LIBRARY)
 gltfpack.wasm: gltf/library.wasm
 
 gltf/library.wasm: ${LIBRARY_SOURCES} ${GLTFPACK_SOURCES} tools/meshloader.cpp
-	$(WASMCC) $^ -o $@ -Os -DNDEBUG --target=wasm32-wasi --sysroot=$(WASI_SDK) -nostartfiles -Wl,--no-entry -Wl,--export=pack -Wl,--export=malloc -Wl,--export=free -Wl,--export=__wasm_call_ctors -Wl,-s
+	$(WASMCC) $^ -o $@ -Os -DNDEBUG --target=wasm32-wasi --sysroot=$(WASI_SDK) -nostartfiles -Wl,--no-entry -Wl,--export=pack -Wl,--export=malloc -Wl,--export=free -Wl,--export=__wasm_call_ctors -Wl,-s -Wl,--allow-undefined-file=gltf/wasistubs.txt
 
 build/decoder_base.wasm: $(WASM_SOURCES)
 	@mkdir -p build

--- a/gltf/README.md
+++ b/gltf/README.md
@@ -68,3 +68,7 @@ The following settings are frequently used to restrict some optimizations:
 * `-kn`: keep named nodes and meshes attached to named nodes so that named nodes can be transformed externally
 * `-km`: keep named materials and disable named material merging
 * `-ke`: keep extras data
+
+## License
+
+gltfpack is available to anybody free of charge, under the terms of MIT License (see LICENSE.md).

--- a/gltf/cli.js
+++ b/gltf/cli.js
@@ -1,0 +1,8 @@
+#!/usr/bin/env node
+var gltfpack = require('./library.js');
+
+var args = process.argv.slice(2);
+
+gltfpack.pack(args).then(function (result) {
+	process.exit(result);
+});

--- a/gltf/cli.js
+++ b/gltf/cli.js
@@ -37,7 +37,6 @@ var interface = {
 	},
 };
 
-gltfpack.init(fs.readFileSync(__dirname + '/library.wasm'));
 gltfpack.pack(args, interface)
 	.then(function (log) {
 		process.stdout.write(log);

--- a/gltf/cli.js
+++ b/gltf/cli.js
@@ -40,10 +40,8 @@ var interface = {
 	},
 };
 
-gltfpack.setLibrary(fs.readFileSync(__dirname + '/library.wasm'));
-
-gltfpack
-	.pack(args, interface)
+gltfpack.init(fs.readFileSync(__dirname + '/library.wasm'));
+gltfpack.pack(args, interface)
 	.then(function () {
 		process.exit(0);
 	})

--- a/gltf/cli.js
+++ b/gltf/cli.js
@@ -1,8 +1,44 @@
 #!/usr/bin/env node
 var gltfpack = require('./library.js');
 
+var fs = require('fs');
+var cp = require('child_process');
+
 var args = process.argv.slice(2);
 
-gltfpack.pack(args).then(function (result) {
+var paths = {
+	"basisu": process.env["BASISU_PATH"],
+	"toktx": process.env["TOKTX_PATH"],
+};
+
+var interface = {
+	read: function (path) {
+		return fs.readFileSync(path);
+	},
+	write: function (path, data) {
+		fs.writeFileSync(path, data);
+	},
+	log: function (channel, data) {
+		(channel == 0 ? process.stdout : process.stderr).write(data);
+	},
+	execute: function (command) {
+		// perform substitution of command executable with environment-specific paths
+		var pk = Object.keys(paths);
+		for (var pi = 0; pi < pk.length; ++pi) {
+			if (command.startsWith(pk[pi] + " ")) {
+				command = paths[pk[pi]] + command.substr(pk[pi].length);
+				break;
+			}
+		}
+
+		var ret = cp.spawnSync(command, [], {shell:true});
+		return ret.status == null ? 256 : ret.status;
+	},
+	unlink: function (path) {
+		fs.unlinkSync(path);
+	},
+};
+
+gltfpack.pack(args, interface).then(function (result) {
 	process.exit(result);
 });

--- a/gltf/cli.js
+++ b/gltf/cli.js
@@ -19,9 +19,6 @@ var interface = {
 	write: function (path, data) {
 		fs.writeFileSync(path, data);
 	},
-	log: function (channel, data) {
-		(channel == 2 ? process.stderr : process.stdout).write(data);
-	},
 	execute: function (command) {
 		// perform substitution of command executable with environment-specific paths
 		var pk = Object.keys(paths);
@@ -42,9 +39,11 @@ var interface = {
 
 gltfpack.init(fs.readFileSync(__dirname + '/library.wasm'));
 gltfpack.pack(args, interface)
-	.then(function () {
+	.then(function (log) {
+		process.stdout.write(log);
 		process.exit(0);
 	})
 	.catch(function (err) {
+		process.stderr.write(err.message);
 		process.exit(1);
 	});

--- a/gltf/cli.js
+++ b/gltf/cli.js
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+// This file is part of gltfpack and is distributed under the terms of MIT License.
 var gltfpack = require('./library.js');
 
 var fs = require('fs');
@@ -19,7 +20,7 @@ var interface = {
 		fs.writeFileSync(path, data);
 	},
 	log: function (channel, data) {
-		(channel == 0 ? process.stdout : process.stderr).write(data);
+		(channel == 2 ? process.stderr : process.stdout).write(data);
 	},
 	execute: function (command) {
 		// perform substitution of command executable with environment-specific paths
@@ -39,6 +40,13 @@ var interface = {
 	},
 };
 
-gltfpack.pack(args, interface).then(function (result) {
-	process.exit(result);
-});
+gltfpack.setLibrary(fs.readFileSync(__dirname + '/library.wasm'));
+
+gltfpack
+	.pack(args, interface)
+	.then(function () {
+		process.exit(0);
+	})
+	.catch(function (err) {
+		process.exit(1);
+	});

--- a/gltf/gltfpack.cpp
+++ b/gltf/gltfpack.cpp
@@ -1210,3 +1210,10 @@ int main(int argc, char** argv)
 
 	return gltfpack(input, output, report, settings);
 }
+
+#ifdef __wasi__
+extern "C" int pack(int argc, char** argv)
+{
+	return main(argc, argv);
+}
+#endif

--- a/gltf/gltfpack.cpp
+++ b/gltf/gltfpack.cpp
@@ -1214,6 +1214,8 @@ int main(int argc, char** argv)
 #ifdef __wasi__
 extern "C" int pack(int argc, char** argv)
 {
-	return main(argc, argv);
+	int result = main(argc, argv);
+	fflush(NULL);
+	return result;
 }
 #endif

--- a/gltf/image.cpp
+++ b/gltf/image.cpp
@@ -104,6 +104,17 @@ static const char* mimeExtension(const char* mime_type)
 	return ".raw";
 }
 
+#ifdef __wasi__
+static int execute(const char* cmd, bool ignore_stdout, bool ignore_stderr)
+{
+	return system(cmd);
+}
+
+static const char* readenv(const char* name)
+{
+	return NULL;
+}
+#else
 static int execute(const char* cmd_, bool ignore_stdout, bool ignore_stderr)
 {
 #ifdef _WIN32
@@ -114,12 +125,10 @@ static int execute(const char* cmd_, bool ignore_stdout, bool ignore_stderr)
 
 	std::string cmd = cmd_;
 
-#ifndef __wasi__
 	if (ignore_stdout)
 		(cmd += " >") += ignore;
 	if (ignore_stderr)
 		(cmd += " 2>") += ignore;
-#endif
 
 	return system(cmd.c_str());
 }
@@ -128,6 +137,7 @@ static const char* readenv(const char* name)
 {
 	return getenv(name);
 }
+#endif
 
 bool checkBasis(bool verbose)
 {

--- a/gltf/library.js
+++ b/gltf/library.js
@@ -4,6 +4,8 @@
  * Initialize the library with the Wasm module (library.wasm)
  *
  * @param wasm Promise with contents of library.wasm
+ *
+ * Note: this is called automatically in node.js
  */
 function init(wasm) {
 	if (ready) {
@@ -342,6 +344,13 @@ function uploadArgv(argv) {
 	}
 
 	return buf;
+}
+
+// Automatic initialization for node.js
+if (typeof window === 'undefined' && typeof process !== 'undefined' && process.release.name === 'node') {
+	var fs = require('fs');
+
+	init(fs.readFileSync(__dirname + '/library.wasm'));
 }
 
 // UMD

--- a/gltf/library.js
+++ b/gltf/library.js
@@ -1,13 +1,13 @@
 // This file is part of gltfpack and is distributed under the terms of MIT License.
 
 /**
- * Compile the Wasm library (library.wasm)
+ * Initialize the library with the Wasm module (library.wasm)
  *
  * @param wasm Promise with contents of library.wasm
  */
-exports.setLibrary = function(wasm) {
+exports.init = function(wasm) {
 	if (ready) {
-		throw new Error("setLibrary must be called once");
+		throw new Error("init must be called once");
 	}
 
 	ready = Promise.resolve(wasm)
@@ -41,7 +41,7 @@ exports.setLibrary = function(wasm) {
  */
 exports.pack = function(args, iface) {
 	if (!ready) {
-		throw new Error("setLibrary must be called before pack");
+		throw new Error("init must be called before pack");
 	}
 
 	var argv = args.slice();

--- a/gltf/library.js
+++ b/gltf/library.js
@@ -5,7 +5,7 @@
  *
  * @param wasm Promise with contents of library.wasm
  */
-exports.init = function(wasm) {
+function init(wasm) {
 	if (ready) {
 		throw new Error("init must be called once");
 	}
@@ -39,7 +39,7 @@ exports.init = function(wasm) {
  * execute(command): Run the requested command and return the return code
  * unlink(path): Remove the requested file (will be called with paths to temp files after texture compression finishes)
  */
-exports.pack = function(args, iface) {
+function pack(args, iface) {
 	if (!ready) {
 		throw new Error("init must be called before pack");
 	}
@@ -342,3 +342,16 @@ function uploadArgv(argv) {
 
 	return buf;
 }
+
+// UMD
+(function (root, factory) {
+    if (typeof define === 'function' && define.amd) {
+        define([], factory);
+    } else if (typeof module === 'object' && module.exports) {
+        module.exports = factory();
+    } else {
+        root.gltfpack = factory();
+  }
+}(typeof self !== 'undefined' ? self : this, function () {
+    return { init, pack };
+}));

--- a/gltf/library.js
+++ b/gltf/library.js
@@ -231,9 +231,11 @@ exports.pack = function(args) {
 	argv.unshift("gltfpack");
 
 	return ready.then(function () {
+		var encoder = new TextEncoder();
+
 		var buf_size = argv.length * 4;
 		for (var i = 0; i < argv.length; ++i) {
-			buf_size += Buffer.from(argv[i], 'utf-8').length + 1;
+			buf_size += encoder.encode(argv[i]).length + 1;
 		}
 
 		var buf = instance.exports.malloc(buf_size);
@@ -242,10 +244,10 @@ exports.pack = function(args) {
 		var heap = getHeap();
 
 		for (var i = 0; i < argv.length; ++i) {
-			var item = Buffer.from(argv[i], 'utf-8');
+			var item = encoder.encode(argv[i]);
 
 			heap.setUint32(buf + i * 4, argp, true);
-			item.copy(new Uint8Array(heap.buffer), argp);
+			new Uint8Array(heap.buffer).set(item, argp);
 			heap.setUint8(argp + item.length, 0);
 
 			argp += item.length + 1;

--- a/gltf/package.json
+++ b/gltf/package.json
@@ -16,7 +16,7 @@
 	"bin": "./cli.js",
 	"main": "./library.js",
 	"files": [
-		"*.js"
+		"*.js", "*.wasm"
 	],
 	"scripts": {
 		"prepublishOnly": "node cli.js -v"

--- a/gltf/package.json
+++ b/gltf/package.json
@@ -6,18 +6,19 @@
 	"license": "MIT",
 	"bugs": "https://github.com/zeux/meshoptimizer/issues",
 	"homepage": "https://github.com/zeux/meshoptimizer",
-	"keywords": ["gltf"],
+	"keywords": [
+		"gltf"
+	],
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/zeux/meshoptimizer"
 	},
-	"bin": {
-		"gltfpack": "./bin/gltfpack.js"
-	},
+	"bin": "./cli.js",
+	"main": "./library.js",
 	"files": [
-		"bin/"
+		"*.js"
 	],
 	"scripts": {
-		"prepublishOnly": "node bin/gltfpack.js -v"
+		"prepublishOnly": "node cli.js -v"
 	}
 }

--- a/gltf/wasistubs.cpp
+++ b/gltf/wasistubs.cpp
@@ -14,7 +14,7 @@ extern "C" void* __cxa_allocate_exception(size_t thrown_size)
 	abort();
 }
 
-__wasi_errno_t __wasi_path_open32(__wasi_fd_t fd, __wasi_lookupflags_t dirflags, const char* path, size_t path_len, __wasi_oflags_t oflags, uint32_t fs_rights_base, uint32_t fs_rights_inherting, __wasi_fdflags_t fdflags, __wasi_fd_t* opened_fd)
+extern "C" __wasi_errno_t __wasi_path_open32(__wasi_fd_t fd, __wasi_lookupflags_t dirflags, const char* path, size_t path_len, __wasi_oflags_t oflags, uint32_t fs_rights_base, uint32_t fs_rights_inherting, __wasi_fdflags_t fdflags, __wasi_fd_t* opened_fd)
     __attribute__((
         __import_module__("wasi_snapshot_preview1"),
         __import_name__("path_open32"),
@@ -25,7 +25,7 @@ __wasi_errno_t __wasi_path_open(__wasi_fd_t fd, __wasi_lookupflags_t dirflags, c
 	return __wasi_path_open32(fd, dirflags, path, path_len, oflags, fs_rights_base, fs_rights_inherting, fdflags, opened_fd);
 }
 
-__wasi_errno_t __wasi_fd_seek32(__wasi_fd_t fd, int32_t offset, __wasi_whence_t whence, int32_t* newoffset)
+extern "C" __wasi_errno_t __wasi_fd_seek32(__wasi_fd_t fd, int32_t offset, __wasi_whence_t whence, int32_t* newoffset)
     __attribute__((
         __import_module__("wasi_snapshot_preview1"),
         __import_name__("fd_seek32"),

--- a/gltf/wasistubs.txt
+++ b/gltf/wasistubs.txt
@@ -1,0 +1,2 @@
+__wasi_path_open32
+__wasi_fd_seek32


### PR DESCRIPTION
This PR reworks gltfpack Wasm module as a reactor that provides a function to run packing process.
It can be ran repeatedly with different inputs.

Instead of using the global argc/argv mechanism we simply pass the relevant data to the pack function; this allows to omit the WASI argc/argv implementation.

Instead of using getenv mechanism we replace the command on the JS side for the execute() function.

The WASI layer is implemented in a node.js-agnostic way, with file I/O using typed buffers (Uint8Array); cli.js uses node.js Buffer objects to implement these but an arbitrary implementation should be possible.

Here's a primitive example of running this in the web browser (without file I/O implemented):

```
gltfpack.init(fetch('./library.wasm').then(resp => resp.arrayBuffer()));
gltfpack.pack([], {}).catch(console.log);
```

Fixes #164.