### PR TITLE
gltfpack: Fix handling of absolute paths on node.js

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -108,6 +108,8 @@ jobs:
     - name: test
       run: |
         node gltf/cli.js -i demo/pirate.obj -o pirate.glb -v
+        node gltf/cli.js -i `pwd`/pirate.glb -o pirate-repack.glb -cc -v
+        wc -c pirate.glb pirate-repack.glb
         node js/meshopt_decoder.test.js
     - name: npm pack
       run: cd gltf && npm pack

--- a/extern/fast_obj.h
+++ b/extern/fast_obj.h
@@ -374,27 +374,6 @@ int string_equal(const char* a, const char* s, const char* e)
 
 
 static
-int string_find_last(const char* s, char c, size_t* p)
-{
-    const char* e;
-
-    e = s + strlen(s);
-    while (e > s)
-    {
-        e--;
-
-        if (*e == c)
-        {
-            *p = (size_t)(e - s);
-            return 1;
-        }
-    }
-
-    return 0;
-}
-
-
-static
 void string_fix_separators(char* s)
 {
     while (*s)
@@ -1289,7 +1268,6 @@ fastObjMesh* fast_obj_read(const char* path)
     char*        end;
     char*        last;
     fastObjUInt  read;
-    size_t       sep;
     fastObjUInt  bytes;
 
 
@@ -1336,13 +1314,16 @@ fastObjMesh* fast_obj_read(const char* path)
 
 
     /* Find base path for materials/textures */
-    if (string_find_last(path, FAST_OBJ_SEPARATOR, &sep))
-        data.base = string_substr(path, 0, sep + 1);
-#ifdef _WIN32
-    /* Check for the other direction slash on windows too, but not linux/mac where it's a valid char */
-    else if (string_find_last(path, FAST_OBJ_OTHER_SEP, &sep))
-        data.base = string_substr(path, 0, sep + 1);
-#endif
+    {
+        const char* sep1 = strrchr(path, FAST_OBJ_SEPARATOR);
+        const char* sep2 = strrchr(path, FAST_OBJ_OTHER_SEP);
+
+        /* Use the last separator in the path */
+        const char* sep = sep2 && (!sep1 || sep1 < sep2) ? sep2 : sep1;
+
+        if (sep)
+            data.base = string_substr(path, 0, sep - path + 1);
+    }
 
 
     /* Create buffer for reading file */

--- a/gltf/gltfpack.cpp
+++ b/gltf/gltfpack.cpp
@@ -8,6 +8,10 @@
 #include <stdlib.h>
 #include <string.h>
 
+#ifdef __wasi__
+#include <unistd.h>
+#endif
+
 #include "../src/meshoptimizer.h"
 
 std::string getVersion()
@@ -1257,6 +1261,8 @@ int main(int argc, char** argv)
 #ifdef __wasi__
 extern "C" int pack(int argc, char** argv)
 {
+	chdir("/gltfpack-$pwd");
+
 	int result = main(argc, argv);
 	fflush(NULL);
 	return result;

--- a/gltf/library.js
+++ b/gltf/library.js
@@ -77,9 +77,8 @@ var ready;
 var instance;
 var interface;
 
-var rootfd = 3;
 var output = { data: new Uint8Array(), position: 0, size: 0 };
-var fds = { 1: output, 2: output };
+var fds = { 1: output, 2: output, 3: { mount: "/", path: "/" }, 4: { mount: "/gltfpack-$pwd", path: "" } };
 
 var wasi = {
 	proc_exit: function(rval) {
@@ -103,8 +102,12 @@ var wasi = {
 	},
 
 	fd_fdstat_get: function(fd, stat) {
+		if (!fds[fd]) {
+			return WASI_EBADF;
+		}
+
 		var heap = getHeap();
-		heap.setUint8(stat + 0, fds[fd] === rootfd ? 3 : 4);
+		heap.setUint8(stat + 0, fds[fd].path !== undefined ? 3 : 4);
 		heap.setUint16(stat + 2, 0, true);
 		heap.setUint32(stat + 8, 0, true);
 		heap.setUint32(stat + 12, 0, true);
@@ -114,14 +117,14 @@ var wasi = {
 	},
 
 	path_open32: function(parent_fd, dirflags, path, path_len, oflags, fs_rights_base, fs_rights_inheriting, fdflags, opened_fd) {
-		if (parent_fd != rootfd) {
+		if (!fds[parent_fd] || fds[parent_fd].path === undefined) {
 			return WASI_EBADF;
 		}
 
 		var heap = getHeap();
 
 		var file = {};
-		file.name = getString(heap.buffer, path, path_len);
+		file.name = fds[parent_fd].path + getString(heap.buffer, path, path_len);
 		file.position = 0;
 
 		if (oflags & 1) {
@@ -152,12 +155,12 @@ var wasi = {
 	},
 
 	path_unlink_file: function(parent_fd, path, path_len) {
-		if (parent_fd !== rootfd) {
+		if (!fds[parent_fd] || fds[parent_fd].path === undefined) {
 			return WASI_EBADF;
 		}
 
 		var heap = getHeap();
-		var name = getString(heap.buffer, path, path_len);
+		var name = fds[parent_fd].path + getString(heap.buffer, path, path_len);
 
 		try {
 			interface.unlink(name);
@@ -167,18 +170,48 @@ var wasi = {
 		}
 	},
 
-	fd_prestat_get: function(fd, buf) {
-		if (fd != rootfd) {
+	path_filestat_get: function(parent_fd, flags, path, path_len, buf) {
+		if (!fds[parent_fd] || fds[parent_fd].path === undefined) {
 			return WASI_EBADF;
 		}
 
 		var heap = getHeap();
+		var name = getString(heap.buffer, path, path_len);
+
+		var heap = getHeap();
+		for (var i = 0; i < 64; ++i)
+			heap.setUint8(buf + i, 0);
+
+		heap.setUint8(buf + 16, name == "." ? 3 : 4);
+		return 0;
+	},
+
+	fd_prestat_get: function(fd, buf) {
+		if (!fds[fd] || fds[fd].path === undefined) {
+			return WASI_EBADF;
+		}
+
+		var path_buf = stringBuffer(fds[fd].mount);
+
+		var heap = getHeap();
 		heap.setUint8(buf, 0);
-		heap.setUint32(buf + 4, 0, true);
+		heap.setUint32(buf + 4, path_buf.length, true);
 		return 0;
 	},
 
 	fd_prestat_dir_name: function(fd, path, path_len) {
+		if (!fds[fd] || fds[fd].path === undefined) {
+			return WASI_EBADF;
+		}
+
+		var path_buf = stringBuffer(fds[fd].mount);
+
+		if (path_len != path_buf.length) {
+			return WASI_EINVAL;
+		}
+
+		var heap = getHeap();
+		new Uint8Array(heap.buffer).set(path_buf, path);
 		return 0;
 	},
 
@@ -293,7 +326,7 @@ var wasi = {
 };
 
 function nextFd() {
-	for (var i = rootfd + 1; ; ++i) {
+	for (var i = 1; ; ++i) {
 		if (fds[i] === undefined) {
 			return i;
 		}
@@ -306,6 +339,10 @@ function getHeap() {
 
 function getString(buffer, offset, length) {
 	return new TextDecoder().decode(new Uint8Array(buffer, offset, length));
+}
+
+function stringBuffer(string) {
+	return new TextEncoder().encode(string);
 }
 
 function growArray(data, len) {
@@ -321,11 +358,9 @@ function growArray(data, len) {
 }
 
 function uploadArgv(argv) {
-	var encoder = new TextEncoder();
-
 	var buf_size = argv.length * 4;
 	for (var i = 0; i < argv.length; ++i) {
-		buf_size += encoder.encode(argv[i]).length + 1;
+		buf_size += stringBuffer(argv[i]).length + 1;
 	}
 
 	var buf = instance.exports.malloc(buf_size);
@@ -334,7 +369,7 @@ function uploadArgv(argv) {
 	var heap = getHeap();
 
 	for (var i = 0; i < argv.length; ++i) {
-		var item = encoder.encode(argv[i]);
+		var item = stringBuffer(argv[i]);
 
 		heap.setUint32(buf + i * 4, argp, true);
 		new Uint8Array(heap.buffer).set(item, argp);

--- a/gltf/package.json
+++ b/gltf/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gltfpack",
-	"version": "0.15.1",
+	"version": "0.15.2",
 	"description": "A command-line tool that can optimize glTF files for size and speed",
 	"author": "Arseny Kapoulkine",
 	"license": "MIT",


### PR DESCRIPTION
When running gltfpack via a node.js build, absolute paths don't work
correctly, as /foo/bar is converted to foo/bar by wasi-libc.

This has to do with the path handling inside wasi-libc, where it looks
at the mounts; given an empty mount path it seems to treat /foo/bar as
mount-relative *and* returns the leading slash which would make sense
for non-empty mount paths.

To work around this, we use the recently introduced chdir support in
wasi-libc. A fake path /gltfpack-cwd is registered as current, and
accesses to that path map to "", which seems to preserve relative paths.

To that end, library.js now implements a slightly more generic version
of mounts, and a stub for path_filestat_get which is needed to get chdir
to work.

Also includes fixes to fast_obj for slash handling so that Windows paths
with mixed slashes work correctly on all platforms including node.

Fixes #224 