### PR TITLE
simplify: Restrict edge collapses to avoid triangle flipping

### DIFF
--- a/demo/main.cpp
+++ b/demo/main.cpp
@@ -456,10 +456,6 @@ void simplify(const Mesh& mesh, float threshold = 0.2f)
 
 	double end = timestamp();
 
-#if TRACE
-	dumpObj(lod, /* recomputeNormals= */ true);
-#endif
-
 	printf("%-9s: %d triangles => %d triangles in %.2f msec\n",
 	       "Simplify",
 	       int(mesh.indices.size() / 3), int(lod.indices.size() / 3), (end - start) * 1000);

--- a/demo/main.cpp
+++ b/demo/main.cpp
@@ -138,6 +138,69 @@ Mesh parseObj(const char* path, double& reindex)
 	return result;
 }
 
+void dumpObj(const Mesh& mesh, bool recomputeNormals = false)
+{
+	std::vector<float> normals;
+
+	if (recomputeNormals)
+	{
+		normals.resize(mesh.vertices.size() * 3);
+
+		for (size_t i = 0; i < mesh.indices.size(); i += 3)
+		{
+			unsigned int a = mesh.indices[i], b = mesh.indices[i + 1], c = mesh.indices[i + 2];
+
+			const Vertex& va = mesh.vertices[a];
+			const Vertex& vb = mesh.vertices[b];
+			const Vertex& vc = mesh.vertices[c];
+
+			float nx = (vb.py - va.py) * (vc.pz - va.pz) - (vb.pz - va.pz) * (vc.py - va.py);
+			float ny = (vb.pz - va.pz) * (vc.px - va.px) - (vb.px - va.px) * (vc.pz - va.pz);
+			float nz = (vb.px - va.px) * (vc.py - va.py) - (vb.py - va.py) * (vc.px - va.px);
+
+			for (int k = 0; k < 3; ++k)
+			{
+				unsigned int index = mesh.indices[i + k];
+
+				normals[index * 3 + 0] += nx;
+				normals[index * 3 + 1] += ny;
+				normals[index * 3 + 2] += nz;
+			}
+		}
+	}
+
+	for (size_t i = 0; i < mesh.vertices.size(); ++i)
+	{
+		const Vertex& v = mesh.vertices[i];
+
+		float nx = v.nx, ny = v.ny, nz = v.nz;
+
+		if (recomputeNormals)
+		{
+			nx = normals[i * 3 + 0];
+			ny = normals[i * 3 + 1];
+			nz = normals[i * 3 + 2];
+
+			float l = sqrtf(nx * nx + ny * ny + nz * nz);
+			float s = l == 0.f ? 0.f : 1.f / l;
+
+			nx *= s;
+			ny *= s;
+			nz *= s;
+		}
+
+		fprintf(stderr, "v %f %f %f\n", v.px, v.py, v.pz);
+		fprintf(stderr, "vn %f %f %f\n", nx, ny, nz);
+	}
+
+	for (size_t i = 0; i < mesh.indices.size(); i += 3)
+	{
+		unsigned int a = mesh.indices[i], b = mesh.indices[i + 1], c = mesh.indices[i + 2];
+
+		fprintf(stderr, "f %d %d %d\n", a + 1, b + 1, c + 1);
+	}
+}
+
 bool isMeshValid(const Mesh& mesh)
 {
 	size_t index_count = mesh.indices.size();
@@ -392,6 +455,10 @@ void simplify(const Mesh& mesh, float threshold = 0.2f)
 	lod.vertices.resize(meshopt_optimizeVertexFetch(&lod.vertices[0], &lod.indices[0], lod.indices.size(), &mesh.vertices[0], mesh.vertices.size(), sizeof(Vertex)));
 
 	double end = timestamp();
+
+#if TRACE
+	dumpObj(lod, /* recomputeNormals= */ true);
+#endif
 
 	printf("%-9s: %d triangles => %d triangles in %.2f msec\n",
 	       "Simplify",

--- a/demo/main.cpp
+++ b/demo/main.cpp
@@ -1069,25 +1069,8 @@ void processDev(const char* path)
 	if (!loadMesh(mesh, path))
 		return;
 
-	Mesh copy = mesh;
-	meshopt_optimizeVertexCache(&copy.indices[0], &copy.indices[0], copy.indices.size(), copy.vertices.size());
-	meshopt_optimizeVertexFetch(&copy.vertices[0], &copy.indices[0], copy.indices.size(), &copy.vertices[0], copy.vertices.size(), sizeof(Vertex));
-
-	Mesh copystrip = mesh;
-	meshopt_optimizeVertexCacheStrip(&copystrip.indices[0], &copystrip.indices[0], copystrip.indices.size(), copystrip.vertices.size());
-	meshopt_optimizeVertexFetch(&copystrip.vertices[0], &copystrip.indices[0], copystrip.indices.size(), &copystrip.vertices[0], copystrip.vertices.size(), sizeof(Vertex));
-
-	encodeIndex(copy, ' ');
-	encodeIndex(copystrip, 'S');
-
-	std::vector<unsigned int> strip(meshopt_stripifyBound(copystrip.indices.size()));
-	strip.resize(meshopt_stripify(&strip[0], &copystrip.indices[0], copystrip.indices.size(), copystrip.vertices.size(), 0));
-
-	encodeIndexSequence(strip, copystrip.vertices.size(), 'D');
-
-	packVertex<PackedVertex>(copy, "");
-	encodeVertex<PackedVertex>(copy, "");
-	encodeVertex<PackedVertexOct>(copy, "O");
+	simplify(mesh);
+	simplifySloppy(mesh);
 }
 
 int main(int argc, char** argv)

--- a/demo/tests.cpp
+++ b/demo/tests.cpp
@@ -755,6 +755,53 @@ static void simplifyPointsStuck()
 	assert(meshopt_simplifyPoints(0, vb, 3, 12, 0) == 0);
 }
 
