### PR TITLE
gltfpack: Properly handle KHR_texture_transform extension

### DIFF
--- a/gltf/gltfpack.cpp
+++ b/gltf/gltfpack.cpp
@@ -373,6 +373,7 @@ static void process(cgltf_data* data, const char* input_path, const char* output
 	bool ext_sheen = false;
 	bool ext_unlit = false;
 	bool ext_instancing = false;
+	bool ext_texture_transform = false;
 
 	size_t accr_offset = 0;
 	size_t node_offset = 0;
@@ -433,6 +434,7 @@ static void process(cgltf_data* data, const char* input_path, const char* output
 		ext_specular = ext_specular || material.has_specular;
 		ext_sheen = ext_sheen || material.has_sheen;
 		ext_unlit = ext_unlit || material.unlit;
+		ext_texture_transform = ext_texture_transform || usesTextureTransform(material);
 	}
 
 	for (size_t i = 0; i < meshes.size(); ++i)
@@ -658,7 +660,7 @@ static void process(cgltf_data* data, const char* input_path, const char* output
 	const ExtensionInfo extensions[] = {
 	    {"KHR_mesh_quantization", settings.quantize, true},
 	    {"EXT_meshopt_compression", settings.compress, !settings.fallback},
-	    {"KHR_texture_transform", settings.quantize && !json_textures.empty(), false},
+	    {"KHR_texture_transform", (settings.quantize && !json_textures.empty()) || ext_texture_transform, false},
 	    {"KHR_materials_pbrSpecularGlossiness", ext_pbr_specular_glossiness, false},
 	    {"KHR_materials_clearcoat", ext_clearcoat, false},
 	    {"KHR_materials_transmission", ext_transmission, false},

--- a/gltf/gltfpack.h
+++ b/gltf/gltfpack.h
@@ -257,6 +257,8 @@ void mergeMeshes(std::vector<Mesh>& meshes, const Settings& settings);
 void filterEmptyMeshes(std::vector<Mesh>& meshes);
 
 bool usesTextureSet(const cgltf_material& material, int set);
+bool usesTextureTransform(const cgltf_material& material);
+
 void mergeMeshMaterials(cgltf_data* data, std::vector<Mesh>& meshes, const Settings& settings);
 void markNeededMaterials(cgltf_data* data, std::vector<MaterialInfo>& materials, const std::vector<Mesh>& meshes, const Settings& settings);
 

--- a/gltf/material.cpp
+++ b/gltf/material.cpp
@@ -289,142 +289,98 @@ void markNeededMaterials(cgltf_data* data, std::vector<MaterialInfo>& materials,
 	}
 }
 
-static bool usesTextureSet(const cgltf_texture_view& view, int set)
+template <typename Pred>
+static bool materialHasProperty(const cgltf_material& material, Pred pred)
 {
-	return view.texture && view.texcoord == set;
+	if (material.has_pbr_metallic_roughness)
+	{
+		if (pred(material.pbr_metallic_roughness.base_color_texture))
+			return true;
+
+		if (pred(material.pbr_metallic_roughness.metallic_roughness_texture))
+			return true;
+	}
+
+	if (material.has_pbr_specular_glossiness)
+	{
+		if (pred(material.pbr_specular_glossiness.diffuse_texture))
+			return true;
+
+		if (pred(material.pbr_specular_glossiness.specular_glossiness_texture))
+			return true;
+	}
+
+	if (material.has_clearcoat)
+	{
+		if (pred(material.clearcoat.clearcoat_texture))
+			return true;
+
+		if (pred(material.clearcoat.clearcoat_roughness_texture))
+			return true;
+
+		if (pred(material.clearcoat.clearcoat_normal_texture))
+			return true;
+	}
+
+	if (material.has_transmission)
+	{
+		if (pred(material.transmission.transmission_texture))
+			return true;
+	}
+
+	if (material.has_specular)
+	{
+		if (pred(material.specular.specular_texture))
+			return true;
+	}
+
+	if (material.has_sheen)
+	{
+		if (pred(material.sheen.sheen_color_texture))
+			return true;
+
+		if (pred(material.sheen.sheen_roughness_texture))
+			return true;
+	}
+
+	if (pred(material.normal_texture))
+		return true;
+
+	if (pred(material.occlusion_texture))
+		return true;
+
+	if (pred(material.emissive_texture))
+		return true;
+
+	return false;
 }
+
+struct UsesTextureSet
+{
+	int set;
+
+	bool operator()(const cgltf_texture_view& view) const
+	{
+		return view.texture && view.texcoord == set;
+	}
+};
 
 bool usesTextureSet(const cgltf_material& material, int set)
 {
-	if (material.has_pbr_metallic_roughness)
-	{
-		if (usesTextureSet(material.pbr_metallic_roughness.base_color_texture, set))
-			return true;
+	UsesTextureSet pred = {set};
 
-		if (usesTextureSet(material.pbr_metallic_roughness.metallic_roughness_texture, set))
-			return true;
-	}
-
-	if (material.has_pbr_specular_glossiness)
-	{
-		if (usesTextureSet(material.pbr_specular_glossiness.diffuse_texture, set))
-			return true;
-
-		if (usesTextureSet(material.pbr_specular_glossiness.specular_glossiness_texture, set))
-			return true;
-	}
-
-	if (material.has_clearcoat)
-	{
-		if (usesTextureSet(material.clearcoat.clearcoat_texture, set))
-			return true;
-
-		if (usesTextureSet(material.clearcoat.clearcoat_roughness_texture, set))
-			return true;
-
-		if (usesTextureSet(material.clearcoat.clearcoat_normal_texture, set))
-			return true;
-	}
-
-	if (material.has_transmission)
-	{
-		if (usesTextureSet(material.transmission.transmission_texture, set))
-			return true;
-	}
-
-	if (material.has_specular)
-	{
-		if (usesTextureSet(material.specular.specular_texture, set))
-			return true;
-	}
-
-	if (material.has_sheen)
-	{
-		if (usesTextureSet(material.sheen.sheen_color_texture, set))
-			return true;
-
-		if (usesTextureSet(material.sheen.sheen_roughness_texture, set))
-			return true;
-	}
-
-	if (usesTextureSet(material.normal_texture, set))
-		return true;
-
-	if (usesTextureSet(material.occlusion_texture, set))
-		return true;
-
-	if (usesTextureSet(material.emissive_texture, set))
-		return true;
-
-	return false;
+	return materialHasProperty(material, pred);
 }
 
-static bool usesTextureTransform(const cgltf_texture_view& view)
+struct UsesTextureTransform
 {
-	return view.has_transform;
-}
+	bool operator()(const cgltf_texture_view& view) const
+	{
+		return view.has_transform;
+	}
+};
 
 bool usesTextureTransform(const cgltf_material& material)
 {
-	if (material.has_pbr_metallic_roughness)
-	{
-		if (usesTextureTransform(material.pbr_metallic_roughness.base_color_texture))
-			return true;
-
-		if (usesTextureTransform(material.pbr_metallic_roughness.metallic_roughness_texture))
-			return true;
-	}
-
-	if (material.has_pbr_specular_glossiness)
-	{
-		if (usesTextureTransform(material.pbr_specular_glossiness.diffuse_texture))
-			return true;
-
-		if (usesTextureTransform(material.pbr_specular_glossiness.specular_glossiness_texture))
-			return true;
-	}
-
-	if (material.has_clearcoat)
-	{
-		if (usesTextureTransform(material.clearcoat.clearcoat_texture))
-			return true;
-
-		if (usesTextureTransform(material.clearcoat.clearcoat_roughness_texture))
-			return true;
-
-		if (usesTextureTransform(material.clearcoat.clearcoat_normal_texture))
-			return true;
-	}
-
-	if (material.has_transmission)
-	{
-		if (usesTextureTransform(material.transmission.transmission_texture))
-			return true;
-	}
-
-	if (material.has_specular)
-	{
-		if (usesTextureTransform(material.specular.specular_texture))
-			return true;
-	}
-
-	if (material.has_sheen)
-	{
-		if (usesTextureTransform(material.sheen.sheen_color_texture))
-			return true;
-
-		if (usesTextureTransform(material.sheen.sheen_roughness_texture))
-			return true;
-	}
-
-	if (usesTextureTransform(material.normal_texture))
-		return true;
-
-	if (usesTextureTransform(material.occlusion_texture))
-		return true;
-
-	if (usesTextureTransform(material.emissive_texture))
-		return true;
-
-	return false;
+	return materialHasProperty(material, UsesTextureTransform());
 }

--- a/gltf/material.cpp
+++ b/gltf/material.cpp
@@ -358,3 +358,73 @@ bool usesTextureSet(const cgltf_material& material, int set)
 
 	return false;
 }
