### PR TITLE
simplify: Return error after simplification

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ ifeq ($(config),iphone)
 endif
 
 ifeq ($(config),trace)
-	CXXFLAGS+=-DTRACE=2
+	CXXFLAGS+=-DTRACE=1
 endif
 
 ifeq ($(config),scalar)

--- a/demo/main.cpp
+++ b/demo/main.cpp
@@ -447,18 +447,21 @@ void simplify(const Mesh& mesh, float threshold = 0.2f)
 
 	size_t target_index_count = size_t(mesh.indices.size() * threshold);
 	float target_error = 1e-2f;
+	float result_error = 0;
 
 	lod.indices.resize(mesh.indices.size()); // note: simplify needs space for index_count elements in the destination array, not target_index_count
-	lod.indices.resize(meshopt_simplify(&lod.indices[0], &mesh.indices[0], mesh.indices.size(), &mesh.vertices[0].px, mesh.vertices.size(), sizeof(Vertex), target_index_count, target_error));
+	lod.indices.resize(meshopt_simplify(&lod.indices[0], &mesh.indices[0], mesh.indices.size(), &mesh.vertices[0].px, mesh.vertices.size(), sizeof(Vertex), target_index_count, target_error, &result_error));
 
 	lod.vertices.resize(lod.indices.size() < mesh.vertices.size() ? lod.indices.size() : mesh.vertices.size()); // note: this is just to reduce the cost of resize()
 	lod.vertices.resize(meshopt_optimizeVertexFetch(&lod.vertices[0], &lod.indices[0], lod.indices.size(), &mesh.vertices[0], mesh.vertices.size(), sizeof(Vertex)));
 
 	double end = timestamp();
 
-	printf("%-9s: %d triangles => %d triangles in %.2f msec\n",
+	printf("%-9s: %d triangles => %d triangles (%.2f%% deviation) in %.2f msec\n",
 	       "Simplify",
-	       int(mesh.indices.size() / 3), int(lod.indices.size() / 3), (end - start) * 1000);
+	       int(mesh.indices.size() / 3), int(lod.indices.size() / 3),
+	       result_error * 100,
+	       (end - start) * 1000);
 }
 
 void simplifySloppy(const Mesh& mesh, float threshold = 0.2f)

--- a/demo/tests.cpp
+++ b/demo/tests.cpp
@@ -802,6 +802,13 @@ static void simplifyFlip()
 	assert(memcmp(ib, expected, sizeof(expected)) == 0);
 }
 
+static void simplifyScale()
+{
+	const float vb[] = {0, 0, 0, 1, 0, 0, 0, 2, 0, 0, 0, 3};
+
+	assert(meshopt_simplifyScale(vb, 4, 12) == 3.f);
+}
+
 static void runTestsOnce()
 {
 	decodeIndexV0();
@@ -849,6 +856,7 @@ static void runTestsOnce()
 	simplifySloppyStuck();
 	simplifyPointsStuck();
 	simplifyFlip();
+	simplifyScale();
 }
 
 namespace meshopt