+static void simplifyFlip()
+{
+	// this mesh has been constructed by taking a tessellated irregular grid with a square cutout
+	// and progressively collapsing edges until the only ones left violate border or flip constraints.
+	// there is only one valid non-flip collapse, so we validate that we take it; when flips are allowed,
+	// the wrong collapse is picked instead.
+	float vb[] = {
+	    1.000000f, 1.000000f, -1.000000f,
+	    1.000000f, 1.000000f, 1.000000f,
+	    1.000000f, -1.000000f, 1.000000f,
+	    1.000000f, -0.200000f, -0.200000f,
+	    1.000000f, 0.200000f, -0.200000f,
+	    1.000000f, -0.200000f, 0.200000f,
+	    1.000000f, 0.200000f, 0.200000f,
+	    1.000000f, 0.500000f, -0.500000f,
+	    1.000000f, -1.000000f, 0.000000f, // clang-format :-/
+	};
+
+	// the collapse we expect is 7 -> 0
+	unsigned int ib[] = {
+	    7, 4, 3,
+	    1, 2, 5,
+	    7, 1, 6,
+	    7, 8, 0, // gets removed
+	    7, 6, 4,
+	    8, 5, 2,
+	    8, 7, 3,
+	    8, 3, 5,
+	    5, 6, 1,
+	    7, 0, 1, // gets removed
+	};
+
+	unsigned int expected[] = {
+	    0, 4, 3,
+	    1, 2, 5,
+	    0, 1, 6,
+	    0, 6, 4,
+	    8, 5, 2,
+	    8, 0, 3,
+	    8, 3, 5,
+	    5, 6, 1, // clang-format :-/
+	};
+
+	assert(meshopt_simplify(ib, ib, 30, vb, 9, 12, 3, 1e-3f) == 24);
+	assert(memcmp(ib, expected, sizeof(expected)) == 0);
+}
+
 static void runTestsOnce()
 {
 	decodeIndexV0();
@@ -801,6 +848,7 @@ static void runTestsOnce()
 	simplifyStuck();
 	simplifySloppyStuck();
 	simplifyPointsStuck();
+	simplifyFlip();
 }
 
 namespace meshopt

