### PR TITLE
indexgenerator: Implement support for PN-AEN tessellation buffers

### DIFF
--- a/demo/main.cpp
+++ b/demo/main.cpp
@@ -1010,6 +1010,19 @@ void spatialSortTriangles(const Mesh& mesh)
 	       (end - start) * 1000);
 }
 
+void tessellation(const Mesh& mesh)
+{
+	double start = timestamp();
+
+	// 12 indices per input triangle
+	std::vector<unsigned int> patchib(mesh.indices.size() * 4);
+	meshopt_generateTessellationIndexBuffer(&patchib[0], &mesh.indices[0], mesh.indices.size(), &mesh.vertices[0].px, mesh.vertices.size(), sizeof(Vertex));
+
+	double end = timestamp();
+
+	printf("Tesselltn: %d patches in %.2f msec\n", int(mesh.indices.size() / 3), (end - start) * 1000);
+}
+
 bool loadMesh(Mesh& mesh, const char* path)
 {
 	double start = timestamp();
@@ -1161,6 +1174,7 @@ void process(const char* path)
 	meshlets(copy, true);
 
 	shadow(copy);
+	tessellation(copy);
 
 	encodeIndex(copy, ' ');
 	encodeIndex(copystrip, 'S');
@@ -1192,11 +1206,7 @@ void processDev(const char* path)
 	if (!loadMesh(mesh, path))
 		return;
 
-	Mesh copy = mesh;
-	meshopt_optimizeVertexCache(&copy.indices[0], &copy.indices[0], copy.indices.size(), copy.vertices.size());
-
-	meshlets(copy, false);
-	meshlets(copy, true);
+	tessellation(mesh);
 }
 
 int main(int argc, char** argv)

--- a/demo/tests.cpp
+++ b/demo/tests.cpp
@@ -824,6 +824,37 @@ static void simplifyScale()
 	assert(meshopt_simplifyScale(vb, 4, 12) == 3.f);
 }
 
+static void tessellation()
+{
+	// 0 1/4
+	// 2/5 3
+	const float vb[] = {0, 0, 0, 1, 0, 0, 0, 1, 0, 1, 1, 0, 1, 0, 0, 0, 1, 0};
+	const unsigned int ib[] = {0, 1, 2, 5, 4, 3};
+
+	unsigned int tessib[24];
+	meshopt_generateTessellationIndexBuffer(tessib, ib, 6, vb, 6, 12);
+
+	unsigned int expected[] = {
+	    // patch 0
+	    0, 1, 2,
+	    0, 1,
+	    4, 5,
+	    2, 0,
+	    0, 1, 2,
+
+	    // patch 1
+	    5, 4, 3,
+	    2, 1,
+	    4, 3,
+	    3, 5,
+	    2, 1, 3,
+
+	    // clang-format :-/
+	};
+
+	assert(memcmp(tessib, expected, sizeof(expected)) == 0);
+}
+
 static void runTestsOnce()
 {
 	decodeIndexV0();
@@ -873,6 +904,8 @@ static void runTestsOnce()
 	simplifyPointsStuck();
 	simplifyFlip();
 	simplifyScale();
+
+	tessellation();
 }
 
 namespace meshopt

--- a/src/indexgenerator.cpp
+++ b/src/indexgenerator.cpp
@@ -4,6 +4,8 @@
 #include <assert.h>
 #include <string.h>
 
+// This work is based on:
+// John McDonald, Mark Kilgard. Crack-Free Point-Normal Triangles using Adjacent Edge Normals. 2010
 namespace meshopt
 {
 
@@ -80,6 +82,45 @@ struct VertexStreamHasher
 		}
 
 		return true;
+	}
+};
+
+struct EdgeHasher
+{
+	const unsigned int* remap;
+
+	size_t hash(unsigned long long edge) const
+	{
+		unsigned int e0 = unsigned(edge >> 32);
+		unsigned int e1 = unsigned(edge);
+
+		unsigned int h1 = remap[e0];
+		unsigned int h2 = remap[e1];
+
+		const unsigned int m = 0x5bd1e995;
+
+		// MurmurHash64B finalizer
+		h1 ^= h2 >> 18;
+		h1 *= m;
+		h2 ^= h1 >> 22;
+		h2 *= m;
+		h1 ^= h2 >> 17;
+		h1 *= m;
+		h2 ^= h1 >> 19;
+		h2 *= m;
+
+		return h2;
+	}
+
+	bool equal(unsigned long long lhs, unsigned long long rhs) const
+	{
+		unsigned int l0 = unsigned(lhs >> 32);
+		unsigned int l1 = unsigned(lhs);
+
+		unsigned int r0 = unsigned(rhs >> 32);
+		unsigned int r1 = unsigned(rhs);
+
+		return remap[l0] == remap[r0] && remap[l1] == remap[r1];
 	}
 };
 
@@ -343,5 +384,93 @@ void meshopt_generateShadowIndexBufferMulti(unsigned int* destination, const uns
 		}
 
 		destination[i] = remap[index];
