### PR TITLE
Support for vrm.

### DIFF
--- a/gltf/gltfpack.cpp
+++ b/gltf/gltfpack.cpp
@@ -667,7 +667,7 @@ static void process(cgltf_data* data, const char* input_path, const char* output
 	const ExtensionInfo extensions[] = {
 	    {"KHR_mesh_quantization", settings.quantize, true},
 	    {"EXT_meshopt_compression", settings.compress, !settings.fallback},
-	    {"KHR_texture_transform", settings.quantize && !json_textures.empty(), false},
+	    {"KHR_texture_transform", (settings.quantize && !json_textures.empty()) || (settings.vrm && !json_textures.empty()), false},
 	    {"KHR_materials_pbrSpecularGlossiness", ext_pbr_specular_glossiness, false},
 	    {"KHR_materials_clearcoat", ext_clearcoat, false},
 	    {"KHR_materials_transmission", ext_transmission, false},

--- a/gltf/gltfpack.cpp
+++ b/gltf/gltfpack.cpp
@@ -900,6 +900,7 @@ int gltfpack(const char* input, const char* output, const char* report, Settings
 	{
 		settings.vrm = true;
 		settings.keep_extras = true;
+		settings.quantize = false;
 	}
 
 	std::string json, bin, fallback;

--- a/gltf/gltfpack.cpp
+++ b/gltf/gltfpack.cpp
@@ -442,7 +442,7 @@ static void process(cgltf_data* data, const char* input_path, const char* output
 
 		comma(json_meshes);
 		append(json_meshes, "{");
-		if (mesh.name)
+		if (!mesh.name.empty())
 		{
 			append(json_meshes, "\"name\":\"");
 			append(json_meshes, mesh.name);

--- a/gltf/gltfpack.cpp
+++ b/gltf/gltfpack.cpp
@@ -899,10 +899,6 @@ int gltfpack(const char* input, const char* output, const char* report, Settings
 	{
 		settings.vrm = true;
 		settings.keep_extras = true;
-		settings.keep_materials = true;
-		settings.mesh_merge = false;
-		settings.keep_nodes = true;
-		settings.quantize = false;
 	}
 
 	std::string json, bin, fallback;

--- a/gltf/gltfpack.cpp
+++ b/gltf/gltfpack.cpp
@@ -838,8 +838,9 @@ int gltfpack(const char* input, const char* output, const char* report, Settings
 
 	const char* iext = strrchr(input, '.');
 	const char* oext = output ? strrchr(output, '.') : NULL;
-	
-	if (iext && (strcmp(iext, ".vrm") == 0 || strcmp(iext, ".VRM") == 0)) {
+
+	if (iext && (strcmp(iext, ".vrm") == 0 || strcmp(iext, ".VRM") == 0))
+	{
 		settings.vrm = true;
 	}
 

--- a/gltf/gltfpack.h
+++ b/gltf/gltfpack.h
@@ -39,7 +39,7 @@ struct Transform
 
 struct Mesh
 {
-	const char* name;
+	std::string name;
 	int scene;
 	std::vector<cgltf_node*> nodes;
 	std::vector<Transform> instances;

--- a/gltf/gltfpack.h
+++ b/gltf/gltfpack.h
@@ -39,6 +39,7 @@ struct Transform
 
 struct Mesh
 {
+	const char* name;
 	int scene;
 	std::vector<cgltf_node*> nodes;
 	std::vector<Transform> instances;
@@ -54,6 +55,8 @@ struct Mesh
 	size_t targets;
 	std::vector<float> target_weights;
 	std::vector<const char*> target_names;
+
+	std::string extras;
 };
 
 struct Track
@@ -125,6 +128,8 @@ struct Settings
 	bool fallback;
 
 	int verbose;
+	
+	bool vrm;
 };
 
 struct QuantizationPosition

--- a/gltf/gltfpack.h
+++ b/gltf/gltfpack.h
@@ -128,7 +128,7 @@ struct Settings
 	bool fallback;
 
 	int verbose;
-	
+
 	bool vrm;
 };
 

--- a/gltf/mesh.cpp
+++ b/gltf/mesh.cpp
@@ -725,10 +725,9 @@ static void sortPointMesh(Mesh& mesh)
 }
 
 void processMesh(Mesh& mesh, const Settings& settings)
-{
-	if (!settings.vrm) {
-		filterStreams(mesh);	
-	}
+{	
+	filterStreams(mesh);	
+
 	switch (mesh.type)
 	{
 	case cgltf_primitive_type_points:
@@ -766,9 +765,7 @@ void debugSimplify(const Mesh& source, Mesh& kinds, Mesh& loops, float ratio)
 
 	// note: it's important to follow the same pipeline as processMesh
 	// otherwise the result won't match
-	if (!settings.vrm) {
-		filterStreams(mesh);	
-	}
+	filterStreams(mesh);	
 	filterBones(mesh);
 	reindexMesh(mesh);
 	filterTriangles(mesh);

--- a/gltf/mesh.cpp
+++ b/gltf/mesh.cpp
@@ -726,8 +726,9 @@ static void sortPointMesh(Mesh& mesh)
 
 void processMesh(Mesh& mesh, const Settings& settings)
 {
-	filterStreams(mesh);
-
+	if (!settings.vrm) {
+		filterStreams(mesh);	
+	}
 	switch (mesh.type)
 	{
 	case cgltf_primitive_type_points:

--- a/gltf/mesh.cpp
+++ b/gltf/mesh.cpp
@@ -766,7 +766,9 @@ void debugSimplify(const Mesh& source, Mesh& kinds, Mesh& loops, float ratio)
 
 	// note: it's important to follow the same pipeline as processMesh
 	// otherwise the result won't match
-	filterStreams(mesh);
+	if (!settings.vrm) {
+		filterStreams(mesh);	
+	}
 	filterBones(mesh);
 	reindexMesh(mesh);
 	filterTriangles(mesh);

--- a/gltf/write.cpp
+++ b/gltf/write.cpp
@@ -739,14 +739,6 @@ static std::string decodeUri(const char* uri)
 
 void writeImage(std::string& json, std::vector<BufferView>& views, const cgltf_image& image, const ImageInfo& info, size_t index, const char* input_path, const char* output_path, const Settings& settings)
 {
-	if (image.name)
-	{
-		append(json, "\"name\":");
-		append(json, "\"");
-		append(json, image.name);
-		append(json, "\"");
-		comma(json);
-	}
 	std::string img_data;
 	std::string mime_type;
 
@@ -1328,8 +1320,7 @@ void writeAnimation(std::string& json, std::vector<BufferView>& views, std::stri
 
 		comma(json_samplers);
 		append(json_samplers, "{\"input\":");
-		append(json_samplers, range ? range_accr : track.constant ? pose_accr
-		                                                          : time_accr);
+		append(json_samplers, range ? range_accr : track.constant ? pose_accr : time_accr);
 		append(json_samplers, ",\"output\":");
 		append(json_samplers, data_accr);
 		append(json_samplers, "}");

--- a/gltf/write.cpp
+++ b/gltf/write.cpp
@@ -739,6 +739,14 @@ static std::string decodeUri(const char* uri)
 
 void writeImage(std::string& json, std::vector<BufferView>& views, const cgltf_image& image, const ImageInfo& info, size_t index, const char* input_path, const char* output_path, const Settings& settings)
 {
+	if (image.name)
+	{
+		append(json, "\"name\":");
+		append(json, "\"");
+		append(json, image.name);
+		append(json, "\"");
+		comma(json);
+	}
 	std::string img_data;
 	std::string mime_type;
 
@@ -1320,7 +1328,8 @@ void writeAnimation(std::string& json, std::vector<BufferView>& views, std::stri
 
 		comma(json_samplers);
 		append(json_samplers, "{\"input\":");
-		append(json_samplers, range ? range_accr : track.constant ? pose_accr : time_accr);
+		append(json_samplers, range ? range_accr : track.constant ? pose_accr
+		                                                          : time_accr);
 		append(json_samplers, ",\"output\":");
 		append(json_samplers, data_accr);
 		append(json_samplers, "}");


### PR DESCRIPTION
Use a vrm file extension to trigger processing.

See #198 for test cases and examples.

The command to test is now:

`./gltfpack -i "Miraikomachi.vrm" -o "Miraikomachi Opt.VRM" `
