### PR TITLE
Rework meshlet construction

### DIFF
--- a/demo/main.cpp
+++ b/demo/main.cpp
@@ -824,6 +824,7 @@ void meshlets(const Mesh& mesh, bool scan)
 {
 	const size_t max_vertices = 64;
 	const size_t max_triangles = 126;
+	const float cone_weight = 0.5f; // note: should be set to 0 unless cone culling is used at runtime!
 
 	// note: input mesh is assumed to be optimized for vertex cache and vertex fetch
 	double start = timestamp();
@@ -832,7 +833,7 @@ void meshlets(const Mesh& mesh, bool scan)
 	if (scan)
 		meshlets.resize(meshopt_buildMeshletsScan(&meshlets[0], &mesh.indices[0], mesh.indices.size(), mesh.vertices.size(), max_vertices, max_triangles));
 	else
-		meshlets.resize(meshopt_buildMeshlets(&meshlets[0], &mesh.indices[0], mesh.indices.size(), &mesh.vertices[0].px, mesh.vertices.size(), sizeof(Vertex), max_vertices, max_triangles));
+		meshlets.resize(meshopt_buildMeshlets(&meshlets[0], &mesh.indices[0], mesh.indices.size(), &mesh.vertices[0].px, mesh.vertices.size(), sizeof(Vertex), max_vertices, max_triangles, cone_weight));
 
 	double end = timestamp();
 

--- a/demo/main.cpp
+++ b/demo/main.cpp
@@ -1178,8 +1178,11 @@ void processDev(const char* path)
 	if (!loadMesh(mesh, path))
 		return;
 
-	meshlets(mesh, false);
-	meshlets(mesh, true);
+	Mesh copy = mesh;
+	meshopt_optimizeVertexCache(&copy.indices[0], &copy.indices[0], copy.indices.size(), copy.vertices.size());
+
+	meshlets(copy, false);
+	meshlets(copy, true);
 }
 
 int main(int argc, char** argv)

--- a/demo/main.cpp
+++ b/demo/main.cpp
@@ -853,7 +853,7 @@ void meshlets(const Mesh& mesh, bool linear)
 	avg_triangles /= double(meshlets.size());
 
 	printf("Meshlets%c: %d meshlets (avg vertices %.1f, avg triangles %.1f, not full %d) in %.2f msec\n",
-		   linear ? 'L' : ' ',
+	       linear ? 'L' : ' ',
 	       int(meshlets.size()), avg_vertices, avg_triangles, int(not_full), (end - start) * 1000);
 
 	float camera[3] = {100, 100, 100};
@@ -917,9 +917,9 @@ void meshlets(const Mesh& mesh, bool linear)
 		meshlets_std += radii[i] < radius_mean + radius_stddev;
 
 	printf("BoundDist: mean %f stddev %f; %.1f%% meshlets are under mean+stddev\n",
-		radius_mean,
-		radius_stddev,
-		double(meshlets_std) / double(meshlets.size()) * 100);
+	       radius_mean,
+	       radius_stddev,
+	       double(meshlets_std) / double(meshlets.size()) * 100);
 
 	printf("ConeCull : rejected apex %d (%.1f%%) / center %d (%.1f%%), trivially accepted %d (%.1f%%) in %.2f msec\n",
 	       int(rejected), double(rejected) / double(meshlets.size()) * 100,

--- a/demo/main.cpp
+++ b/demo/main.cpp
@@ -1182,6 +1182,7 @@ void processDev(const char* path)
 	meshopt_optimizeVertexCache(&copy.indices[0], &copy.indices[0], copy.indices.size(), copy.vertices.size());
 
 	meshlets(copy, false);
+	meshlets(copy, true);
 }
 
 int main(int argc, char** argv)

--- a/demo/main.cpp
+++ b/demo/main.cpp
@@ -1179,6 +1179,7 @@ void processDev(const char* path)
 		return;
 
 	meshlets(mesh, false);
+	meshlets(mesh, true);
 }
 
 int main(int argc, char** argv)

--- a/demo/main.cpp
+++ b/demo/main.cpp
@@ -1178,11 +1178,7 @@ void processDev(const char* path)
 	if (!loadMesh(mesh, path))
 		return;
 
-	Mesh copy = mesh;
-	meshopt_optimizeVertexCache(&copy.indices[0], &copy.indices[0], copy.indices.size(), copy.vertices.size());
-
-	meshlets(copy, false);
-	meshlets(copy, true);
+	meshlets(mesh, false);
 }
 
 int main(int argc, char** argv)

--- a/demo/main.cpp
+++ b/demo/main.cpp
@@ -1181,7 +1181,6 @@ void processDev(const char* path)
 	meshopt_optimizeVertexCache(&copy.indices[0], &copy.indices[0], copy.indices.size(), copy.vertices.size());
 
 	meshlets(copy, false);
-	meshlets(copy, true);
 }
 
 int main(int argc, char** argv)

--- a/demo/main.cpp
+++ b/demo/main.cpp
@@ -820,7 +820,7 @@ void shadow(const Mesh& mesh)
 	       (end - start) * 1000);
 }
 
