### PR TITLE
indexgenerator: Implement support for triangle adjacency index buffers

### DIFF
--- a/demo/main.cpp
+++ b/demo/main.cpp
@@ -824,7 +824,7 @@ void meshlets(const Mesh& mesh, bool scan)
 {
 	const size_t max_vertices = 64;
 	const size_t max_triangles = 124; // NVidia-recommended 126, rounded down to a multiple of 4
-	const float cone_weight = 0.5f; // note: should be set to 0 unless cone culling is used at runtime!
+	const float cone_weight = 0.5f;   // note: should be set to 0 unless cone culling is used at runtime!
 
 	// note: input mesh is assumed to be optimized for vertex cache and vertex fetch
 	double start = timestamp();
@@ -1010,17 +1010,24 @@ void spatialSortTriangles(const Mesh& mesh)
 	       (end - start) * 1000);
 }
 
-void tessellation(const Mesh& mesh)
+void tessellationAdjacency(const Mesh& mesh)
 {
 	double start = timestamp();
 
 	// 12 indices per input triangle
-	std::vector<unsigned int> patchib(mesh.indices.size() * 4);
-	meshopt_generateTessellationIndexBuffer(&patchib[0], &mesh.indices[0], mesh.indices.size(), &mesh.vertices[0].px, mesh.vertices.size(), sizeof(Vertex));
+	std::vector<unsigned int> tessib(mesh.indices.size() * 4);
+	meshopt_generateTessellationIndexBuffer(&tessib[0], &mesh.indices[0], mesh.indices.size(), &mesh.vertices[0].px, mesh.vertices.size(), sizeof(Vertex));
+
+	double middle = timestamp();
+
+	// 6 indices per input triangle
+	std::vector<unsigned int> adjib(mesh.indices.size() * 2);
+	meshopt_generateAdjacencyIndexBuffer(&adjib[0], &mesh.indices[0], mesh.indices.size(), &mesh.vertices[0].px, mesh.vertices.size(), sizeof(Vertex));
 
 	double end = timestamp();
 
-	printf("Tesselltn: %d patches in %.2f msec\n", int(mesh.indices.size() / 3), (end - start) * 1000);
+	printf("Tesselltn: %d patches in %.2f msec\n", int(mesh.indices.size() / 3), (middle - start) * 1000);
+	printf("Adjacency: %d patches in %.2f msec\n", int(mesh.indices.size() / 3), (end - middle) * 1000);
 }
 
 bool loadMesh(Mesh& mesh, const char* path)
@@ -1174,7 +1181,7 @@ void process(const char* path)
 	meshlets(copy, true);
 
 	shadow(copy);
-	tessellation(copy);
+	tessellationAdjacency(copy);
 
 	encodeIndex(copy, ' ');
 	encodeIndex(copystrip, 'S');
@@ -1206,7 +1213,7 @@ void processDev(const char* path)
 	if (!loadMesh(mesh, path))
 		return;
 
-	tessellation(mesh);
+	tessellationAdjacency(mesh);
 }
 
 int main(int argc, char** argv)

--- a/demo/tests.cpp
+++ b/demo/tests.cpp
@@ -824,6 +824,33 @@ static void simplifyScale()
 	assert(meshopt_simplifyScale(vb, 4, 12) == 3.f);
 }
 
+static void adjacency()
+{
+	// 0 1/4
+	// 2/5 3
+	const float vb[] = {0, 0, 0, 1, 0, 0, 0, 1, 0, 1, 1, 0, 1, 0, 0, 0, 1, 0};
+	const unsigned int ib[] = {0, 1, 2, 5, 4, 3};
+
+	unsigned int adjib[12];
+	meshopt_generateAdjacencyIndexBuffer(adjib, ib, 6, vb, 6, 12);
+
+	unsigned int expected[] = {
+	    // patch 0
+	    0, 0,
+	    1, 3,
+	    2, 2,
+
+	    // patch 1
+	    5, 0,
+	    4, 4,
+	    3, 3,
+
+	    // clang-format :-/
+	};
+
+	assert(memcmp(adjib, expected, sizeof(expected)) == 0);
+}
+
 static void tessellation()
 {
 	// 0 1/4
@@ -905,6 +932,7 @@ static void runTestsOnce()
 	simplifyFlip();
 	simplifyScale();
 
+	adjacency();
 	tessellation();
 }
 

