### PR TITLE
gltfpack: Preserve the time range for pose-only animations

### DIFF
--- a/gltf/animation.cpp
+++ b/gltf/animation.cpp
@@ -299,6 +299,7 @@ void processAnimation(Animation& animation, const Settings& settings)
 		if (isTrackEqual(track.data, track.path, frames, &track.data[0], track.components))
 		{
 			// track is constant (equal to first keyframe), we only need the first keyframe
+			track.constant = true;
 			track.data.resize(track.components);
 
 			// track.dummy is true iff track redundantly sets up the value to be equal to default node transform

--- a/gltf/gltfpack.h
+++ b/gltf/gltfpack.h
@@ -61,6 +61,7 @@ struct Track
 	cgltf_node* node;
 	cgltf_animation_path_type path;
 
+	bool constant;
 	bool dummy;
 
 	size_t components; // 1 unless path is cgltf_animation_path_type_weights

--- a/gltf/write.cpp
+++ b/gltf/write.cpp
@@ -1211,7 +1211,10 @@ void writeAnimation(std::string& json, std::vector<BufferView>& views, std::stri
 
 	if (tracks.empty())
 	{
-		fprintf(stderr, "Warning: ignoring animation %d because it has no valid tracks\n", int(i));
+		char index[16];
+		sprintf(index, "%d", int(i));
+
+		fprintf(stderr, "Warning: ignoring animation %s because it has no tracks with motion; use -ac to override\n", animation.name && *animation.name ? animation.name : index);
 		return;
 	}
 

--- a/gltf/write.cpp
+++ b/gltf/write.cpp
@@ -890,12 +890,12 @@ size_t writeMeshIndices(std::vector<BufferView>& views, std::string& json_access
 	return index_accr;
 }
 
-static size_t writeAnimationTime(std::vector<BufferView>& views, std::string& json_accessors, size_t& accr_offset, float mint, int frames, const Settings& settings)
+static size_t writeAnimationTime(std::vector<BufferView>& views, std::string& json_accessors, size_t& accr_offset, float mint, int frames, float period, const Settings& settings)
 {
 	std::vector<float> time(frames);
 
 	for (int j = 0; j < frames; ++j)
-		time[j] = mint + float(j) / settings.anim_freq;
+		time[j] = mint + float(j) * period;
 
 	std::string scratch;
 	StreamFormat format = writeTimeStream(scratch, time);
@@ -1225,14 +1225,25 @@ void writeAnimation(std::string& json, std::vector<BufferView>& views, std::stri
 	{
 		const Track& track = *tracks[j];
 
+		assert(track.time.empty());
 		assert(track.data.size() == track.components * (track.constant ? 1 : animation.frames));
 
 		needs_time = needs_time || !track.constant;
 		needs_pose = needs_pose || track.constant;
 	}
 
-	size_t time_accr = needs_time ? writeAnimationTime(views, json_accessors, accr_offset, animation.start, animation.frames, settings) : 0;
-	size_t pose_accr = needs_pose ? writeAnimationTime(views, json_accessors, accr_offset, animation.start, 1, settings) : 0;
+	bool needs_range = needs_pose && !needs_time && animation.frames > 1;
+
+	needs_pose = needs_pose && !(needs_range && tracks.size() == 1);
+
+	assert(int(needs_time) + int(needs_pose) + int(needs_range) <= 2);
+
+	float animation_period = 1.f / float(settings.anim_freq);
+	float animation_length = float(animation.frames - 1) * animation_period;
+
+	size_t time_accr = needs_time ? writeAnimationTime(views, json_accessors, accr_offset, animation.start, animation.frames, animation_period, settings) : 0;
+	size_t pose_accr = needs_pose ? writeAnimationTime(views, json_accessors, accr_offset, animation.start, 1, 0.f, settings) : 0;
+	size_t range_accr = needs_range ? writeAnimationTime(views, json_accessors, accr_offset, animation.start, 2, animation_length, settings) : 0;
 
 	std::string json_samplers;
 	std::string json_channels;
@@ -1243,8 +1254,18 @@ void writeAnimation(std::string& json, std::vector<BufferView>& views, std::stri
 	{
 		const Track& track = *tracks[j];
 
+		bool range = needs_range && j == 0;
+		int range_size = range ? 2 : 1;
+
 		std::string scratch;
 		StreamFormat format = writeKeyframeStream(scratch, track.path, track.data, settings);
+
+		if (range)
+		{
+			assert(range_size == 2);
+			scratch += scratch;
+		}
+
 		BufferView::Compression compression = settings.compress && track.path != cgltf_animation_path_type_weights ? BufferView::Compression_Attribute : BufferView::Compression_None;
 
 		size_t view = getBufferView(views, BufferView::Kind_Keyframe, format.filter, compression, format.stride, track.path);
@@ -1252,13 +1273,13 @@ void writeAnimation(std::string& json, std::vector<BufferView>& views, std::stri
 		views[view].data += scratch;
 
 		comma(json_accessors);
-		writeAccessor(json_accessors, view, offset, format.type, format.component_type, format.normalized, track.data.size());
+		writeAccessor(json_accessors, view, offset, format.type, format.component_type, format.normalized, track.data.size() * range_size);
 
 		size_t data_accr = accr_offset++;
 
 		comma(json_samplers);
 		append(json_samplers, "{\"input\":");
-		append(json_samplers, track.constant ? pose_accr : time_accr);
+		append(json_samplers, range ? range_accr : track.constant ? pose_accr : time_accr);
 		append(json_samplers, ",\"output\":");
 		append(json_samplers, data_accr);
 		append(json_samplers, "}");

--- a/gltf/write.cpp
+++ b/gltf/write.cpp
@@ -1225,10 +1225,10 @@ void writeAnimation(std::string& json, std::vector<BufferView>& views, std::stri
 	{
 		const Track& track = *tracks[j];
 
-		bool tc = track.data.size() == track.components;
+		assert(track.data.size() == track.components * (track.constant ? 1 : animation.frames));
 
-		needs_time = needs_time || !tc;
-		needs_pose = needs_pose || tc;
+		needs_time = needs_time || !track.constant;
+		needs_pose = needs_pose || track.constant;
 	}
 
 	size_t time_accr = needs_time ? writeAnimationTime(views, json_accessors, accr_offset, animation.start, animation.frames, settings) : 0;
@@ -1242,8 +1242,6 @@ void writeAnimation(std::string& json, std::vector<BufferView>& views, std::stri
 	for (size_t j = 0; j < tracks.size(); ++j)
 	{
 		const Track& track = *tracks[j];
-
-		bool tc = track.data.size() == track.components;
 
 		std::string scratch;
 		StreamFormat format = writeKeyframeStream(scratch, track.path, track.data, settings);
@@ -1260,7 +1258,7 @@ void writeAnimation(std::string& json, std::vector<BufferView>& views, std::stri
 
 		comma(json_samplers);
 		append(json_samplers, "{\"input\":");
-		append(json_samplers, tc ? pose_accr : time_accr);
+		append(json_samplers, track.constant ? pose_accr : time_accr);
 		append(json_samplers, ",\"output\":");
 		append(json_samplers, data_accr);
 		append(json_samplers, "}");


### PR DESCRIPTION
When an animation consists exclusively of constant tracks, we would
previously export only a single keyframe for all tracks. This loses time
information that may be important for playback in case the pose is
sequenced for a given duration by the mixer.

To minimize the size impact, we expand exactly one track and only for
animations that don't have actual timed tracks; for that to work we need
to output a special input track with two time values, start and start +
(frames - 1) / freq, which should match the end time that we would emit
if any tracks had data.

Fixes #185.