### PR TITLE
Removed ossfuzz make rule

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -124,9 +124,6 @@ codecbench-simd.js codecbench-simd.wasm: tools/codecbench.cpp ${LIBRARY_SOURCES}
 codecfuzz: tools/codecfuzz.cpp src/vertexcodec.cpp src/indexcodec.cpp
 	$(CXX) $^ -fsanitize=fuzzer,address,undefined -O1 -g -o $@
 
-ossfuzz: tools/codecfuzz.cpp src/vertexcodec.cpp src/indexcodec.cpp
-	$(CXX) $^ -o "${OUT}/codecfuzzer" ${LIB_FUZZING_ENGINE}
-
 $(LIBRARY): $(LIBRARY_OBJECTS)
 	ar rcs $@ $^
 


### PR DESCRIPTION
The rule is not being used as it is now. It may be brought back at a later time, but it is being removed now to avoid having unused code.