--- a/src/meshoptimizer.h
+++ b/src/meshoptimizer.h
@@ -264,8 +264,10 @@ MESHOPTIMIZER_EXPERIMENTAL void meshopt_decodeFilterExp(void* buffer, size_t ver
  *
  * destination must contain enough space for the *source* index buffer (since optimization is iterative, this means index_count elements - *not* target_index_count!)
  * vertex_positions should have float3 position in the first 12 bytes of each vertex - similar to glVertexPointer
+ * target_error represents the error relative to mesh extents that can be tolerated, e.g. 0.01 = 1% deformation
+ * result_error can be NULL; when it's not NULL, it will contain the resulting (relative) error after simplification
  */
-MESHOPTIMIZER_EXPERIMENTAL size_t meshopt_simplify(unsigned int* destination, const unsigned int* indices, size_t index_count, const float* vertex_positions, size_t vertex_count, size_t vertex_positions_stride, size_t target_index_count, float target_error);
+MESHOPTIMIZER_EXPERIMENTAL size_t meshopt_simplify(unsigned int* destination, const unsigned int* indices, size_t index_count, const float* vertex_positions, size_t vertex_count, size_t vertex_positions_stride, size_t target_index_count, float target_error, float* result_error);
 
 /**
  * Experimental: Mesh simplifier (sloppy)
@@ -521,7 +523,7 @@ inline size_t meshopt_encodeIndexSequence(unsigned char* buffer, size_t buffer_s
 template <typename T>
 inline int meshopt_decodeIndexSequence(T* destination, size_t index_count, const unsigned char* buffer, size_t buffer_size);
 template <typename T>
-inline size_t meshopt_simplify(T* destination, const T* indices, size_t index_count, const float* vertex_positions, size_t vertex_count, size_t vertex_positions_stride, size_t target_index_count, float target_error);
+inline size_t meshopt_simplify(T* destination, const T* indices, size_t index_count, const float* vertex_positions, size_t vertex_count, size_t vertex_positions_stride, size_t target_index_count, float target_error, float* result_error = 0);
 template <typename T>
 inline size_t meshopt_simplifySloppy(T* destination, const T* indices, size_t index_count, const float* vertex_positions, size_t vertex_count, size_t vertex_positions_stride, size_t target_index_count);
 template <typename T>
@@ -836,12 +838,12 @@ inline int meshopt_decodeIndexSequence(T* destination, size_t index_count, const
 }
 
 template <typename T>
-inline size_t meshopt_simplify(T* destination, const T* indices, size_t index_count, const float* vertex_positions, size_t vertex_count, size_t vertex_positions_stride, size_t target_index_count, float target_error)
+inline size_t meshopt_simplify(T* destination, const T* indices, size_t index_count, const float* vertex_positions, size_t vertex_count, size_t vertex_positions_stride, size_t target_index_count, float target_error, float* result_error)
 {
 	meshopt_IndexAdapter<T> in(0, indices, index_count);
 	meshopt_IndexAdapter<T> out(destination, 0, index_count);
 
-	return meshopt_simplify(out.data, in.data, index_count, vertex_positions, vertex_count, vertex_positions_stride, target_index_count, target_error);
+	return meshopt_simplify(out.data, in.data, index_count, vertex_positions, vertex_count, vertex_positions_stride, target_index_count, target_error, result_error);
 }
 
 template <typename T>

--- a/src/meshoptimizer.h
+++ b/src/meshoptimizer.h
@@ -295,6 +295,14 @@ MESHOPTIMIZER_EXPERIMENTAL size_t meshopt_simplifySloppy(unsigned int* destinati
 MESHOPTIMIZER_EXPERIMENTAL size_t meshopt_simplifyPoints(unsigned int* destination, const float* vertex_positions, size_t vertex_count, size_t vertex_positions_stride, size_t target_vertex_count);
 
 /**
+ * Experimental: Returns the error scaling factor used by the simplifier to convert between absolute and relative extents
+ * 
+ * Absolute error must be *divided* by the scaling factor before passing it to meshopt_simplify as target_error
+ * Relative error returned by meshopt_simplify via result_error must be *multiplied* by the scaling factor to get absolute error.
+ */
+MESHOPTIMIZER_EXPERIMENTAL float meshopt_simplifyScale(const float* vertex_positions, size_t vertex_count, size_t vertex_positions_stride);
+
+/**
  * Mesh stripifier
  * Converts a previously vertex cache optimized triangle list to triangle strip, stitching strips using restart index or degenerate triangles
  * Returns the number of indices in the resulting strip, with destination containing new index data


### PR DESCRIPTION
This change adds an extra optional argument, `result_error`, to `meshopt_simplify` that can be used to output the error after the simplification, which - just like target_error - is a measure of the relative (0..1) deviation of the produced result from the source mesh. The argument is optional in C++ but required when C interface is used - NULL can be passed if this information isn't required.

When absolute errors are required instead, newly added `meshopt_simplifyScale` can be used to scale the input or the output error back into world space.

Fixes #59.