--- a/src/simplifier.cpp
+++ b/src/simplifier.cpp
@@ -23,12 +23,6 @@
 namespace meshopt
 {
 
-#ifdef _MSC_VER
-#pragma warning(disable: 4127) // conditional expression is constant; TODO remove this with kPreventFlips
-#endif
-
-const bool kPreventFlips = true;
-
 struct EdgeAdjacency
 {
 	struct Edge
@@ -646,12 +640,11 @@ static bool hasTriangleFlips(const EdgeAdjacency& adjacency, const Vector3* vert
 		unsigned int b = collapse_remap[edges[i].prev];
 
 		// skip triangles that get collapsed
-		// note: this is mathematically redundant as if either of these is true, the dot product should be 0
+		// note: this is mathematically redundant as if either of these is true, the dot product in hasTriangleFlip should be 0
 		if (a == i1 || b == i1)
 			continue;
 
 		// early-out when at least one triangle flips due to a collapse
-		// note: since we generally don't expect flips it's not clear if this is better than branchless |=
 		if (hasTriangleFlip(vertex_positions[a], vertex_positions[b], v0, v1))
 			return true;
 	}
@@ -893,7 +886,7 @@ static size_t performEdgeCollapses(unsigned int* collapse_remap, unsigned char* 
 			continue;
 		}
 
-		if (kPreventFlips && hasTriangleFlips(adjacency, vertex_positions, collapse_remap, r0, r1))
+		if (hasTriangleFlips(adjacency, vertex_positions, collapse_remap, r0, r1))
 		{
 			// adjust collapse goal since this collapse is invalid and shouldn't factor into error goal
 			edge_collapse_goal++;
@@ -1329,8 +1322,8 @@ size_t meshopt_simplify(unsigned int* destination, const unsigned int* indices, 
 
 	while (result_count > target_index_count)
 	{
-		if (kPreventFlips)
-			updateEdgeAdjacency(adjacency, result, result_count, vertex_count, remap);
+		// note: throughout the simplification process adjacency structure reflects welded topology for result-in-progress
+		updateEdgeAdjacency(adjacency, result, result_count, vertex_count, remap);
 
 		size_t edge_collapse_count = pickEdgeCollapses(edge_collapses, result, result_count, remap, vertex_kind, loop);
 

--- a/src/simplifier.cpp
+++ b/src/simplifier.cpp
@@ -779,6 +779,7 @@ static void rankEdgeCollapses(Collapse* collapses, size_t collapse_count, const 
 
 		unsigned int i0 = c.v0;
 		unsigned int i1 = c.v1;
+		unsigned int bidi = c.bidi;
 
 		// most edges are bidirectional which means we need to evaluate errors for two collapses
 		// to keep this code branchless we just use the same edge for unidirectional edges
@@ -801,15 +802,16 @@ static void rankEdgeCollapses(Collapse* collapses, size_t collapse_count, const 
 
 		if (kPreventFlips == 3 && hasTriangleFlips(passadjacency, indices, vertex_positions, remap, remap[c.v0], remap[c.v1]))
 		{
-			if (c.bidi && !hasTriangleFlips(passadjacency, indices, vertex_positions, remap, remap[c.v1], remap[c.v0]))
+			if (bidi && !hasTriangleFlips(passadjacency, indices, vertex_positions, remap, remap[c.v1], remap[c.v0]))
 			{
 				// flip collapse
-				c.v0 = ei > ej ? i0 : j0;
-				c.v1 = ei > ej ? i1 : j1;
-				c.error = ei > ej ? ei : ej;
+				c.v0 = ei <= ej ? j0 : i0;
+				c.v1 = ei <= ej ? j1 : i1;
+				c.error = ei <= ej ? ej : ei;
 			}
 			else
 			{
+				// both directions are broken, kill collapse
 				c.error = FLT_MAX;
 			}
 		}

--- a/src/simplifier.cpp
+++ b/src/simplifier.cpp
@@ -23,6 +23,10 @@
 namespace meshopt
 {
 
+#ifdef _MSC_VER
+#pragma warning(disable: 4127) // conditional expression is constant; TODO remove this when kPreventFlips stops being int
+#endif
+
 // 0: don't prevent flips
 // 1: prevent flips by discarding edges during collapse
 // 2: prevent flips by penalizing edges that flip (single direction)
@@ -654,8 +658,8 @@ static void fillEdgeQuadrics(Quadric* vertex_quadrics, const unsigned int* indic
 bool hasTriangleFlip(const Vector3& a, const Vector3& b, const Vector3& c, const Vector3& d)
 {
 	Vector3 eb = {b.x - a.x, b.y - a.y, b.z - a.z};
-	Vector3 ec = {c.x - a.x, c.y - a.y, c.z - b.z};
-	Vector3 ed = {d.x - a.x, d.y - a.y, d.z - d.z};
+	Vector3 ec = {c.x - a.x, c.y - a.y, c.z - a.z};
+	Vector3 ed = {d.x - a.x, d.y - a.y, d.z - a.z};
 
 	Vector3 nbc = {eb.y * ec.z - eb.z * ec.y, eb.z * ec.x - eb.x * ec.z, eb.x * ec.y - eb.y * ec.x};
 	Vector3 nbd = {eb.y * ed.z - eb.z * ed.y, eb.z * ed.x - eb.x * ed.z, eb.x * ed.y - eb.y * ed.x};


### PR DESCRIPTION
Right now simplifier does not restrict edge collapses beyond
topology/quadric errors, which in some cases results in triangles
getting flipped.

This is a well known problem and a well known solution is to check
whether the triangles are flipped explicitly during collapse.

Unfortunately, the simplifier currently doesn't maintain enough data to
be able to perform this analysis; this change adds code to maintain a
second adjacency structure (that identifies triangles during collapse)
and uses it to validate collapses right before they happen.

~The current implementation seems to resolve existing issues with the
flipping but results in substantially worse simplification performance
(4-5x slowdown, most of the work seems to be in hasTriangleFlips). This
will *not* be merged in this state; I'm going to try a couple of different
approaches to cache and/or otherwise adjust the computation to be faster.~

This implementation makes simplification 20-30% slower, but we get improved
resulting meshes and a new adjacency structure that's maintained throughout
collapse passes which may prove beneficial in the future.

Before this change:
![image](https://user-images.githubusercontent.com/1106629/102674031-65b96900-4149-11eb-8d42-e208f42e79b3.png)

After this change:
![image](https://user-images.githubusercontent.com/1106629/103059766-e2d64b00-455a-11eb-9d52-ba8ffa1f8bf0.png)

Fixes #86
Fixes #206