+	}
+}
+
+void meshopt_generateTessellationIndexBuffer(unsigned int* destination, const unsigned int* indices, size_t index_count, const float* vertex_positions, size_t vertex_count, size_t vertex_positions_stride)
+{
+	using namespace meshopt;
+
+	assert(index_count % 3 == 0);
+	assert(vertex_positions_stride > 0 && vertex_positions_stride <= 256);
+	assert(vertex_positions_stride % sizeof(float) == 0);
+
+	meshopt_Allocator allocator;
+
+	static const int next[3] = {1, 2, 0};
+
+	VertexHasher vertex_hasher = {reinterpret_cast<const unsigned char*>(vertex_positions), 3 * sizeof(float), vertex_positions_stride};
+
+	size_t vertex_table_size = hashBuckets(vertex_count);
+	unsigned int* vertex_table = allocator.allocate<unsigned int>(vertex_table_size);
+	memset(vertex_table, -1, vertex_table_size * sizeof(unsigned int));
+
+	// build position remap: for each vertex, which other (canonical) vertex does it map to?
+	unsigned int* remap = allocator.allocate<unsigned int>(vertex_count);
+
+	for (size_t i = 0; i < vertex_count; ++i)
+	{
+		unsigned int index = unsigned(i);
+		unsigned int* entry = hashLookup(vertex_table, vertex_table_size, vertex_hasher, index, ~0u);
+
+		if (*entry == ~0u)
+			*entry = index;
+
+		remap[index] = *entry;
+	}
+
+	// build edge set; this stores all triangle edges but we can look these up by any other wedge
+	EdgeHasher edge_hasher = {remap};
+
+	size_t edge_table_size = hashBuckets(index_count);
+	unsigned long long* edge_table = allocator.allocate<unsigned long long>(edge_table_size);
+	memset(edge_table, -1, edge_table_size * sizeof(unsigned long long));
+
+	for (size_t i = 0; i < index_count; i += 3)
+	{
+		for (int e = 0; e < 3; ++e)
+		{
+			unsigned int i0 = indices[i + e];
+			unsigned int i1 = indices[i + next[e]];
+			assert(i0 < vertex_count && i1 < vertex_count);
+
+			unsigned long long edge = ((unsigned long long)i0 << 32) | i1;
+			unsigned long long* entry = hashLookup(edge_table, edge_table_size, edge_hasher, edge, ~0ull);
+
+			if (*entry == ~0ull)
+				*entry = edge;
+		}
+	}
+
+	// build resulting index buffer: 12 indices for each input triangle
+	for (size_t i = 0; i < index_count; i += 3)
+	{
+		unsigned int patch[12];
+
+		for (int e = 0; e < 3; ++e)
+		{
+			unsigned int i0 = indices[i + e];
+			unsigned int i1 = indices[i + next[e]];
+			assert(i0 < vertex_count && i1 < vertex_count);
+
+			// note: this refers to the opposite edge!
+			unsigned long long edge = ((unsigned long long)i1 << 32) | i0;
+			unsigned long long oppe = *hashLookup(edge_table, edge_table_size, edge_hasher, edge, ~0ull);
+
+			// use the same edge if opposite edge doesn't exist (border)
+			oppe = (oppe == ~0ull) ? edge : oppe;
+
+			// triangle index (0, 1, 2)
+			patch[e] = i0;
+
+			// opposite edge (3, 4; 5, 6; 7, 8)
+			patch[3 + e * 2 + 0] = unsigned(oppe);
+			patch[3 + e * 2 + 1] = unsigned(oppe >> 32);
+
+			// dominant vertex (9, 10, 11)
+			patch[9 + e] = remap[i0];
+		}
+
+		memcpy(destination + i * 4, patch, sizeof(patch));
 	}
 }


### PR DESCRIPTION
To render a mesh with normal/UV seams using hardware tessellation, the
PN-triangles method is not sufficient as it produces cracks on normal
discontinuities (position displacement based on normal is not consistent
along both sides of the seam), and displacement mapping uses slightly
different texture samples which results in cracks along UV seams.

In 2010, NVidia proposed a PN-AEN tessellation scheme that fixes the
problem around normal discontinuities by using opposite edge normals and
averaging the resulting control point data. In 2011, NVidia proposed a
further tweak on top of this technique that allows to select the
"dominant" edge by choosing the min. edge index out of the
current/adjacent edges, and using the UV data from that edge on the
patch edges to sample the displacement data. For corners, there can be
more than two wedges that have the same position, so you need to store
the dominant vertex for each patch corner as well.

As a result, generating a 12-vertex patch for each input triangle allows
to use the hardware tessellation engine to implement PN-AEN (using 9
vertices) and/or displacement mapping (using 3 more vertices) without
cracks.

This change implements the data preprocessing step for this algorithm as
meshopt_generateTessellationIndexBuffer; this index buffer can be
directly fed to the GPU along with the requisite hull/domain shaders.

For implementing the shader code, the following papers are recommended:

John McDonald, Mark Kilgard
Crack-Free Point-Normal Triangles using Adjacent Edge Normals. 2010

John McDonald
Tessellation on Any Budget. 2010

Bryan Dudash
My Tessellation Has Cracks! 2012