### PR TITLE
gltfpack: More precise and explicit controls over compression/quantization

### DIFF
--- a/gltf/gltfpack.cpp
+++ b/gltf/gltfpack.cpp
@@ -649,7 +649,7 @@ static void process(cgltf_data* data, const char* input_path, const char* output
 
 	const ExtensionInfo extensions[] = {
 	    {"KHR_mesh_quantization", settings.quantize, true},
-	    {"EXT_meshopt_compression", settings.compress, !settings.fallback},
+	    {"EXT_meshopt_compression", settings.compress > 0, !settings.fallback},
 	    {"KHR_texture_transform", settings.quantize && !json_textures.empty(), false},
 	    {"KHR_materials_pbrSpecularGlossiness", ext_pbr_specular_glossiness, false},
 	    {"KHR_materials_clearcoat", ext_clearcoat, false},
@@ -1079,12 +1079,19 @@ int main(int argc, char** argv)
 		}
 		else if (strcmp(arg, "-c") == 0)
 		{
-			settings.compress = true;
+			if (i + 1 < argc && isdigit(argv[i + 1][0]))
+			{
+				settings.compress = atoi(argv[++i]);
+			}
+			else
+			{
+				settings.compress = 2;
+			}
 		}
 		else if (strcmp(arg, "-cc") == 0)
 		{
-			settings.compress = true;
-			settings.compressmore = true;
+			fprintf(stderr, "Warning: -cc is deprecated and will be removed in the future; use -c instead\n");
+			settings.compress = 2;
 		}
 		else if (strcmp(arg, "-cf") == 0)
 		{
@@ -1153,7 +1160,7 @@ int main(int argc, char** argv)
 			fprintf(stderr, "\nBasics:\n");
 			fprintf(stderr, "\t-i file: input file to process, .obj/.gltf/.glb\n");
 			fprintf(stderr, "\t-o file: output file path, .gltf/.glb\n");
-			fprintf(stderr, "\t-c: produce compressed gltf/glb files (-cc for higher compression ratio)\n");
+			fprintf(stderr, "\t-c: produce compressed gltf/glb files with optimal compression\n");
 			fprintf(stderr, "\nTextures:\n");
 			fprintf(stderr, "\t-tc: convert all textures to KTX2 with BasisU supercompression (using basisu/toktx executable)\n");
 			fprintf(stderr, "\t-tu: use UASTC when encoding textures (much higher quality and much larger size)\n");
@@ -1180,6 +1187,7 @@ int main(int argc, char** argv)
 			fprintf(stderr, "\t-mm: merge instances of the same mesh together when possible\n");
 			fprintf(stderr, "\t-mi: use EXT_mesh_gpu_instancing when serializing multiple mesh instances\n");
 			fprintf(stderr, "\nMiscellaneous:\n");
+			fprintf(stderr, "\t-c N: produce compressed gltf/glb files with compression level N (N should be between 0 and 2)\n");
 			fprintf(stderr, "\t-cf: produce compressed gltf/glb files with fallback for loaders that don't support compression\n");
 			fprintf(stderr, "\t-noq: disable quantization; produces much larger glTF files with no extensions\n");
 			fprintf(stderr, "\t-v: verbose output (print version when used without other options)\n");

--- a/gltf/gltfpack.cpp
+++ b/gltf/gltfpack.cpp
@@ -648,7 +648,7 @@ static void process(cgltf_data* data, const char* input_path, const char* output
 	append(json, "}");
 
 	const ExtensionInfo extensions[] = {
-	    {"KHR_mesh_quantization", settings.quantize > 1, true},
+	    {"KHR_mesh_quantization", settings.quantize > 0, true},
 	    {"EXT_meshopt_compression", settings.compress > 0, !settings.fallback},
 	    {"KHR_texture_transform", settings.quantize > 1 && !json_textures.empty(), false},
 	    {"KHR_materials_pbrSpecularGlossiness", ext_pbr_specular_glossiness, false},

--- a/gltf/gltfpack.h
+++ b/gltf/gltfpack.h
@@ -116,8 +116,7 @@ struct Settings
 	float texture_scale;
 	bool texture_pow2;
 
-	bool quantize;
-
+	int quantize;
 	int compress;
 	bool fallback;
 

--- a/gltf/gltfpack.h
+++ b/gltf/gltfpack.h
@@ -118,8 +118,7 @@ struct Settings
 
 	bool quantize;
 
-	bool compress;
-	bool compressmore;
+	int compress;
 	bool fallback;
 
 	int verbose;

--- a/gltf/mesh.cpp
+++ b/gltf/mesh.cpp
@@ -745,7 +745,7 @@ void processMesh(Mesh& mesh, const Settings& settings)
 		filterTriangles(mesh);
 		if (settings.simplify_threshold < 1)
 			simplifyMesh(mesh, settings.simplify_threshold, settings.simplify_aggressive);
-		optimizeMesh(mesh, settings.compressmore);
+		optimizeMesh(mesh, settings.compress > 1);
 		break;
 
 	default:

--- a/gltf/stream.cpp
+++ b/gltf/stream.cpp
@@ -225,7 +225,7 @@ StreamFormat writeVertexStream(std::string& bin, const Stream& stream, const Qua
 {
 	if (stream.type == cgltf_attribute_type_position)
 	{
-		if (!settings.quantize)
+		if (settings.quantize < 2)
 			return writeVertexStreamRaw(bin, stream, cgltf_type_vec3, 3);
 
 		if (stream.target == 0)
@@ -300,7 +300,7 @@ StreamFormat writeVertexStream(std::string& bin, const Stream& stream, const Qua
 	}
 	else if (stream.type == cgltf_attribute_type_texcoord)
 	{
-		if (!settings.quantize)
+		if (settings.quantize < 2)
 			return writeVertexStreamRaw(bin, stream, cgltf_type_vec2, 2);
 
 		float uv_rscale[2] = {
@@ -324,7 +324,7 @@ StreamFormat writeVertexStream(std::string& bin, const Stream& stream, const Qua
 	}
 	else if (stream.type == cgltf_attribute_type_normal)
 	{
-		if (!settings.quantize)
+		if (settings.quantize == 0)
 			return writeVertexStreamRaw(bin, stream, cgltf_type_vec3, 3);
 
 		bool oct = settings.compress > 1 && stream.target == 0;
@@ -401,7 +401,7 @@ StreamFormat writeVertexStream(std::string& bin, const Stream& stream, const Qua
 	}
 	else if (stream.type == cgltf_attribute_type_tangent)
 	{
-		if (!settings.quantize)
+		if (settings.quantize == 0)
 			return writeVertexStreamRaw(bin, stream, cgltf_type_vec4, 4);
 
 		bool oct = settings.compress > 1 && stream.target == 0;

--- a/gltf/stream.cpp
+++ b/gltf/stream.cpp
@@ -327,7 +327,7 @@ StreamFormat writeVertexStream(std::string& bin, const Stream& stream, const Qua
 		if (!settings.quantize)
 			return writeVertexStreamRaw(bin, stream, cgltf_type_vec3, 3);
 
-		bool oct = settings.compressmore && stream.target == 0;
+		bool oct = settings.compress > 1 && stream.target == 0;
 		int bits = settings.nrm_bits;
 
 		StreamFormat::Filter filter = oct ? StreamFormat::Filter_Oct : StreamFormat::Filter_None;
@@ -404,7 +404,7 @@ StreamFormat writeVertexStream(std::string& bin, const Stream& stream, const Qua
 		if (!settings.quantize)
 			return writeVertexStreamRaw(bin, stream, cgltf_type_vec4, 4);
 
-		bool oct = settings.compressmore && stream.target == 0;
+		bool oct = settings.compress > 1 && stream.target == 0;
 		int bits = (settings.nrm_bits > 8) ? 8 : settings.nrm_bits;
 
 		StreamFormat::Filter filter = oct ? StreamFormat::Filter_Oct : StreamFormat::Filter_None;
@@ -626,7 +626,7 @@ StreamFormat writeKeyframeStream(std::string& bin, cgltf_animation_path_type typ
 {
 	if (type == cgltf_animation_path_type_rotation)
 	{
-		StreamFormat::Filter filter = settings.compressmore ? StreamFormat::Filter_Quat : StreamFormat::Filter_None;
+		StreamFormat::Filter filter = settings.compress > 1 ? StreamFormat::Filter_Quat : StreamFormat::Filter_None;
 
 		for (size_t i = 0; i < data.size(); ++i)
 		{
@@ -667,7 +667,7 @@ StreamFormat writeKeyframeStream(std::string& bin, cgltf_animation_path_type typ
 	}
 	else if (type == cgltf_animation_path_type_translation || type == cgltf_animation_path_type_scale)
 	{
-		StreamFormat::Filter filter = settings.compressmore ? StreamFormat::Filter_Exp : StreamFormat::Filter_None;
+		StreamFormat::Filter filter = settings.compress > 1 ? StreamFormat::Filter_Exp : StreamFormat::Filter_None;
 		int bits = (type == cgltf_animation_path_type_translation) ? settings.trn_bits : settings.scl_bits;
 
 		for (size_t i = 0; i < data.size(); ++i)

--- a/gltf/write.cpp
+++ b/gltf/write.cpp
@@ -848,7 +848,7 @@ void writeMeshAttributes(std::string& json, std::vector<BufferView>& views, std:
 		{
 			float min[3] = {};
 			float max[3] = {};
-			getPositionBounds(min, max, stream, settings.quantize ? &qp : NULL);
+			getPositionBounds(min, max, stream, settings.quantize > 1 ? &qp : NULL);
 
 			writeAccessor(json_accessors, view, offset, format.type, format.component_type, format.normalized, stream.data.size(), min, max, 3);
 		}
@@ -926,7 +926,7 @@ size_t writeJointBindMatrices(std::vector<BufferView>& views, std::string& json_
 			cgltf_accessor_read_float(skin.inverse_bind_matrices, j, transform, 16);
 		}
 
-		if (settings.quantize)
+		if (settings.quantize > 1)
 		{
 			float node_scale = qp.scale / float((1 << qp.bits) - 1);
 
@@ -983,7 +983,7 @@ size_t writeInstances(std::vector<BufferView>& views, std::string& json_accessor
 	{
 		decomposeTransform(position[i].f, rotation[i].f, scale[i].f, transforms[i].data);
 
-		if (settings.quantize)
+		if (settings.quantize > 1)
 		{
 			const float* transform = transforms[i].data;
 


### PR DESCRIPTION
This change replaces -c and -cc with `-c N` to specify the compression level (0 = no compression, 1 = basic compression, 2 = thorough compression) and -noq with `-q N` to specify the quantization level (0 = no quantization, 1 = quantize everything that can be quantized without extra extensions, 2 = quantize positions and texture coordinates as well).

Although the issue is that -q 0 actually still quantizes colors and joint weights so I'm not sure this is a good way to specify these... Ideally this would be changed so that -q 0 doesn't do that before merging, although that changes -noq behavior. Alternatively maybe all of this is a bad idea and we should instead just have binary compression & quantization options, where -noq only disables quantization on position and texture coordinates...