+
+static bool usesTextureTransform(const cgltf_texture_view& view)
+{
+	return view.has_transform;
+}
+
+bool usesTextureTransform(const cgltf_material& material)
+{
+	if (material.has_pbr_metallic_roughness)
+	{
+		if (usesTextureTransform(material.pbr_metallic_roughness.base_color_texture))
+			return true;
+
+		if (usesTextureTransform(material.pbr_metallic_roughness.metallic_roughness_texture))
+			return true;
+	}
+
+	if (material.has_pbr_specular_glossiness)
+	{
+		if (usesTextureTransform(material.pbr_specular_glossiness.diffuse_texture))
+			return true;
+
+		if (usesTextureTransform(material.pbr_specular_glossiness.specular_glossiness_texture))
+			return true;
+	}
+
+	if (material.has_clearcoat)
+	{
+		if (usesTextureTransform(material.clearcoat.clearcoat_texture))
+			return true;
+
+		if (usesTextureTransform(material.clearcoat.clearcoat_roughness_texture))
+			return true;
+
+		if (usesTextureTransform(material.clearcoat.clearcoat_normal_texture))
+			return true;
+	}
+
+	if (material.has_transmission)
+	{
+		if (usesTextureTransform(material.transmission.transmission_texture))
+			return true;
+	}
+
+	if (material.has_specular)
+	{
+		if (usesTextureTransform(material.specular.specular_texture))
+			return true;
+	}
+
+	if (material.has_sheen)
+	{
+		if (usesTextureTransform(material.sheen.sheen_color_texture))
+			return true;
+
+		if (usesTextureTransform(material.sheen.sheen_roughness_texture))
+			return true;
+	}
+
+	if (usesTextureTransform(material.normal_texture))
+		return true;
+
+	if (usesTextureTransform(material.occlusion_texture))
+		return true;
+
+	if (usesTextureTransform(material.emissive_texture))
+		return true;
+
+	return false;
+}


### PR DESCRIPTION
When -noq is used we still may need to preserve KHR_texture_transform in
extensionsUsed if it was used in the source scene in one of the
materials.

Fixes #227.