--- a/src/indexgenerator.cpp
+++ b/src/indexgenerator.cpp
@@ -387,6 +387,93 @@ void meshopt_generateShadowIndexBufferMulti(unsigned int* destination, const uns
 	}
 }
 
+void meshopt_generateAdjacencyIndexBuffer(unsigned int* destination, const unsigned int* indices, size_t index_count, const float* vertex_positions, size_t vertex_count, size_t vertex_positions_stride)
+{
+	using namespace meshopt;
+
+	assert(index_count % 3 == 0);
+	assert(vertex_positions_stride > 0 && vertex_positions_stride <= 256);
+	assert(vertex_positions_stride % sizeof(float) == 0);
+
+	meshopt_Allocator allocator;
+
+	static const int next[4] = {1, 2, 0, 1};
+
+	VertexHasher vertex_hasher = {reinterpret_cast<const unsigned char*>(vertex_positions), 3 * sizeof(float), vertex_positions_stride};
+
+	size_t vertex_table_size = hashBuckets(vertex_count);
+	unsigned int* vertex_table = allocator.allocate<unsigned int>(vertex_table_size);
+	memset(vertex_table, -1, vertex_table_size * sizeof(unsigned int));
+
+	// build position remap: for each vertex, which other (canonical) vertex does it map to?
+	unsigned int* remap = allocator.allocate<unsigned int>(vertex_count);
+
+	for (size_t i = 0; i < vertex_count; ++i)
+	{
+		unsigned int index = unsigned(i);
+		unsigned int* entry = hashLookup(vertex_table, vertex_table_size, vertex_hasher, index, ~0u);
+
+		if (*entry == ~0u)
+			*entry = index;
+
+		remap[index] = *entry;
+	}
+
+	// build edge set; this stores all triangle edges but we can look these up by any other wedge
+	EdgeHasher edge_hasher = {remap};
+
+	size_t edge_table_size = hashBuckets(index_count);
+	unsigned long long* edge_table = allocator.allocate<unsigned long long>(edge_table_size);
+	unsigned int* edge_vertex_table = allocator.allocate<unsigned int>(edge_table_size);
+
+	memset(edge_table, -1, edge_table_size * sizeof(unsigned long long));
+	memset(edge_vertex_table, -1, edge_table_size * sizeof(unsigned int));
+
+	for (size_t i = 0; i < index_count; i += 3)
+	{
+		for (int e = 0; e < 3; ++e)
+		{
+			unsigned int i0 = indices[i + e];
+			unsigned int i1 = indices[i + next[e]];
+			unsigned int i2 = indices[i + next[e + 1]];
+			assert(i0 < vertex_count && i1 < vertex_count && i2 < vertex_count);
+
+			unsigned long long edge = ((unsigned long long)i0 << 32) | i1;
+			unsigned long long* entry = hashLookup(edge_table, edge_table_size, edge_hasher, edge, ~0ull);
+
+			if (*entry == ~0ull)
+			{
+				*entry = edge;
+
+				// store vertex opposite to the edge
+				edge_vertex_table[entry - edge_table] = i2;
+			}
+		}
+	}
+
+	// build resulting index buffer: 6 indices for each input triangle
+	for (size_t i = 0; i < index_count; i += 3)
+	{
+		unsigned int patch[6];
+
+		for (int e = 0; e < 3; ++e)
+		{
+			unsigned int i0 = indices[i + e];
+			unsigned int i1 = indices[i + next[e]];
+			assert(i0 < vertex_count && i1 < vertex_count);
+
+			// note: this refers to the opposite edge!
+			unsigned long long edge = ((unsigned long long)i1 << 32) | i0;
+			unsigned long long* oppe = hashLookup(edge_table, edge_table_size, edge_hasher, edge, ~0ull);
+
+			patch[e * 2 + 0] = i0;
+			patch[e * 2 + 1] = (*oppe == ~0ull) ? i0 : edge_vertex_table[oppe - edge_table];
+		}
+
+		memcpy(destination + i * 2, patch, sizeof(patch));
+	}
+}
+
 void meshopt_generateTessellationIndexBuffer(unsigned int* destination, const unsigned int* indices, size_t index_count, const float* vertex_positions, size_t vertex_count, size_t vertex_positions_stride)
 {
 	using namespace meshopt;

--- a/src/meshoptimizer.h
+++ b/src/meshoptimizer.h
@@ -98,6 +98,19 @@ MESHOPTIMIZER_API void meshopt_generateShadowIndexBuffer(unsigned int* destinati
 MESHOPTIMIZER_API void meshopt_generateShadowIndexBufferMulti(unsigned int* destination, const unsigned int* indices, size_t index_count, size_t vertex_count, const struct meshopt_Stream* streams, size_t stream_count);
 
 /**
+ * Generate index buffer that can be used as a geometry shader input with triangle adjacency topology
+ * Each triangle is converted into a 6-vertex patch with the following layout:
+ * - 0, 2, 4: original triangle vertices
+ * - 1, 3, 5: vertices adjacent to edges 02, 24 and 40
+ * The resulting patch can be rendered with geometry shaders using e.g. VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST_WITH_ADJACENCY.
+ * This can be used to implement algorithms like silhouette detection/expansion and other forms of GS-driven rendering.
+ *
+ * destination must contain enough space for the resulting index buffer (index_count*2 elements)
+ * vertex_positions should have float3 position in the first 12 bytes of each vertex - similar to glVertexPointer
+ */
+MESHOPTIMIZER_EXPERIMENTAL void meshopt_generateAdjacencyIndexBuffer(unsigned int* destination, const unsigned int* indices, size_t index_count, const float* vertex_positions, size_t vertex_count, size_t vertex_positions_stride);
+
+/**
  * Generate index buffer that can be used for PN-AEN tessellation with crack-free displacement
  * Each triangle is converted into a 12-vertex patch with the following layout:
  * - 0, 1, 2: original triangle vertices
@@ -538,6 +551,8 @@ inline void meshopt_generateShadowIndexBuffer(T* destination, const T* indices, 
 template <typename T>
 inline void meshopt_generateShadowIndexBufferMulti(T* destination, const T* indices, size_t index_count, size_t vertex_count, const meshopt_Stream* streams, size_t stream_count);
 template <typename T>
+inline void meshopt_generateAdjacencyIndexBuffer(T* destination, const T* indices, size_t index_count, const float* vertex_positions, size_t vertex_count, size_t vertex_positions_stride);
+template <typename T>
 inline void meshopt_generateTessellationIndexBuffer(T* destination, const T* indices, size_t index_count, const float* vertex_positions, size_t vertex_count, size_t vertex_positions_stride);
 template <typename T>
 inline void meshopt_optimizeVertexCache(T* destination, const T* indices, size_t index_count, size_t vertex_count);
@@ -788,6 +803,15 @@ inline void meshopt_generateShadowIndexBufferMulti(T* destination, const T* indi
 	meshopt_IndexAdapter<T> out(destination, 0, index_count);
 
 	meshopt_generateShadowIndexBufferMulti(out.data, in.data, index_count, vertex_count, streams, stream_count);
+}
+
+template <typename T>
+inline void meshopt_generateAdjacencyIndexBuffer(T* destination, const T* indices, size_t index_count, const float* vertex_positions, size_t vertex_count, size_t vertex_positions_stride)
+{
+	meshopt_IndexAdapter<T> in(0, indices, index_count);
+	meshopt_IndexAdapter<T> out(destination, 0, index_count * 2);
+
+	meshopt_generateAdjacencyIndexBuffer(out.data, in.data, index_count, vertex_positions, vertex_count, vertex_positions_stride);
 }
 
 template <typename T>


### PR DESCRIPTION
Several algorithms that use geometry shaders to render data require
adjacency information; triangle-with-adjacency topology in various APIs
provides a way to supply 3 extra vertices per each triangle that
represent vertices opposite to each triangle's edge.

This data can then be used to compute silhouettes and perform other
types of local geometric processing.

This change implements the data preprocessing step that is similar to
the previous tessellation IB - but instead of storing vertices that
adjoin the triangle from the opposite side, we need to store
complementary / opposite vertices of adjacent triangles, which requires
a separate temporary table.