### PR TITLE
clusterizer: Rework meshlet interface to use SoA results

### DIFF
--- a/demo/main.cpp
+++ b/demo/main.cpp
@@ -885,7 +885,7 @@ void meshlets(const Mesh& mesh, bool scan)
 	{
 		const meshopt_Meshlet& m = meshlets[i];
 
-		meshopt_Bounds bounds = meshopt_computeMeshletBounds(&meshlet_vertices[m.vertex_offset], &meshlet_triangles[m.triangle_offset], m.triangle_count * 3, &mesh.vertices[0].px, mesh.vertices.size(), sizeof(Vertex));
+		meshopt_Bounds bounds = meshopt_computeMeshletBounds(&meshlet_vertices[m.vertex_offset], &meshlet_triangles[m.triangle_offset], m.triangle_count, &mesh.vertices[0].px, mesh.vertices.size(), sizeof(Vertex));
 
 		radii[i] = bounds.radius;
 

--- a/demo/main.cpp
+++ b/demo/main.cpp
@@ -823,7 +823,7 @@ void shadow(const Mesh& mesh)
 void meshlets(const Mesh& mesh, bool scan)
 {
 	const size_t max_vertices = 64;
-	const size_t max_triangles = 128;
+	const size_t max_triangles = 124; // NVidia-recommended 126, rounded down to a multiple of 4
 	const float cone_weight = 0.5f; // note: should be set to 0 unless cone culling is used at runtime!
 
 	// note: input mesh is assumed to be optimized for vertex cache and vertex fetch

--- a/demo/main.cpp
+++ b/demo/main.cpp
@@ -844,7 +844,7 @@ void meshlets(const Mesh& mesh, bool scan)
 
 		// this is an example of how to trim the vertex/triangle arrays when copying data out to GPU storage
 		meshlet_vertices.resize(last.vertex_offset + last.vertex_count);
-		meshlet_triangles.resize(last.triangle_offset + last.triangle_count * 3);
+		meshlet_triangles.resize(last.triangle_offset + ((last.triangle_count * 3 + 3) & ~3));
 	}
 
 	double end = timestamp();

--- a/demo/main.cpp
+++ b/demo/main.cpp
@@ -831,20 +831,20 @@ void meshlets(const Mesh& mesh, bool scan)
 	size_t max_meshlets = meshopt_buildMeshletsBound(mesh.indices.size(), max_vertices, max_triangles);
 	std::vector<meshopt_Meshlet> meshlets(max_meshlets);
 	std::vector<unsigned int> meshlet_vertices(max_meshlets * max_vertices);
-	std::vector<unsigned char> meshlet_indices(max_meshlets * max_triangles * 3);
+	std::vector<unsigned char> meshlet_triangles(max_meshlets * max_triangles * 3);
 
 	if (scan)
-		meshlets.resize(meshopt_buildMeshletsScan(&meshlets[0], &meshlet_vertices[0], &meshlet_indices[0], &mesh.indices[0], mesh.indices.size(), mesh.vertices.size(), max_vertices, max_triangles));
+		meshlets.resize(meshopt_buildMeshletsScan(&meshlets[0], &meshlet_vertices[0], &meshlet_triangles[0], &mesh.indices[0], mesh.indices.size(), mesh.vertices.size(), max_vertices, max_triangles));
 	else
-		meshlets.resize(meshopt_buildMeshlets(&meshlets[0], &meshlet_vertices[0], &meshlet_indices[0], &mesh.indices[0], mesh.indices.size(), &mesh.vertices[0].px, mesh.vertices.size(), sizeof(Vertex), max_vertices, max_triangles, cone_weight));
+		meshlets.resize(meshopt_buildMeshlets(&meshlets[0], &meshlet_vertices[0], &meshlet_triangles[0], &mesh.indices[0], mesh.indices.size(), &mesh.vertices[0].px, mesh.vertices.size(), sizeof(Vertex), max_vertices, max_triangles, cone_weight));
 
 	if (meshlets.size())
 	{
 		const meshopt_Meshlet& last = meshlets.back();
 
-		// this is an example of how to trim the vertex/index arrays when copying data out to GPU storage
+		// this is an example of how to trim the vertex/triangle arrays when copying data out to GPU storage
 		meshlet_vertices.resize(last.vertex_offset + last.vertex_count);
-		meshlet_indices.resize(last.index_offset + last.triangle_count * 3);
+		meshlet_triangles.resize(last.triangle_offset + last.triangle_count * 3);
 	}
 
 	double end = timestamp();
@@ -883,7 +883,9 @@ void meshlets(const Mesh& mesh, bool scan)
 	double startc = timestamp();
 	for (size_t i = 0; i < meshlets.size(); ++i)
 	{
-		meshopt_Bounds bounds = meshopt_computeMeshletBounds(&meshlet_indices[meshlets[i].index_offset], &meshlet_vertices[meshlets[i].vertex_offset], meshlets[i].triangle_count * 3, &mesh.vertices[0].px, mesh.vertices.size(), sizeof(Vertex));
+		const meshopt_Meshlet& m = meshlets[i];
+
+		meshopt_Bounds bounds = meshopt_computeMeshletBounds(&meshlet_vertices[m.vertex_offset], &meshlet_triangles[m.triangle_offset], m.triangle_count * 3, &mesh.vertices[0].px, mesh.vertices.size(), sizeof(Vertex));
 
 		radii[i] = bounds.radius;
 

--- a/gltf/mesh.cpp
+++ b/gltf/mesh.cpp
@@ -876,12 +876,12 @@ void debugMeshlets(const Mesh& source, Mesh& meshlets, Mesh& bounds, int max_ver
 
 	std::vector<meshopt_Meshlet> ml(max_meshlets);
 	std::vector<unsigned int> mlv(max_meshlets * max_vertices);
-	std::vector<unsigned char> mli(max_meshlets * max_triangles * 3);
+	std::vector<unsigned char> mlt(max_meshlets * max_triangles * 3);
 
 	if (scan)
-		ml.resize(meshopt_buildMeshletsScan(&ml[0], &mlv[0], &mli[0], &mesh.indices[0], mesh.indices.size(), positions->data.size(), max_vertices, max_triangles));
+		ml.resize(meshopt_buildMeshletsScan(&ml[0], &mlv[0], &mlt[0], &mesh.indices[0], mesh.indices.size(), positions->data.size(), max_vertices, max_triangles));
 	else
-		ml.resize(meshopt_buildMeshlets(&ml[0], &mlv[0], &mli[0], &mesh.indices[0], mesh.indices.size(), positions->data[0].f, positions->data.size(), sizeof(Attr), max_vertices, max_triangles, cone_weight));
+		ml.resize(meshopt_buildMeshlets(&ml[0], &mlv[0], &mlt[0], &mesh.indices[0], mesh.indices.size(), positions->data[0].f, positions->data.size(), sizeof(Attr), max_vertices, max_triangles, cone_weight));
 
 	// generate meshlet meshes, using unique colors
 	meshlets.nodes = mesh.nodes;
@@ -910,9 +910,9 @@ void debugMeshlets(const Mesh& source, Mesh& meshlets, Mesh& bounds, int max_ver
 
 		for (size_t j = 0; j < m.triangle_count; ++j)
 		{
-			meshlets.indices.push_back(offset + mli[m.index_offset + j * 3 + 0]);
-			meshlets.indices.push_back(offset + mli[m.index_offset + j * 3 + 1]);
-			meshlets.indices.push_back(offset + mli[m.index_offset + j * 3 + 2]);
+			meshlets.indices.push_back(offset + mlt[m.triangle_offset + j * 3 + 0]);
+			meshlets.indices.push_back(offset + mlt[m.triangle_offset + j * 3 + 1]);
+			meshlets.indices.push_back(offset + mlt[m.triangle_offset + j * 3 + 2]);
 		}
 	}
 
@@ -930,7 +930,7 @@ void debugMeshlets(const Mesh& source, Mesh& meshlets, Mesh& bounds, int max_ver
 	{
 		const meshopt_Meshlet& m = ml[i];
 
-		meshopt_Bounds mb = meshopt_computeMeshletBounds(&mli[m.index_offset], &mlv[m.vertex_offset], m.triangle_count * 3, positions->data[0].f, positions->data.size(), sizeof(Attr));
+		meshopt_Bounds mb = meshopt_computeMeshletBounds(&mlv[m.vertex_offset], &mlt[m.triangle_offset], m.triangle_count * 3, positions->data[0].f, positions->data.size(), sizeof(Attr));
 
 		unsigned int h = unsigned(i);
 		h ^= h >> 13;

--- a/gltf/mesh.cpp
+++ b/gltf/mesh.cpp
@@ -869,14 +869,19 @@ void debugMeshlets(const Mesh& source, Mesh& meshlets, Mesh& bounds, int max_ver
 	const Stream* positions = getStream(mesh, cgltf_attribute_type_position);
 	assert(positions);
 
-	const size_t max_triangles = 126;
 	const float cone_weight = 0.f;
 
-	std::vector<meshopt_Meshlet> mr(meshopt_buildMeshletsBound(mesh.indices.size(), max_vertices, max_triangles));
+	size_t max_triangles = (max_vertices * 2 + 3) & ~3;
+	size_t max_meshlets = meshopt_buildMeshletsBound(mesh.indices.size(), max_vertices, max_triangles);
+
+	std::vector<meshopt_Meshlet> ml(max_meshlets);
+	std::vector<unsigned int> mlv(max_meshlets * max_vertices);
+	std::vector<unsigned char> mli(max_meshlets * max_triangles * 3);
+
 	if (scan)
-		mr.resize(meshopt_buildMeshletsScan(&mr[0], &mesh.indices[0], mesh.indices.size(), positions->data.size(), max_vertices, max_triangles));
+		ml.resize(meshopt_buildMeshletsScan(&ml[0], &mlv[0], &mli[0], &mesh.indices[0], mesh.indices.size(), positions->data.size(), max_vertices, max_triangles));
 	else
-		mr.resize(meshopt_buildMeshlets(&mr[0], &mesh.indices[0], mesh.indices.size(), positions->data[0].f, positions->data.size(), sizeof(Attr), max_vertices, max_triangles, cone_weight));
+		ml.resize(meshopt_buildMeshlets(&ml[0], &mlv[0], &mli[0], &mesh.indices[0], mesh.indices.size(), positions->data[0].f, positions->data.size(), sizeof(Attr), max_vertices, max_triangles, cone_weight));
 
 	// generate meshlet meshes, using unique colors
 	meshlets.nodes = mesh.nodes;
@@ -884,9 +889,9 @@ void debugMeshlets(const Mesh& source, Mesh& meshlets, Mesh& bounds, int max_ver
 	Stream mv = {cgltf_attribute_type_position};
 	Stream mc = {cgltf_attribute_type_color};
 
-	for (size_t i = 0; i < mr.size(); ++i)
+	for (size_t i = 0; i < ml.size(); ++i)
 	{
-		const meshopt_Meshlet& ml = mr[i];
+		const meshopt_Meshlet& m = ml[i];
 
 		unsigned int h = unsigned(i);
 		h ^= h >> 13;
@@ -897,17 +902,17 @@ void debugMeshlets(const Mesh& source, Mesh& meshlets, Mesh& bounds, int max_ver
 
 		unsigned int offset = unsigned(mv.data.size());
 
-		for (size_t j = 0; j < ml.vertex_count; ++j)
+		for (size_t j = 0; j < m.vertex_count; ++j)
 		{
-			mv.data.push_back(positions->data[ml.vertices[j]]);
+			mv.data.push_back(positions->data[mlv[m.vertex_offset + j]]);
 			mc.data.push_back(c);
 		}
 
-		for (size_t j = 0; j < ml.triangle_count; ++j)
+		for (size_t j = 0; j < m.triangle_count; ++j)
 		{
-			meshlets.indices.push_back(offset + ml.indices[j][0]);
-			meshlets.indices.push_back(offset + ml.indices[j][1]);
-			meshlets.indices.push_back(offset + ml.indices[j][2]);
+			meshlets.indices.push_back(offset + mli[m.index_offset + j * 3 + 0]);
+			meshlets.indices.push_back(offset + mli[m.index_offset + j * 3 + 1]);
+			meshlets.indices.push_back(offset + mli[m.index_offset + j * 3 + 2]);
 		}
 	}
 
@@ -921,11 +926,11 @@ void debugMeshlets(const Mesh& source, Mesh& meshlets, Mesh& bounds, int max_ver
 	Stream bv = {cgltf_attribute_type_position};
 	Stream bc = {cgltf_attribute_type_color};
 
-	for (size_t i = 0; i < mr.size(); ++i)
+	for (size_t i = 0; i < ml.size(); ++i)
 	{
-		const meshopt_Meshlet& ml = mr[i];
+		const meshopt_Meshlet& m = ml[i];
 
-		meshopt_Bounds mb = meshopt_computeMeshletBounds(&ml, positions->data[0].f, positions->data.size(), sizeof(Attr));
+		meshopt_Bounds mb = meshopt_computeMeshletBounds(&mli[m.index_offset], &mlv[m.vertex_offset], m.triangle_count * 3, positions->data[0].f, positions->data.size(), sizeof(Attr));
 
 		unsigned int h = unsigned(i);
 		h ^= h >> 13;

--- a/gltf/mesh.cpp
+++ b/gltf/mesh.cpp
@@ -930,7 +930,7 @@ void debugMeshlets(const Mesh& source, Mesh& meshlets, Mesh& bounds, int max_ver
 	{
 		const meshopt_Meshlet& m = ml[i];
 
-		meshopt_Bounds mb = meshopt_computeMeshletBounds(&mlv[m.vertex_offset], &mlt[m.triangle_offset], m.triangle_count * 3, positions->data[0].f, positions->data.size(), sizeof(Attr));
+		meshopt_Bounds mb = meshopt_computeMeshletBounds(&mlv[m.vertex_offset], &mlt[m.triangle_offset], m.triangle_count, positions->data[0].f, positions->data.size(), sizeof(Attr));
 
 		unsigned int h = unsigned(i);
 		h ^= h >> 13;

--- a/src/clusterizer.cpp
+++ b/src/clusterizer.cpp
@@ -816,18 +816,17 @@ meshopt_Bounds meshopt_computeClusterBounds(const unsigned int* indices, size_t 
 	return bounds;
 }
 
-meshopt_Bounds meshopt_computeMeshletBounds(const unsigned int* meshlet_vertices, const unsigned char* meshlet_triangles, size_t index_count, const float* vertex_positions, size_t vertex_count, size_t vertex_positions_stride)
+meshopt_Bounds meshopt_computeMeshletBounds(const unsigned int* meshlet_vertices, const unsigned char* meshlet_triangles, size_t triangle_count, const float* vertex_positions, size_t vertex_count, size_t vertex_positions_stride)
 {
 	using namespace meshopt;
 
-	assert(index_count % 3 == 0);
-	assert(index_count / 3 <= kMeshletMaxTriangles);
+	assert(triangle_count <= kMeshletMaxTriangles);
 	assert(vertex_positions_stride > 0 && vertex_positions_stride <= 256);
 	assert(vertex_positions_stride % sizeof(float) == 0);
 
 	unsigned int indices[kMeshletMaxTriangles * 3];
 
-	for (size_t i = 0; i < index_count; ++i)
+	for (size_t i = 0; i < triangle_count * 3; ++i)
 	{
 		unsigned int index = meshlet_vertices[meshlet_triangles[i]];
 		assert(index < vertex_count);
@@ -835,5 +834,5 @@ meshopt_Bounds meshopt_computeMeshletBounds(const unsigned int* meshlet_vertices
 		indices[i] = index;
 	}
 
-	return meshopt_computeClusterBounds(indices, index_count, vertex_positions, vertex_count, vertex_positions_stride);
+	return meshopt_computeClusterBounds(indices, triangle_count * 3, vertex_positions, vertex_count, vertex_positions_stride);
 }

--- a/src/clusterizer.cpp
+++ b/src/clusterizer.cpp
@@ -13,6 +13,12 @@
 namespace meshopt
 {
 
+// This must be <= 255 since index 0xff is used internally to indice a vertex that doesn't belong to a meshlet
+const size_t kMeshletMaxVertices = 255;
+
+// A reasonable limit is around 2*max_vertices or less
+const size_t kMeshletMaxTriangles = 512;
+
 struct TriangleAdjacency2
 {
 	unsigned int* counts;
@@ -215,7 +221,7 @@ static float computeTriangleCones(Cone* triangles, const unsigned int* indices, 
 	return mesh_area;
 }
 
-static bool appendMeshlet(meshopt_Meshlet& meshlet, unsigned int a, unsigned int b, unsigned int c, unsigned char* used, meshopt_Meshlet* destination, size_t offset, size_t max_vertices, size_t max_triangles)
+static bool appendMeshlet(meshopt_Meshlet& meshlet, unsigned int a, unsigned int b, unsigned int c, unsigned char* used, meshopt_Meshlet* meshlets, unsigned int* meshlet_vertices, unsigned char* meshlet_indices, size_t meshlet_offset, size_t max_vertices, size_t max_triangles)
 {
 	unsigned char& av = used[a];
 	unsigned char& bv = used[b];
@@ -227,12 +233,15 @@ static bool appendMeshlet(meshopt_Meshlet& meshlet, unsigned int a, unsigned int
 
 	if (meshlet.vertex_count + used_extra > max_vertices || meshlet.triangle_count >= max_triangles)
 	{
-		destination[offset] = meshlet;
+		meshlets[meshlet_offset] = meshlet;
 
 		for (size_t j = 0; j < meshlet.vertex_count; ++j)
-			used[meshlet.vertices[j]] = 0xff;
+			used[meshlet_vertices[meshlet.vertex_offset + j]] = 0xff;
 
-		memset(&meshlet, 0, sizeof(meshlet));
+		meshlet.vertex_offset += meshlet.vertex_count;
+		meshlet.index_offset += (meshlet.triangle_count * 3 + 3) & ~3; // 4b alignment for index data
+		meshlet.vertex_count = 0;
+		meshlet.triangle_count = 0;
 
 		result = true;
 	}
@@ -240,24 +249,24 @@ static bool appendMeshlet(meshopt_Meshlet& meshlet, unsigned int a, unsigned int
 	if (av == 0xff)
 	{
 		av = meshlet.vertex_count;
-		meshlet.vertices[meshlet.vertex_count++] = a;
+		meshlet_vertices[meshlet.vertex_offset + meshlet.vertex_count++] = a;
 	}
 
 	if (bv == 0xff)
 	{
 		bv = meshlet.vertex_count;
-		meshlet.vertices[meshlet.vertex_count++] = b;
+		meshlet_vertices[meshlet.vertex_offset + meshlet.vertex_count++] = b;
 	}
 
 	if (cv == 0xff)
 	{
 		cv = meshlet.vertex_count;
-		meshlet.vertices[meshlet.vertex_count++] = c;
+		meshlet_vertices[meshlet.vertex_offset + meshlet.vertex_count++] = c;
 	}
 
-	meshlet.indices[meshlet.triangle_count][0] = av;
-	meshlet.indices[meshlet.triangle_count][1] = bv;
-	meshlet.indices[meshlet.triangle_count][2] = cv;
+	meshlet_indices[meshlet.index_offset + meshlet.triangle_count * 3 + 0] = av;
+	meshlet_indices[meshlet.index_offset + meshlet.triangle_count * 3 + 1] = bv;
+	meshlet_indices[meshlet.index_offset + meshlet.triangle_count * 3 + 2] = cv;
 	meshlet.triangle_count++;
 
 	return result;
@@ -348,7 +357,8 @@ static size_t kdtreeBuild(size_t offset, KDNode* nodes, size_t node_count, const
 	}
 
 	// split axis is one where the variance is largest
-	unsigned int axis = vars[0] >= vars[1] && vars[0] >= vars[2] ? 0 : vars[1] >= vars[2] ? 1 : 2;
+	unsigned int axis = vars[0] >= vars[1] && vars[0] >= vars[2] ? 0 : vars[1] >= vars[2] ? 1
+	                                                                                      : 2;
 
 	float split = mean[axis];
 	size_t middle = kdtreePartition(indices, count, points, stride, axis, split);
@@ -419,9 +429,12 @@ static void kdtreeNearest(KDNode* nodes, unsigned int root, const float* points,
 
 size_t meshopt_buildMeshletsBound(size_t index_count, size_t max_vertices, size_t max_triangles)
 {
+	using namespace meshopt;
+
 	assert(index_count % 3 == 0);
-	assert(max_vertices >= 3);
-	assert(max_triangles >= 1);
+	assert(max_vertices >= 3 && max_vertices <= kMeshletMaxVertices);
+	assert(max_triangles >= 1 && max_triangles <= kMeshletMaxTriangles);
+	assert(max_triangles % 4 == 0); // ensures the caller will compute output space properly as index data is 4b aligned
 
 	// meshlet construction is limited by max vertices and max triangles per meshlet
 	// the worst case is that the input is an unindexed stream since this equally stresses both limits
@@ -433,24 +446,19 @@ size_t meshopt_buildMeshletsBound(size_t index_count, size_t max_vertices, size_
 	return meshlet_limit_vertices > meshlet_limit_triangles ? meshlet_limit_vertices : meshlet_limit_triangles;
 }
 
-size_t meshopt_buildMeshlets(meshopt_Meshlet* destination, const unsigned int* indices, size_t index_count, const float* vertex_positions, size_t vertex_count, size_t vertex_positions_stride, size_t max_vertices, size_t max_triangles, float cone_weight)
+size_t meshopt_buildMeshlets(meshopt_Meshlet* meshlets, unsigned int* meshlet_vertices, unsigned char* meshlet_indices, const unsigned int* indices, size_t index_count, const float* vertex_positions, size_t vertex_count, size_t vertex_positions_stride, size_t max_vertices, size_t max_triangles, float cone_weight)
 {
 	using namespace meshopt;
 
 	assert(index_count % 3 == 0);
-	assert(max_vertices >= 3);
-	assert(max_triangles >= 1);
 	assert(vertex_positions_stride > 0 && vertex_positions_stride <= 256);
 	assert(vertex_positions_stride % sizeof(float) == 0);
 
+	assert(max_vertices >= 3 && max_vertices <= kMeshletMaxVertices);
+	assert(max_triangles >= 1 && max_triangles <= kMeshletMaxTriangles);
+	assert(max_triangles % 4 == 0); // ensures the caller will compute output space properly as index data is 4b aligned
+
 	meshopt_Allocator allocator;
-
-	meshopt_Meshlet meshlet;
-	memset(&meshlet, 0, sizeof(meshlet));
-
-	assert(max_vertices <= sizeof(meshlet.vertices) / sizeof(meshlet.vertices[0]));
-	assert(max_vertices <= 255);
-	assert(max_triangles <= sizeof(meshlet.indices) / 3);
 
 	TriangleAdjacency2 adjacency = {};
 	buildTriangleAdjacency(adjacency, indices, index_count, vertex_count, allocator);
@@ -483,7 +491,8 @@ size_t meshopt_buildMeshlets(meshopt_Meshlet* destination, const unsigned int* i
 	unsigned char* used = allocator.allocate<unsigned char>(vertex_count);
 	memset(used, -1, vertex_count);
 
-	size_t offset = 0;
+	meshopt_Meshlet meshlet = {};
+	size_t meshlet_offset = 0;
 
 	Cone meshlet_cone_acc = {};
 
@@ -497,7 +506,7 @@ size_t meshopt_buildMeshlets(meshopt_Meshlet* destination, const unsigned int* i
 
 		for (size_t i = 0; i < meshlet.vertex_count; ++i)
 		{
-			unsigned int index = meshlet.vertices[i];
+			unsigned int index = meshlet_vertices[meshlet.vertex_offset + i];
 
 			unsigned int* neighbours = &adjacency.data[0] + adjacency.offsets[index];
 			size_t neighbours_size = adjacency.counts[index];
@@ -566,9 +575,9 @@ size_t meshopt_buildMeshlets(meshopt_Meshlet* destination, const unsigned int* i
 		assert(a < vertex_count && b < vertex_count && c < vertex_count);
 
 		// add meshlet to the output; when the current meshlet is full we reset the accumulated bounds
-		if (appendMeshlet(meshlet, a, b, c, used, destination, offset, max_vertices, max_triangles))
+		if (appendMeshlet(meshlet, a, b, c, used, meshlets, meshlet_vertices, meshlet_indices, meshlet_offset, max_vertices, max_triangles))
 		{
-			offset++;
+			meshlet_offset++;
 			memset(&meshlet_cone_acc, 0, sizeof(meshlet_cone_acc));
 		}
 
@@ -610,35 +619,30 @@ size_t meshopt_buildMeshlets(meshopt_Meshlet* destination, const unsigned int* i
 	}
 
 	if (meshlet.triangle_count)
-		destination[offset++] = meshlet;
+		meshlets[meshlet_offset++] = meshlet;
 
-	assert(offset <= meshopt_buildMeshletsBound(index_count, max_vertices, max_triangles));
-
-	return offset;
+	assert(meshlet_offset <= meshopt_buildMeshletsBound(index_count, max_vertices, max_triangles));
+	return meshlet_offset;
 }
 
-size_t meshopt_buildMeshletsScan(meshopt_Meshlet* destination, const unsigned int* indices, size_t index_count, size_t vertex_count, size_t max_vertices, size_t max_triangles)
+size_t meshopt_buildMeshletsScan(meshopt_Meshlet* meshlets, unsigned int* meshlet_vertices, unsigned char* meshlet_indices, const unsigned int* indices, size_t index_count, size_t vertex_count, size_t max_vertices, size_t max_triangles)
 {
 	using namespace meshopt;
 
 	assert(index_count % 3 == 0);
-	assert(max_vertices >= 3);
-	assert(max_triangles >= 1);
+
+	assert(max_vertices >= 3 && max_vertices <= kMeshletMaxVertices);
+	assert(max_triangles >= 1 && max_triangles <= kMeshletMaxTriangles);
+	assert(max_triangles % 4 == 0); // ensures the caller will compute output space properly as index data is 4b aligned
 
 	meshopt_Allocator allocator;
-
-	meshopt_Meshlet meshlet;
-	memset(&meshlet, 0, sizeof(meshlet));
-
-	assert(max_vertices <= sizeof(meshlet.vertices) / sizeof(meshlet.vertices[0]));
-	assert(max_vertices <= 255);
-	assert(max_triangles <= sizeof(meshlet.indices) / 3);
 
 	// index of the vertex in the meshlet, 0xff if the vertex isn't used
 	unsigned char* used = allocator.allocate<unsigned char>(vertex_count);
 	memset(used, -1, vertex_count);
 
-	size_t offset = 0;
+	meshopt_Meshlet meshlet = {};
+	size_t meshlet_offset = 0;
 
 	for (size_t i = 0; i < index_count; i += 3)
 	{
@@ -646,15 +650,14 @@ size_t meshopt_buildMeshletsScan(meshopt_Meshlet* destination, const unsigned in
 		assert(a < vertex_count && b < vertex_count && c < vertex_count);
 
 		// appends triangle to the meshlet and writes previous meshlet to the output if full
-		offset += appendMeshlet(meshlet, a, b, c, used, destination, offset, max_vertices, max_triangles);
+		meshlet_offset += appendMeshlet(meshlet, a, b, c, used, meshlets, meshlet_vertices, meshlet_indices, meshlet_offset, max_vertices, max_triangles);
 	}
 
 	if (meshlet.triangle_count)
-		destination[offset++] = meshlet;
+		meshlets[meshlet_offset++] = meshlet;
 
-	assert(offset <= meshopt_buildMeshletsBound(index_count, max_vertices, max_triangles));
-
-	return offset;
+	assert(meshlet_offset <= meshopt_buildMeshletsBound(index_count, max_vertices, max_triangles));
+	return meshlet_offset;
 }
 
 meshopt_Bounds meshopt_computeClusterBounds(const unsigned int* indices, size_t index_count, const float* vertex_positions, size_t vertex_count, size_t vertex_positions_stride)
@@ -662,18 +665,17 @@ meshopt_Bounds meshopt_computeClusterBounds(const unsigned int* indices, size_t 
 	using namespace meshopt;
 
 	assert(index_count % 3 == 0);
+	assert(index_count / 3 <= kMeshletMaxTriangles);
 	assert(vertex_positions_stride > 0 && vertex_positions_stride <= 256);
 	assert(vertex_positions_stride % sizeof(float) == 0);
-
-	assert(index_count / 3 <= 256);
 
 	(void)vertex_count;
 
 	size_t vertex_stride_float = vertex_positions_stride / sizeof(float);
 
 	// compute triangle normals and gather triangle corners
-	float normals[256][3];
-	float corners[256][3][3];
+	float normals[kMeshletMaxTriangles][3];
+	float corners[kMeshletMaxTriangles][3][3];
 	size_t triangles = 0;
 
 	for (size_t i = 0; i < index_count; i += 3)
@@ -811,25 +813,24 @@ meshopt_Bounds meshopt_computeClusterBounds(const unsigned int* indices, size_t 
 	return bounds;
 }
 
-meshopt_Bounds meshopt_computeMeshletBounds(const meshopt_Meshlet* meshlet, const float* vertex_positions, size_t vertex_count, size_t vertex_positions_stride)
+meshopt_Bounds meshopt_computeMeshletBounds(const unsigned char* meshlet_indices, const unsigned int* meshlet_vertices, size_t index_count, const float* vertex_positions, size_t vertex_count, size_t vertex_positions_stride)
 {
+	using namespace meshopt;
+
+	assert(index_count % 3 == 0);
+	assert(index_count / 3 <= kMeshletMaxTriangles);
 	assert(vertex_positions_stride > 0 && vertex_positions_stride <= 256);
 	assert(vertex_positions_stride % sizeof(float) == 0);
 
-	unsigned int indices[sizeof(meshlet->indices) / sizeof(meshlet->indices[0][0])];
+	unsigned int indices[kMeshletMaxTriangles * 3];
 
-	for (size_t i = 0; i < meshlet->triangle_count; ++i)
+	for (size_t i = 0; i < index_count; ++i)
 	{
-		unsigned int a = meshlet->vertices[meshlet->indices[i][0]];
-		unsigned int b = meshlet->vertices[meshlet->indices[i][1]];
-		unsigned int c = meshlet->vertices[meshlet->indices[i][2]];
+		unsigned int index = meshlet_vertices[meshlet_indices[i]];
+		assert(index < vertex_count);
 
-		assert(a < vertex_count && b < vertex_count && c < vertex_count);
-
-		indices[i * 3 + 0] = a;
-		indices[i * 3 + 1] = b;
-		indices[i * 3 + 2] = c;
+		indices[i] = index;
 	}
 
-	return meshopt_computeClusterBounds(indices, meshlet->triangle_count * 3, vertex_positions, vertex_count, vertex_positions_stride);
+	return meshopt_computeClusterBounds(indices, index_count, vertex_positions, vertex_count, vertex_positions_stride);
 }

--- a/src/clusterizer.cpp
+++ b/src/clusterizer.cpp
@@ -248,19 +248,19 @@ static bool appendMeshlet(meshopt_Meshlet& meshlet, unsigned int a, unsigned int
 
 	if (av == 0xff)
 	{
-		av = meshlet.vertex_count;
+		av = (unsigned char)meshlet.vertex_count;
 		meshlet_vertices[meshlet.vertex_offset + meshlet.vertex_count++] = a;
 	}
 
 	if (bv == 0xff)
 	{
-		bv = meshlet.vertex_count;
+		bv = (unsigned char)meshlet.vertex_count;
 		meshlet_vertices[meshlet.vertex_offset + meshlet.vertex_count++] = b;
 	}
 
 	if (cv == 0xff)
 	{
-		cv = meshlet.vertex_count;
+		cv = (unsigned char)meshlet.vertex_count;
 		meshlet_vertices[meshlet.vertex_offset + meshlet.vertex_count++] = c;
 	}
 
@@ -435,6 +435,9 @@ size_t meshopt_buildMeshletsBound(size_t index_count, size_t max_vertices, size_
 	assert(max_vertices >= 3 && max_vertices <= kMeshletMaxVertices);
 	assert(max_triangles >= 1 && max_triangles <= kMeshletMaxTriangles);
 	assert(max_triangles % 4 == 0); // ensures the caller will compute output space properly as index data is 4b aligned
+
+	(void)kMeshletMaxVertices;
+	(void)kMeshletMaxTriangles;
 
 	// meshlet construction is limited by max vertices and max triangles per meshlet
 	// the worst case is that the input is an unindexed stream since this equally stresses both limits

--- a/src/meshoptimizer.h
+++ b/src/meshoptimizer.h
@@ -438,7 +438,7 @@ struct meshopt_Bounds
  * index_count/3 should be less than or equal to 512 (the function assumes clusters of limited size)
  */
 MESHOPTIMIZER_EXPERIMENTAL struct meshopt_Bounds meshopt_computeClusterBounds(const unsigned int* indices, size_t index_count, const float* vertex_positions, size_t vertex_count, size_t vertex_positions_stride);
-MESHOPTIMIZER_EXPERIMENTAL struct meshopt_Bounds meshopt_computeMeshletBounds(const unsigned int* meshlet_vertices, const unsigned char* meshlet_triangles, size_t index_count, const float* vertex_positions, size_t vertex_count, size_t vertex_positions_stride);
+MESHOPTIMIZER_EXPERIMENTAL struct meshopt_Bounds meshopt_computeMeshletBounds(const unsigned int* meshlet_vertices, const unsigned char* meshlet_triangles, size_t triangle_count, const float* vertex_positions, size_t vertex_count, size_t vertex_positions_stride);
 
 /**
  * Experimental: Spatial sorter


### PR DESCRIPTION
The existing interface for meshlet construction used fixed size arrays
as part of meshopt_Meshlet structure. This was hard to extend - on AMD
hardware larger meshlet sizes may be appropriate, and increasing the
size of the arrays in the structure results in subtantial increase in
memory consumption for older limits.

In addition, meshopt_Meshlet should be regarded as an intermediate
structure as it's not appropriate for direct consumption on GPU, but
that's in contrast with other algorithms in meshopt that usually produce
data fit for GPU.

This change thus reworks the meshlet algorithms to work with packed
vertex index / triangle data. This allows us to be flexible wrt the max
meshlet size.

When writing out vertex indices, we pack them tightly; for triangle
indices we align each meshlet to a 4 byte boundary to maximize GPU
efficiency.

The caller must now allocate 3 arrays. To make the worst case bound
analysis easier, we make sure the array size is simply max_meshlets
times max_vertices / max_triangles*3; to make sure 4b padding doesn't
violate the worst case bound we restrict max_triangles to be divisible
by 4.

Fixes #179.