-void meshlets(const Mesh& mesh, bool linear)
+void meshlets(const Mesh& mesh, bool scan)
 {
 	const size_t max_vertices = 64;
 	const size_t max_triangles = 126;
@@ -829,8 +829,8 @@ void meshlets(const Mesh& mesh, bool linear)
 	double start = timestamp();
 	std::vector<meshopt_Meshlet> meshlets(meshopt_buildMeshletsBound(mesh.indices.size(), max_vertices, max_triangles));
 
-	if (linear)
-		meshlets.resize(meshopt_buildMeshletsLinear(&meshlets[0], &mesh.indices[0], mesh.indices.size(), mesh.vertices.size(), max_vertices, max_triangles));
+	if (scan)
+		meshlets.resize(meshopt_buildMeshletsScan(&meshlets[0], &mesh.indices[0], mesh.indices.size(), mesh.vertices.size(), max_vertices, max_triangles));
 	else
 		meshlets.resize(meshopt_buildMeshlets(&meshlets[0], &mesh.indices[0], mesh.indices.size(), &mesh.vertices[0].px, mesh.vertices.size(), sizeof(Vertex), max_vertices, max_triangles));
 
@@ -853,7 +853,7 @@ void meshlets(const Mesh& mesh, bool linear)
 	avg_triangles /= double(meshlets.size());
 
 	printf("Meshlets%c: %d meshlets (avg vertices %.1f, avg triangles %.1f, not full %d) in %.2f msec\n",
-	       linear ? 'L' : ' ',
+	       scan ? 'S' : ' ',
 	       int(meshlets.size()), avg_vertices, avg_triangles, int(not_full), (end - start) * 1000);
 
 	float camera[3] = {100, 100, 100};

--- a/gltf/gltfpack.cpp
+++ b/gltf/gltfpack.cpp
@@ -321,7 +321,7 @@ static void process(cgltf_data* data, const char* input_path, const char* output
 		{
 			Mesh meshlets = {};
 			Mesh bounds = {};
-			debugMeshlets(meshes[i], meshlets, bounds, settings.meshlet_debug);
+			debugMeshlets(meshes[i], meshlets, bounds, settings.meshlet_debug, /* scan= */ false);
 			debug_meshes.push_back(meshlets);
 			debug_meshes.push_back(bounds);
 		}

--- a/gltf/gltfpack.h
+++ b/gltf/gltfpack.h
@@ -248,7 +248,7 @@ void processAnimation(Animation& animation, const Settings& settings);
 void processMesh(Mesh& mesh, const Settings& settings);
 
 void debugSimplify(const Mesh& mesh, Mesh& kinds, Mesh& loops, float ratio);
-void debugMeshlets(const Mesh& mesh, Mesh& meshlets, Mesh& bounds, int max_vertices);
+void debugMeshlets(const Mesh& mesh, Mesh& meshlets, Mesh& bounds, int max_vertices, bool scan);
 
 bool compareMeshTargets(const Mesh& lhs, const Mesh& rhs);
 bool compareMeshNodes(const Mesh& lhs, const Mesh& rhs);

--- a/gltf/mesh.cpp
+++ b/gltf/mesh.cpp
@@ -870,7 +870,7 @@ void debugMeshlets(const Mesh& source, Mesh& meshlets, Mesh& bounds, int max_ver
 	const size_t max_triangles = 126;
 
 	std::vector<meshopt_Meshlet> mr(meshopt_buildMeshletsBound(mesh.indices.size(), max_vertices, max_triangles));
-	mr.resize(meshopt_buildMeshlets(&mr[0], &mesh.indices[0], mesh.indices.size(), positions->data.size(), max_vertices, max_triangles));
+	mr.resize(meshopt_buildMeshletsScan(&mr[0], &mesh.indices[0], mesh.indices.size(), positions->data.size(), max_vertices, max_triangles));
 
 	// generate meshlet meshes, using unique colors
 	meshlets.nodes = mesh.nodes;

--- a/gltf/mesh.cpp
+++ b/gltf/mesh.cpp
@@ -856,13 +856,15 @@ void debugSimplify(const Mesh& source, Mesh& kinds, Mesh& loops, float ratio)
 		}
 }
 
-void debugMeshlets(const Mesh& source, Mesh& meshlets, Mesh& bounds, int max_vertices)
+void debugMeshlets(const Mesh& source, Mesh& meshlets, Mesh& bounds, int max_vertices, bool scan)
 {
 	Mesh mesh = source;
 	assert(mesh.type == cgltf_primitive_type_triangles);
 
 	reindexMesh(mesh);
-	optimizeMesh(mesh, false);
+
+	if (scan)
+		optimizeMesh(mesh, false);
 
 	const Stream* positions = getStream(mesh, cgltf_attribute_type_position);
 	assert(positions);
@@ -870,7 +872,10 @@ void debugMeshlets(const Mesh& source, Mesh& meshlets, Mesh& bounds, int max_ver
 	const size_t max_triangles = 126;
 
 	std::vector<meshopt_Meshlet> mr(meshopt_buildMeshletsBound(mesh.indices.size(), max_vertices, max_triangles));
-	mr.resize(meshopt_buildMeshletsScan(&mr[0], &mesh.indices[0], mesh.indices.size(), positions->data.size(), max_vertices, max_triangles));
+	if (scan)
+		mr.resize(meshopt_buildMeshletsScan(&mr[0], &mesh.indices[0], mesh.indices.size(), positions->data.size(), max_vertices, max_triangles));
+	else
+		mr.resize(meshopt_buildMeshlets(&mr[0], &mesh.indices[0], mesh.indices.size(), positions->data[0].f, positions->data.size(), sizeof(Attr), max_vertices, max_triangles));
 
 	// generate meshlet meshes, using unique colors
 	meshlets.nodes = mesh.nodes;

--- a/gltf/mesh.cpp
+++ b/gltf/mesh.cpp
@@ -870,12 +870,13 @@ void debugMeshlets(const Mesh& source, Mesh& meshlets, Mesh& bounds, int max_ver
 	assert(positions);
 
 	const size_t max_triangles = 126;
+	const float cone_weight = 0.f;
 
 	std::vector<meshopt_Meshlet> mr(meshopt_buildMeshletsBound(mesh.indices.size(), max_vertices, max_triangles));
 	if (scan)
 		mr.resize(meshopt_buildMeshletsScan(&mr[0], &mesh.indices[0], mesh.indices.size(), positions->data.size(), max_vertices, max_triangles));
 	else
-		mr.resize(meshopt_buildMeshlets(&mr[0], &mesh.indices[0], mesh.indices.size(), positions->data[0].f, positions->data.size(), sizeof(Attr), max_vertices, max_triangles));
+		mr.resize(meshopt_buildMeshlets(&mr[0], &mesh.indices[0], mesh.indices.size(), positions->data[0].f, positions->data.size(), sizeof(Attr), max_vertices, max_triangles, cone_weight));
 
 	// generate meshlet meshes, using unique colors
 	meshlets.nodes = mesh.nodes;

--- a/src/clusterizer.cpp
+++ b/src/clusterizer.cpp
@@ -227,7 +227,7 @@ size_t meshopt_buildMeshlets(struct meshopt_Meshlet* destination, const unsigned
 	memset(used, -1, vertex_count);
 
 	size_t offset = 0;
-	size_t input_cursor = 0;
+	unsigned int input_cursor = 0;
 
 	float meshlet_data[6] = {};
 
@@ -235,7 +235,7 @@ size_t meshopt_buildMeshlets(struct meshopt_Meshlet* destination, const unsigned
 	{
 		unsigned int best_triangle = ~0u;
 		unsigned int best_extra = 3;
-		float best_distance = 1e+35; // TODO FLT_MAX
+		float best_distance = 1e+35f; // TODO FLT_MAX
 		float best_spread = -1.f;
 
 		float meshlet_center_scale = meshlet.triangle_count == 0 ? 0.f : 1.f / float(meshlet.triangle_count);

--- a/src/clusterizer.cpp
+++ b/src/clusterizer.cpp
@@ -308,6 +308,7 @@ size_t kdtreeBuild(KDNode& result, KDNode* nodes, size_t next_node, const Cone* 
 
 	float minv[3] = {FLT_MAX, FLT_MAX, FLT_MAX};
 	float maxv[3] = {-FLT_MAX, -FLT_MAX, -FLT_MAX};
+	float avgv[3] = {};
 
 	for (size_t i = 0; i < count; ++i)
 	{
@@ -320,13 +321,14 @@ size_t kdtreeBuild(KDNode& result, KDNode* nodes, size_t next_node, const Cone* 
 
 			minv[j] = minv[j] > vj ? vj : minv[j];
 			maxv[j] = maxv[j] < vj ? vj : maxv[j];
+			avgv[j] += vj;
 		}
 	}
 
 	float sizev[3] = { maxv[0] - minv[0], maxv[1] - minv[1], maxv[2] - minv[2] };
 	unsigned int axis = sizev[0] >= sizev[1] && sizev[0] >= sizev[2] ? 0 : sizev[1] >= sizev[2] ? 1 : 2;
 
-	float split = (maxv[axis] + minv[axis]) * 0.5f;
+	float split = avgv[axis] / float(count);
 	KDTreeSorter sorter = { data, axis, split };
 	size_t middle = std::partition(indices, indices + count, sorter) - indices;
 

--- a/src/clusterizer.cpp
+++ b/src/clusterizer.cpp
@@ -378,23 +378,13 @@ void kdtreeNearest(KDNode* nodes, unsigned int root, const Cone* triangles, cons
 	}
 
 	float delta = position[node.axis] - node.split;
-	unsigned int left = node.children * 2 - 1;
-	unsigned int right = node.children * 2;
+	unsigned int first = node.children * 2 - (delta <= 0);
+	unsigned int second = ((first + 1) ^ 1) - 1;
 
-	if (delta <= 0)
-	{
-		kdtreeNearest(nodes, left, triangles, emitted_flags, position, result, limit);
+	kdtreeNearest(nodes, first, triangles, emitted_flags, position, result, limit);
 
-		if (delta >= -limit)
-			kdtreeNearest(nodes, right, triangles, emitted_flags, position, result, limit);
-	}
-	else
-	{
-		kdtreeNearest(nodes, right, triangles, emitted_flags, position, result, limit);
-
-		if (delta <= limit)
-			kdtreeNearest(nodes, left, triangles, emitted_flags, position, result, limit);
-	}
+	if (fabsf(delta) <= limit)
+		kdtreeNearest(nodes, second, triangles, emitted_flags, position, result, limit);
 }
 
 } // namespace meshopt

--- a/src/clusterizer.cpp
+++ b/src/clusterizer.cpp
@@ -138,6 +138,65 @@ static void computeBoundingSphere(float result[4], const float points[][3], size
 	result[3] = radius;
 }
 
+static size_t hashBuckets3(size_t count)
+{
+	size_t buckets = 1;
+	while (buckets < count)
+		buckets *= 2;
+
+	return buckets;
+}
+
+static void buildWedges(unsigned int* wedge, const float* vertex_positions, size_t vertex_stride_float, size_t vertex_count, meshopt_Allocator& allocator)
+{
+	memset(wedge, -1, vertex_count * sizeof(unsigned int));
+
+	size_t table_size = hashBuckets3(vertex_count);
+	unsigned int* table = allocator.allocate<unsigned int>(table_size);
+	memset(table, -1, table_size * sizeof(unsigned int));
+
+	for (size_t i = 0; i < vertex_count; ++i)
+	{
+		// MurmurHash2
+		const unsigned int m = 0x5bd1e995;
+		const int r = 24;
+
+		unsigned int h = 0;
+		const unsigned int* key = reinterpret_cast<const unsigned int*>(vertex_positions + i * vertex_stride_float);
+
+		for (size_t j = 0; j < 3; ++j)
+		{
+			unsigned int k = key[j];
+
+			k *= m;
+			k ^= k >> r;
+			k *= m;
+
+			h *= m;
+			h ^= k;
+		}
+
+		unsigned int& next = table[h & (table_size - 1)];
+
+		wedge[i] = next;
+		next = unsigned(i);
+	}
+
+	for (size_t i = 0; i < table_size; ++i)
+	{
+		if (table[i] == ~0u)
+			continue;
+
+		unsigned int start = table[i];
+		unsigned int end = start;
+
+		while (wedge[end] != ~0u)
+			end = wedge[end];
+
+		wedge[end] = start;
+	}
+}
+
 } // namespace meshopt
 
 size_t meshopt_buildMeshletsBound(size_t index_count, size_t max_vertices, size_t max_triangles)
@@ -168,9 +227,6 @@ size_t meshopt_buildMeshlets(struct meshopt_Meshlet* destination, const unsigned
 
 	size_t vertex_stride_float = vertex_positions_stride / sizeof(float);
 
-	(void)vertex_stride_float;
-	(void)vertex_positions;
-
 	meshopt_Allocator allocator;
 
 	meshopt_Meshlet meshlet;
@@ -180,9 +236,11 @@ size_t meshopt_buildMeshlets(struct meshopt_Meshlet* destination, const unsigned
 	assert(max_vertices <= 255);
 	assert(max_triangles <= sizeof(meshlet.indices) / 3);
 
-	// TODO: build adjacency from position-index data only
 	TriangleAdjacency adjacency = {};
 	buildTriangleAdjacency(adjacency, indices, index_count, vertex_count, allocator);
+
+	unsigned int* wedge = allocator.allocate<unsigned int>(vertex_count);
+	buildWedges(wedge, vertex_positions, vertex_stride_float, vertex_count, allocator);
 
 	unsigned int* live_triangles = allocator.allocate<unsigned int>(vertex_count);
 	memcpy(live_triangles, adjacency.counts, vertex_count * sizeof(unsigned int));
@@ -313,6 +371,53 @@ size_t meshopt_buildMeshlets(struct meshopt_Meshlet* destination, const unsigned
 			}
 
         // done:;
+		}
+
+		if (best_triangle == ~0u)
+		{
+			unsigned int best_vertex = ~0u;
+
+			for (size_t i = 0; i < meshlet.vertex_count; ++i)
+			{
+				unsigned int index = meshlet.vertices[i];
+
+				for (;;)
+				{
+					if (live_triangles[index] > 0)
+					{
+						const float* pos = vertex_positions + vertex_stride_float * index;
+
+						float distance =
+						    (pos[0] - meshlet_center[0]) *
+						        (pos[0] - meshlet_center[0]) +
+						    (pos[1] - meshlet_center[1]) *
+						        (pos[1] - meshlet_center[1]) +
+						    (pos[2] - meshlet_center[2]) *
+						        (pos[2] - meshlet_center[2]);
+
+						if (distance < best_distance)
+						{
+							best_vertex = index;
+							best_distance = distance;
+						}
+					}
+
+					if (wedge[index] == meshlet.vertices[i])
+						break;
+
+					index = wedge[index];
+				}
+			}
+
+			if (best_vertex != ~0u)
+			{
+				unsigned int* neighbours = &adjacency.data[0] + adjacency.offsets[best_vertex];
+				size_t neighbours_size = adjacency.counts[best_vertex];
+
+				assert(neighbours_size > 0);
+				assert(!emitted_flags[neighbours[0]]);
+				best_triangle = neighbours[0];
+			}
 		}
 
 		if (best_triangle == ~0u)

--- a/src/clusterizer.cpp
+++ b/src/clusterizer.cpp
@@ -282,25 +282,28 @@ static size_t kdtreePartition(unsigned int* indices, size_t count, const float* 
 	assert(count > 0);
 
 	size_t l = 0;
-	size_t r = count - 1;
+	size_t r = count;
 
-	while (l < r)
+	while (l != r)
 	{
 		while (points[indices[l] * stride + axis] < pivot)
+		{
 			l++;
+			if (l == r) return l;
+		}
 
-		while (points[indices[r] * stride + axis] > pivot)
+		do
+		{
 			r--;
-
-		if (l >= r)
-			break;
+			if (l == r) return l;
+		}
+		while (points[indices[r] * stride + axis] > pivot);
 
 		unsigned int t = indices[l];
 		indices[l] = indices[r];
 		indices[r] = t;
 
 		l++;
-		r--;
 	}
 
 	return l;

--- a/src/clusterizer.cpp
+++ b/src/clusterizer.cpp
@@ -13,14 +13,14 @@
 namespace meshopt
 {
 
-struct TriangleAdjacency
+struct TriangleAdjacency2
 {
 	unsigned int* counts;
 	unsigned int* offsets;
 	unsigned int* data;
 };
 
-static void buildTriangleAdjacency(TriangleAdjacency& adjacency, const unsigned int* indices, size_t index_count, size_t vertex_count, meshopt_Allocator& allocator)
+static void buildTriangleAdjacency(TriangleAdjacency2& adjacency, const unsigned int* indices, size_t index_count, size_t vertex_count, meshopt_Allocator& allocator)
 {
 	size_t face_count = index_count / 3;
 
@@ -469,7 +469,7 @@ size_t meshopt_buildMeshlets(meshopt_Meshlet* destination, const unsigned int* i
 	assert(max_vertices <= 255);
 	assert(max_triangles <= sizeof(meshlet.indices) / 3);
 
-	TriangleAdjacency adjacency = {};
+	TriangleAdjacency2 adjacency = {};
 	buildTriangleAdjacency(adjacency, indices, index_count, vertex_count, allocator);
 
 	unsigned int* live_triangles = allocator.allocate<unsigned int>(vertex_count);

--- a/src/clusterizer.cpp
+++ b/src/clusterizer.cpp
@@ -436,7 +436,7 @@ size_t meshopt_buildMeshletsBound(size_t index_count, size_t max_vertices, size_
 	return meshlet_limit_vertices > meshlet_limit_triangles ? meshlet_limit_vertices : meshlet_limit_triangles;
 }
 
-size_t meshopt_buildMeshlets(struct meshopt_Meshlet* destination, const unsigned int* indices, size_t index_count, const float* vertex_positions, size_t vertex_count, size_t vertex_positions_stride, size_t max_vertices, size_t max_triangles, float cone_weight)
+size_t meshopt_buildMeshlets(meshopt_Meshlet* destination, const unsigned int* indices, size_t index_count, const float* vertex_positions, size_t vertex_count, size_t vertex_positions_stride, size_t max_vertices, size_t max_triangles, float cone_weight)
 {
 	using namespace meshopt;
 

--- a/src/clusterizer.cpp
+++ b/src/clusterizer.cpp
@@ -375,9 +375,9 @@ static void kdtreeNearest(KDNode* nodes, unsigned int root, const float* points,
 {
 	const KDNode& node = nodes[root];
 
-	// leaf
 	if (node.axis == 3)
 	{
+		// leaf
 		for (unsigned int i = 0; i <= node.children; ++i)
 		{
 			unsigned int index = nodes[root + i].index;
@@ -399,20 +399,20 @@ static void kdtreeNearest(KDNode* nodes, unsigned int root, const float* points,
 				limit = distance;
 			}
 		}
-
-		return;
 	}
+	else
+	{
+		// branch; we order recursion to process the node that search position is in first
+		float delta = position[node.axis] - node.split;
+		unsigned int first = (delta <= 0) ? 0 : node.children;
+		unsigned int second = first ^ node.children;
 
-	// branch; we order recursion to process the node that search position is in first
-	float delta = position[node.axis] - node.split;
-	unsigned int first = (delta <= 0) ? 0 : node.children;
-	unsigned int second = first ^ node.children;
+		kdtreeNearest(nodes, root + 1 + first, points, stride, emitted_flags, position, result, limit);
 
-	kdtreeNearest(nodes, root + 1 + first, points, stride, emitted_flags, position, result, limit);
-
-	// only process the other node if it can have a match based on closest distance so far
-	if (fabsf(delta) <= limit)
-		kdtreeNearest(nodes, root + 1 + second, points, stride, emitted_flags, position, result, limit);
+		// only process the other node if it can have a match based on closest distance so far
+		if (fabsf(delta) <= limit)
+			kdtreeNearest(nodes, root + 1 + second, points, stride, emitted_flags, position, result, limit);
+	}
 }
 
 } // namespace meshopt

--- a/src/clusterizer.cpp
+++ b/src/clusterizer.cpp
@@ -279,40 +279,23 @@ struct KDNode
 
 static size_t kdtreePartition(unsigned int* indices, size_t count, const float* points, size_t stride, unsigned int axis, float pivot)
 {
-	assert(count > 0);
+	size_t m = 0;
 
-	size_t l = 0;
-	size_t r = count;
-
-	// invariant: all elements before l are less than or equal to pivot
-	// invariant: all elements at or after r are greater than pivot
-	while (l != r)
+	// invariant: elements in range [0, m) are < pivot, elements in range [m, i) are >= pivot
+	for (size_t i = 0; i < count; ++i)
 	{
-		// preserves invariant l, makes sure the leftover range is not empty
-		while (points[indices[l] * stride + axis] < pivot)
-		{
-			l++;
-			if (l == r) return l;
-		}
+		float v = points[indices[i] * stride + axis];
 
-		// preserves invariant r until loop exit, makes sure the leftover range is not empty
-		do
-		{
-			r--;
-			if (l == r) return l;
-		}
-		while (points[indices[r] * stride + axis] > pivot);
+		// swap(m, i) unconditionally
+		unsigned int t = indices[m];
+		indices[m] = indices[i];
+		indices[i] = t;
 
-		// per invariants above we have at least one element remaining
-		// element at index r is now <= pivot, swapping it restores loop invariants
-		unsigned int t = indices[l];
-		indices[l] = indices[r];
-		indices[r] = t;
-
-		l++;
+		// when v >= pivot, we swap i with m without advancing it, preserving invariants
+		m += v < pivot;
 	}
 
-	return l;
+	return m;
 }
 
 static size_t kdtreeBuildLeaf(size_t offset, KDNode* nodes, size_t node_count, unsigned int* indices, size_t count)

--- a/src/clusterizer.cpp
+++ b/src/clusterizer.cpp
@@ -377,6 +377,31 @@ size_t meshopt_buildMeshlets(struct meshopt_Meshlet* destination, const unsigned
 		{
 			unsigned int best_vertex = ~0u;
 
+		#if 1
+			for (size_t i = 0; i < vertex_count; ++i)
+			{
+				unsigned int index = unsigned(i);
+
+				if (live_triangles[index] > 0)
+				{
+					const float* pos = vertex_positions + vertex_stride_float * index;
+
+					float distance =
+					    (pos[0] - meshlet_center[0]) *
+					        (pos[0] - meshlet_center[0]) +
+					    (pos[1] - meshlet_center[1]) *
+					        (pos[1] - meshlet_center[1]) +
+					    (pos[2] - meshlet_center[2]) *
+					        (pos[2] - meshlet_center[2]);
+
+					if (distance < best_distance)
+					{
+						best_vertex = index;
+						best_distance = distance;
+					}
+				}
+			}
+		#else
 			for (size_t i = 0; i < meshlet.vertex_count; ++i)
 			{
 				unsigned int index = meshlet.vertices[i];
@@ -408,11 +433,13 @@ size_t meshopt_buildMeshlets(struct meshopt_Meshlet* destination, const unsigned
 					index = wedge[index];
 				}
 			}
+		#endif
 
 			if (best_vertex != ~0u)
 			{
 				unsigned int* neighbours = &adjacency.data[0] + adjacency.offsets[best_vertex];
 				size_t neighbours_size = adjacency.counts[best_vertex];
+				(void)neighbours_size;
 
 				assert(neighbours_size > 0);
 				assert(!emitted_flags[neighbours[0]]);

--- a/src/clusterizer.cpp
+++ b/src/clusterizer.cpp
@@ -419,7 +419,7 @@ size_t meshopt_buildMeshlets(struct meshopt_Meshlet* destination, const unsigned
 	return offset;
 }
 
-size_t meshopt_buildMeshletsLinear(meshopt_Meshlet* destination, const unsigned int* indices, size_t index_count, size_t vertex_count, size_t max_vertices, size_t max_triangles)
+size_t meshopt_buildMeshletsScan(meshopt_Meshlet* destination, const unsigned int* indices, size_t index_count, size_t vertex_count, size_t max_vertices, size_t max_triangles)
 {
 	assert(index_count % 3 == 0);
 	assert(max_vertices >= 3);

--- a/src/clusterizer.cpp
+++ b/src/clusterizer.cpp
@@ -234,17 +234,12 @@ size_t meshopt_buildMeshlets(struct meshopt_Meshlet* destination, const unsigned
 		float best_distance = 1e+35; // TODO FLT_MAX
 		float best_spread = -1.f;
 
-		// TODO: update meshlet center as we go
-		float meshlet_points[64][3];
-		for (size_t i = 0; i < meshlet.vertex_count; ++i)
-		{
-			meshlet_points[i][0] = vertex_positions[meshlet.vertices[i] * vertex_stride_float + 0];
-			meshlet_points[i][1] = vertex_positions[meshlet.vertices[i] * vertex_stride_float + 1];
-			meshlet_points[i][2] = vertex_positions[meshlet.vertices[i] * vertex_stride_float + 2];
-		}
+		float meshlet_center_scale = meshlet.triangle_count == 0 ? 0.f : 1.f / float(meshlet.triangle_count);
 
-		float meshlet_center[4];
-		computeBoundingSphere(meshlet_center, meshlet_points, meshlet.vertex_count);
+		float meshlet_center[3];
+		meshlet_center[0] = meshlet_data[0] * meshlet_center_scale;
+		meshlet_center[1] = meshlet_data[1] * meshlet_center_scale;
+		meshlet_center[2] = meshlet_data[2] * meshlet_center_scale;
 
 		float meshlet_axis = meshlet_data[3] * meshlet_data[3] + meshlet_data[4] * meshlet_data[4] + meshlet_data[5] * meshlet_data[5];
 		float meshlet_axis_scale = meshlet_axis == 0.f ? 0.f : 1.f / sqrtf(meshlet_axis);
@@ -277,24 +272,26 @@ size_t meshopt_buildMeshlets(struct meshopt_Meshlet* destination, const unsigned
 				        (triangle_data[triangle * 6 + 2] - meshlet_center[2]);
 
 				float spread = meshlet_axis_scale *
-					(triangle_data[triangle * 6 + 3] * meshlet_data[3] +
-					triangle_data[triangle * 6 + 4] * meshlet_data[4] +
-					triangle_data[triangle * 6 + 5] * meshlet_data[5]);
+				               (triangle_data[triangle * 6 + 3] * meshlet_data[3] +
+				                triangle_data[triangle * 6 + 4] * meshlet_data[4] +
+				                triangle_data[triangle * 6 + 5] * meshlet_data[5]);
 
 				(void)best_distance;
 				(void)best_spread;
 
-			#if 1
+#if 0
 				if (extra < best_extra || (extra == best_extra && spread > best_spread))
-			#else
+#else
 				if (extra < best_extra || (extra == best_extra && distance < best_distance))
-			#endif
+#endif
 				{
 					best_triangle = triangle;
 					best_extra = extra;
 					best_distance = distance;
 					best_spread = spread;
 				}
+
+				// TODO: early out when best extra is 0
 			}
 		}
 

--- a/src/meshoptimizer.h
+++ b/src/meshoptimizer.h
@@ -387,8 +387,9 @@ struct meshopt_Meshlet
  *
  * destination must contain enough space for all meshlets, worst case size can be computed with meshopt_buildMeshletsBound
  * max_vertices and max_triangles can't exceed limits statically declared in meshopt_Meshlet (max_vertices <= 64, max_triangles <= 126)
+ * cone_weight should be set to 0 when cone culling is not used, and a value between 0 and 1 otherwise to balance between cluster size and cone culling efficiency
  */
-MESHOPTIMIZER_EXPERIMENTAL size_t meshopt_buildMeshlets(struct meshopt_Meshlet* destination, const unsigned int* indices, size_t index_count, const float* vertex_positions, size_t vertex_count, size_t vertex_positions_stride, size_t max_vertices, size_t max_triangles);
+MESHOPTIMIZER_EXPERIMENTAL size_t meshopt_buildMeshlets(struct meshopt_Meshlet* destination, const unsigned int* indices, size_t index_count, const float* vertex_positions, size_t vertex_count, size_t vertex_positions_stride, size_t max_vertices, size_t max_triangles, float cone_weight);
 MESHOPTIMIZER_EXPERIMENTAL size_t meshopt_buildMeshletsScan(struct meshopt_Meshlet* destination, const unsigned int* indices, size_t index_count, size_t vertex_count, size_t max_vertices, size_t max_triangles);
 MESHOPTIMIZER_EXPERIMENTAL size_t meshopt_buildMeshletsBound(size_t index_count, size_t max_vertices, size_t max_triangles);
 
@@ -548,7 +549,7 @@ inline meshopt_OverdrawStatistics meshopt_analyzeOverdraw(const T* indices, size
 template <typename T>
 inline meshopt_VertexFetchStatistics meshopt_analyzeVertexFetch(const T* indices, size_t index_count, size_t vertex_count, size_t vertex_size);
 template <typename T>
-inline size_t meshopt_buildMeshlets(meshopt_Meshlet* destination, const T* indices, size_t index_count, const float* vertex_positions, size_t vertex_count, size_t vertex_positions_stride, size_t max_vertices, size_t max_triangles);
+inline size_t meshopt_buildMeshlets(meshopt_Meshlet* destination, const T* indices, size_t index_count, const float* vertex_positions, size_t vertex_count, size_t vertex_positions_stride, size_t max_vertices, size_t max_triangles, float cone_weight);
 template <typename T>
 inline size_t meshopt_buildMeshletsScan(meshopt_Meshlet* destination, const T* indices, size_t index_count, size_t vertex_count, size_t max_vertices, size_t max_triangles);
 template <typename T>
@@ -911,11 +912,11 @@ inline meshopt_VertexFetchStatistics meshopt_analyzeVertexFetch(const T* indices
 }
 
 template <typename T>
-inline size_t meshopt_buildMeshlets(meshopt_Meshlet* destination, const T* indices, size_t index_count, const float* vertex_positions, size_t vertex_count, size_t vertex_positions_stride, size_t max_vertices, size_t max_triangles)
+inline size_t meshopt_buildMeshlets(meshopt_Meshlet* destination, const T* indices, size_t index_count, const float* vertex_positions, size_t vertex_count, size_t vertex_positions_stride, size_t max_vertices, size_t max_triangles, float cone_weight)
 {
 	meshopt_IndexAdapter<T> in(0, indices, index_count);
 
-	return meshopt_buildMeshlets(destination, in.data, index_count, vertex_positions, vertex_count, vertex_positions_stride, max_vertices, max_triangles);
+	return meshopt_buildMeshlets(destination, in.data, index_count, vertex_positions, vertex_count, vertex_positions_stride, max_vertices, max_triangles, cone_weight);
 }
 
 template <typename T>

--- a/src/meshoptimizer.h
+++ b/src/meshoptimizer.h
@@ -388,7 +388,8 @@ struct meshopt_Meshlet
  * destination must contain enough space for all meshlets, worst case size can be computed with meshopt_buildMeshletsBound
  * max_vertices and max_triangles can't exceed limits statically declared in meshopt_Meshlet (max_vertices <= 64, max_triangles <= 126)
  */
-MESHOPTIMIZER_EXPERIMENTAL size_t meshopt_buildMeshlets(struct meshopt_Meshlet* destination, const unsigned int* indices, size_t index_count, size_t vertex_count, size_t max_vertices, size_t max_triangles);
+MESHOPTIMIZER_EXPERIMENTAL size_t meshopt_buildMeshlets(struct meshopt_Meshlet* destination, const unsigned int* indices, size_t index_count, const float* vertex_positions, size_t vertex_count, size_t vertex_positions_stride, size_t max_vertices, size_t max_triangles);
+MESHOPTIMIZER_EXPERIMENTAL size_t meshopt_buildMeshletsLinear(struct meshopt_Meshlet* destination, const unsigned int* indices, size_t index_count, size_t vertex_count, size_t max_vertices, size_t max_triangles);
 MESHOPTIMIZER_EXPERIMENTAL size_t meshopt_buildMeshletsBound(size_t index_count, size_t max_vertices, size_t max_triangles);
 
 struct meshopt_Bounds
@@ -547,7 +548,9 @@ inline meshopt_OverdrawStatistics meshopt_analyzeOverdraw(const T* indices, size
 template <typename T>
 inline meshopt_VertexFetchStatistics meshopt_analyzeVertexFetch(const T* indices, size_t index_count, size_t vertex_count, size_t vertex_size);
 template <typename T>
-inline size_t meshopt_buildMeshlets(meshopt_Meshlet* destination, const T* indices, size_t index_count, size_t vertex_count, size_t max_vertices, size_t max_triangles);
+inline size_t meshopt_buildMeshlets(meshopt_Meshlet* destination, const T* indices, size_t index_count, const float* vertex_positions, size_t vertex_count, size_t vertex_positions_stride, size_t max_vertices, size_t max_triangles);
+template <typename T>
+inline size_t meshopt_buildMeshletsLinear(meshopt_Meshlet* destination, const T* indices, size_t index_count, size_t vertex_count, size_t max_vertices, size_t max_triangles);
 template <typename T>
 inline meshopt_Bounds meshopt_computeClusterBounds(const T* indices, size_t index_count, const float* vertex_positions, size_t vertex_count, size_t vertex_positions_stride);
 template <typename T>
@@ -908,11 +911,19 @@ inline meshopt_VertexFetchStatistics meshopt_analyzeVertexFetch(const T* indices
 }
 
 template <typename T>
-inline size_t meshopt_buildMeshlets(meshopt_Meshlet* destination, const T* indices, size_t index_count, size_t vertex_count, size_t max_vertices, size_t max_triangles)
+inline size_t meshopt_buildMeshlets(meshopt_Meshlet* destination, const T* indices, size_t index_count, const float* vertex_positions, size_t vertex_count, size_t vertex_positions_stride, size_t max_vertices, size_t max_triangles)
 {
 	meshopt_IndexAdapter<T> in(0, indices, index_count);
 
-	return meshopt_buildMeshlets(destination, in.data, index_count, vertex_count, max_vertices, max_triangles);
+	return meshopt_buildMeshlets(destination, in.data, index_count, vertex_positions, vertex_count, vertex_positions_stride, max_vertices, max_triangles);
+}
+
+template <typename T>
+inline size_t meshopt_buildMeshletsLinear(meshopt_Meshlet* destination, const T* indices, size_t index_count, size_t vertex_count, size_t max_vertices, size_t max_triangles)
+{
+	meshopt_IndexAdapter<T> in(0, indices, index_count);
+
+	return meshopt_buildMeshletsLinear(destination, in.data, index_count, vertex_count, max_vertices, max_triangles);
 }
 
 template <typename T>

--- a/src/meshoptimizer.h
+++ b/src/meshoptimizer.h
@@ -383,9 +383,11 @@ struct meshopt_Meshlet
  * Experimental: Meshlet builder
  * Splits the mesh into a set of meshlets where each meshlet has a micro index buffer indexing into meshlet vertices that refer to the original vertex buffer
  * The resulting data can be used to render meshes using NVidia programmable mesh shading pipeline, or in other cluster-based renderers.
- * For maximum efficiency the index buffer being converted has to be optimized for vertex cache first.
+ * When using buildMeshlets, vertex positions need to be provided to minimize the size of the resulting clusters.
+ * When using buildMeshletsScan, for maximum efficiency the index buffer being converted has to be optimized for vertex cache first.
  *
  * destination must contain enough space for all meshlets, worst case size can be computed with meshopt_buildMeshletsBound
+ * vertex_positions should have float3 position in the first 12 bytes of each vertex - similar to glVertexPointer
  * max_vertices and max_triangles can't exceed limits statically declared in meshopt_Meshlet (max_vertices <= 64, max_triangles <= 126)
  * cone_weight should be set to 0 when cone culling is not used, and a value between 0 and 1 otherwise to balance between cluster size and cone culling efficiency
  */

--- a/src/meshoptimizer.h
+++ b/src/meshoptimizer.h
@@ -389,7 +389,7 @@ struct meshopt_Meshlet
  * max_vertices and max_triangles can't exceed limits statically declared in meshopt_Meshlet (max_vertices <= 64, max_triangles <= 126)
  */
 MESHOPTIMIZER_EXPERIMENTAL size_t meshopt_buildMeshlets(struct meshopt_Meshlet* destination, const unsigned int* indices, size_t index_count, const float* vertex_positions, size_t vertex_count, size_t vertex_positions_stride, size_t max_vertices, size_t max_triangles);
-MESHOPTIMIZER_EXPERIMENTAL size_t meshopt_buildMeshletsLinear(struct meshopt_Meshlet* destination, const unsigned int* indices, size_t index_count, size_t vertex_count, size_t max_vertices, size_t max_triangles);
+MESHOPTIMIZER_EXPERIMENTAL size_t meshopt_buildMeshletsScan(struct meshopt_Meshlet* destination, const unsigned int* indices, size_t index_count, size_t vertex_count, size_t max_vertices, size_t max_triangles);
 MESHOPTIMIZER_EXPERIMENTAL size_t meshopt_buildMeshletsBound(size_t index_count, size_t max_vertices, size_t max_triangles);
 
 struct meshopt_Bounds
@@ -550,7 +550,7 @@ inline meshopt_VertexFetchStatistics meshopt_analyzeVertexFetch(const T* indices
 template <typename T>
 inline size_t meshopt_buildMeshlets(meshopt_Meshlet* destination, const T* indices, size_t index_count, const float* vertex_positions, size_t vertex_count, size_t vertex_positions_stride, size_t max_vertices, size_t max_triangles);
 template <typename T>
-inline size_t meshopt_buildMeshletsLinear(meshopt_Meshlet* destination, const T* indices, size_t index_count, size_t vertex_count, size_t max_vertices, size_t max_triangles);
+inline size_t meshopt_buildMeshletsScan(meshopt_Meshlet* destination, const T* indices, size_t index_count, size_t vertex_count, size_t max_vertices, size_t max_triangles);
 template <typename T>
 inline meshopt_Bounds meshopt_computeClusterBounds(const T* indices, size_t index_count, const float* vertex_positions, size_t vertex_count, size_t vertex_positions_stride);
 template <typename T>
@@ -919,11 +919,11 @@ inline size_t meshopt_buildMeshlets(meshopt_Meshlet* destination, const T* indic
 }
 
 template <typename T>
-inline size_t meshopt_buildMeshletsLinear(meshopt_Meshlet* destination, const T* indices, size_t index_count, size_t vertex_count, size_t max_vertices, size_t max_triangles)
+inline size_t meshopt_buildMeshletsScan(meshopt_Meshlet* destination, const T* indices, size_t index_count, size_t vertex_count, size_t max_vertices, size_t max_triangles)
 {
 	meshopt_IndexAdapter<T> in(0, indices, index_count);
 
-	return meshopt_buildMeshletsLinear(destination, in.data, index_count, vertex_count, max_vertices, max_triangles);
+	return meshopt_buildMeshletsScan(destination, in.data, index_count, vertex_count, max_vertices, max_triangles);
 }
 
 template <typename T>


### PR DESCRIPTION
In order to build meshlets that can be used in mesh shader based renderers and in other cases where cluster culling is valuable, we used to have a naive linear algorithm that converted a vertex cache optimized index buffer to meshlet sequence.

This algorithm mostly worked fine when the goal was to produce meshlets that don't need to be culled, but had suboptimal results when occlusion or cone culling was needed.

This change renames the old algorithm to buildMeshletsScan and introduces a new algorithm that generates high quality meshlet data regardless of the original triangle order, trying to balance meshlet packing efficiency (# of vertices/triangles), size (bounding radius) and triangle orientation.

Optimizing for radius and orientation presents conflicting goals; to maximize cone culling efficiency the optimal meshlets represent large planar patches, but for surfaces with high curvature this results in long strips that go around the curve. To that end, new meshlet builder (in addition to vertex positions) requires a weight, that can balance these for the target use case (for example, setting `cone_weight` to 0.9 would make sense when cone culling is used as a sole culling method).

The new algorithm is substantially slower than the old one which should be expected as it does thorough scoring of all triangles, not unlike the vertex cache optimizer (but it is slower than vertex cache optimizer for a number of reasons). Performance depends on the mesh, but should be around ~1-2M triangles/sec.

Example output with meshlet bounds visualization:

Before: 318 meshlets
![image](https://user-images.githubusercontent.com/1106629/104415735-5e5a6500-5527-11eb-84f2-adb9d32deccc.png)

After: 311 meshlets
![image](https://user-images.githubusercontent.com/1106629/104415747-631f1900-5527-11eb-9f91-35338eb3902e.png)

Example output on a full scene when cone & occlusion culling is used:

Old algorithm: 66.6M rendered triangles

![image](https://user-images.githubusercontent.com/1106629/104415950-c8730a00-5527-11eb-8b88-5f19a51e55ce.png)

New algorithm, cone weight 0: 65.4M rendered triangles

![image](https://user-images.githubusercontent.com/1106629/104415981-d3c63580-5527-11eb-85f6-afd220c25e3c.png)

New algorithm, cone weight 0.5: 63.1M rendered triangles

![image](https://user-images.githubusercontent.com/1106629/104416023-e3de1500-5527-11eb-849a-c0ff6be278eb.png)

New algorithm, cone weight 1.0: 61.9M rendered triangles

![image](https://user-images.githubusercontent.com/1106629/104416048-efc9d700-5527-11eb-8258-03226dd21c75.png)

Contributes to #179.