### PR TITLE
Add Make rule for OSS-fuzz

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -124,6 +124,9 @@ codecbench-simd.js codecbench-simd.wasm: tools/codecbench.cpp ${LIBRARY_SOURCES}
 codecfuzz: tools/codecfuzz.cpp src/vertexcodec.cpp src/indexcodec.cpp
 	$(CXX) $^ -fsanitize=fuzzer,address,undefined -O1 -g -o $@
 
+ossfuzz: tools/codecfuzz.cpp src/vertexcodec.cpp src/indexcodec.cpp
+	$(CXX) $^ -o "${OUT}/codecfuzzer" ${LIB_FUZZING_ENGINE}
+
 $(LIBRARY): $(LIBRARY_OBJECTS)
 	ar rcs $@ $^
 


### PR DESCRIPTION
This PR adds a rule in the Makefile to build the codecfuzzer in the OSS-fuzz environment.