### PR TITLE
gltfpack: Update KHR_materials_specular to match new draft

### DIFF
--- a/extern/cgltf.h
+++ b/extern/cgltf.h
@@ -439,6 +439,7 @@ typedef struct cgltf_ior
 typedef struct cgltf_specular
 {
 	cgltf_texture_view specular_texture;
+	cgltf_texture_view specular_color_texture;
 	cgltf_float specular_color_factor[3];
 	cgltf_float specular_factor;
 } cgltf_specular;
@@ -1768,6 +1769,7 @@ void cgltf_free(cgltf_data* data)
 		if(data->materials[i].has_specular)
 		{
 			cgltf_free_extensions(data, data->materials[i].specular.specular_texture.extensions, data->materials[i].specular.specular_texture.extensions_count);
+			cgltf_free_extensions(data, data->materials[i].specular.specular_color_texture.extensions, data->materials[i].specular.specular_color_texture.extensions_count);
 		}
 		if(data->materials[i].has_transmission)
 		{
@@ -3466,6 +3468,10 @@ static int cgltf_parse_json_specular(cgltf_options* options, jsmntok_t const* to
 		else if (cgltf_json_strcmp(tokens+i, json_chunk, "specularTexture") == 0)
 		{
 			i = cgltf_parse_json_texture_view(options, tokens, i + 1, json_chunk, &out_specular->specular_texture);
+		}
+		else if (cgltf_json_strcmp(tokens + i, json_chunk, "specularColorTexture") == 0)
+		{
+			i = cgltf_parse_json_texture_view(options, tokens, i + 1, json_chunk, &out_specular->specular_color_texture);
 		}
 		else
 		{
@@ -5594,6 +5600,7 @@ static int cgltf_fixup_pointers(cgltf_data* data)
 		CGLTF_PTRFIXUP(data->materials[i].clearcoat.clearcoat_normal_texture.texture, data->textures, data->textures_count);
 
 		CGLTF_PTRFIXUP(data->materials[i].specular.specular_texture.texture, data->textures, data->textures_count);
+		CGLTF_PTRFIXUP(data->materials[i].specular.specular_color_texture.texture, data->textures, data->textures_count);
 
 		CGLTF_PTRFIXUP(data->materials[i].transmission.transmission_texture.texture, data->textures, data->textures_count);
 

--- a/gltf/gltfpack.h
+++ b/gltf/gltfpack.h
@@ -175,6 +175,10 @@ struct MaterialInfo
 {
 	bool keep;
 
+	bool usesTextureTransform;
+	bool needsTangents;
+	unsigned int textureSetMask;
+
 	int remap;
 };
 
@@ -245,9 +249,9 @@ cgltf_data* parseObj(const char* path, std::vector<Mesh>& meshes, const char** e
 cgltf_data* parseGltf(const char* path, std::vector<Mesh>& meshes, std::vector<Animation>& animations, std::string& extras, const char** error);
 
 void processAnimation(Animation& animation, const Settings& settings);
-void processMesh(Mesh& mesh, const Settings& settings);
+void processMesh(Mesh& mesh, const MaterialInfo& mi, const Settings& settings);
 
-void debugSimplify(const Mesh& mesh, Mesh& kinds, Mesh& loops, float ratio);
+void debugSimplify(const Mesh& mesh, const MaterialInfo& mi, Mesh& kinds, Mesh& loops, float ratio);
 void debugMeshlets(const Mesh& mesh, Mesh& meshlets, Mesh& bounds, int max_vertices, bool scan);
 
 bool compareMeshTargets(const Mesh& lhs, const Mesh& rhs);
@@ -256,13 +260,11 @@ void mergeMeshInstances(Mesh& mesh);
 void mergeMeshes(std::vector<Mesh>& meshes, const Settings& settings);
 void filterEmptyMeshes(std::vector<Mesh>& meshes);
 
-bool usesTextureSet(const cgltf_material& material, int set);
-bool usesTextureTransform(const cgltf_material& material);
-
 void mergeMeshMaterials(cgltf_data* data, std::vector<Mesh>& meshes, const Settings& settings);
 void markNeededMaterials(cgltf_data* data, std::vector<MaterialInfo>& materials, const std::vector<Mesh>& meshes, const Settings& settings);
 
-void analyzeImages(cgltf_data* data, std::vector<ImageInfo>& images);
+void analyzeMaterials(cgltf_data* data, std::vector<MaterialInfo>& materials, std::vector<ImageInfo>& images);
+
 const char* inferMimeType(const char* path);
 bool checkBasis(bool verbose);
 bool encodeBasis(const std::string& data, const char* mime_type, std::string& result, bool normal_map, bool srgb, int quality, float scale, bool pow2, bool uastc, bool verbose);

--- a/gltf/image.cpp
+++ b/gltf/image.cpp
@@ -66,8 +66,8 @@ void analyzeImages(cgltf_data* data, std::vector<ImageInfo>& images)
 		{
 			const cgltf_specular& specular = material.specular;
 
-			if (specular.specular_texture.texture && specular.specular_texture.texture->image)
-				images[specular.specular_texture.texture->image - data->images].srgb = true;
+			if (specular.specular_color_texture.texture && specular.specular_color_texture.texture->image)
+				images[specular.specular_color_texture.texture->image - data->images].srgb = true;
 		}
 
 		if (material.has_sheen)

--- a/gltf/image.cpp
+++ b/gltf/image.cpp
@@ -32,60 +32,6 @@ static const BasisSettings kBasisSettings[10] = {
     {1, 255, 2, 0.f},
 };
 
-void analyzeImages(cgltf_data* data, std::vector<ImageInfo>& images)
-{
-	for (size_t i = 0; i < data->materials_count; ++i)
-	{
-		const cgltf_material& material = data->materials[i];
-
-		if (material.has_pbr_metallic_roughness)
-		{
-			const cgltf_pbr_metallic_roughness& pbr = material.pbr_metallic_roughness;
-
-			if (pbr.base_color_texture.texture && pbr.base_color_texture.texture->image)
-				images[pbr.base_color_texture.texture->image - data->images].srgb = true;
-		}
-
-		if (material.has_pbr_specular_glossiness)
-		{
-			const cgltf_pbr_specular_glossiness& pbr = material.pbr_specular_glossiness;
-
-			if (pbr.diffuse_texture.texture && pbr.diffuse_texture.texture->image)
-				images[pbr.diffuse_texture.texture->image - data->images].srgb = true;
-		}
-
-		if (material.has_clearcoat)
-		{
-			const cgltf_clearcoat& clearcoat = material.clearcoat;
-
-			if (clearcoat.clearcoat_normal_texture.texture && clearcoat.clearcoat_normal_texture.texture->image)
-				images[clearcoat.clearcoat_normal_texture.texture->image - data->images].normal_map = true;
-		}
-
-		if (material.has_specular)
-		{
-			const cgltf_specular& specular = material.specular;
-
-			if (specular.specular_color_texture.texture && specular.specular_color_texture.texture->image)
-				images[specular.specular_color_texture.texture->image - data->images].srgb = true;
-		}
-
-		if (material.has_sheen)
-		{
-			const cgltf_sheen& sheen = material.sheen;
-
-			if (sheen.sheen_color_texture.texture && sheen.sheen_color_texture.texture->image)
-				images[sheen.sheen_color_texture.texture->image - data->images].srgb = true;
-		}
-
-		if (material.emissive_texture.texture && material.emissive_texture.texture->image)
-			images[material.emissive_texture.texture->image - data->images].srgb = true;
-
-		if (material.normal_texture.texture && material.normal_texture.texture->image)
-			images[material.normal_texture.texture->image - data->images].normal_map = true;
-	}
-}
-
 const char* inferMimeType(const char* path)
 {
 	std::string ext = getExtension(path);

--- a/gltf/material.cpp
+++ b/gltf/material.cpp
@@ -133,10 +133,13 @@ static bool areMaterialComponentsEqual(const cgltf_specular& lhs, const cgltf_sp
 	if (!areTextureViewsEqual(lhs.specular_texture, rhs.specular_texture))
 		return false;
 
-	if (memcmp(lhs.specular_color_factor, rhs.specular_color_factor, sizeof(cgltf_float) * 3) != 0)
+	if (!areTextureViewsEqual(lhs.specular_color_texture, rhs.specular_color_texture))
 		return false;
 
 	if (lhs.specular_factor != rhs.specular_factor)
+		return false;
+
+	if (memcmp(lhs.specular_color_factor, rhs.specular_color_factor, sizeof(cgltf_float) * 3) != 0)
 		return false;
 
 	return true;
@@ -331,6 +334,9 @@ static bool materialHasProperty(const cgltf_material& material, Pred pred)
 	if (material.has_specular)
 	{
 		if (pred(material.specular.specular_texture))
+			return true;
+
+		if (pred(material.specular.specular_color_texture))
 			return true;
 	}
 

--- a/gltf/material.cpp
+++ b/gltf/material.cpp
@@ -301,7 +301,7 @@ enum TextureKind
 
 static void analyzeMaterialTexture(const cgltf_texture_view& view, TextureKind kind, MaterialInfo& mi, cgltf_data* data, std::vector<ImageInfo>& images)
 {
-	mi.usesTextureTransform |= view.has_transform;
+	mi.usesTextureTransform |= bool(view.has_transform);
 
 	if (view.texture && view.texture->image)
 	{

--- a/gltf/material.cpp
+++ b/gltf/material.cpp
@@ -292,101 +292,74 @@ void markNeededMaterials(cgltf_data* data, std::vector<MaterialInfo>& materials,
 	}
 }
 
-template <typename Pred>
-static bool materialHasProperty(const cgltf_material& material, Pred pred)
+enum TextureKind
+{
+	TextureKind_Generic,
+	TextureKind_Color,
+	TextureKind_Normal,
+};
+
+static void analyzeMaterialTexture(const cgltf_texture_view& view, TextureKind kind, MaterialInfo& mi, cgltf_data* data, std::vector<ImageInfo>& images)
+{
+	mi.usesTextureTransform |= view.has_transform;
+
+	if (view.texture && view.texture->image)
+	{
+		mi.textureSetMask |= 1u << view.texcoord;
+		mi.needsTangents |= (kind == TextureKind_Normal);
+
+		images[view.texture->image - data->images].srgb |= (kind == TextureKind_Color);
+		images[view.texture->image - data->images].normal_map |= (kind == TextureKind_Normal);
+	}
+}
+
+static void analyzeMaterial(const cgltf_material& material, MaterialInfo& mi, cgltf_data* data, std::vector<ImageInfo>& images)
 {
 	if (material.has_pbr_metallic_roughness)
 	{
-		if (pred(material.pbr_metallic_roughness.base_color_texture))
-			return true;
-
-		if (pred(material.pbr_metallic_roughness.metallic_roughness_texture))
-			return true;
+		analyzeMaterialTexture(material.pbr_metallic_roughness.base_color_texture, TextureKind_Color, mi, data, images);
+		analyzeMaterialTexture(material.pbr_metallic_roughness.metallic_roughness_texture, TextureKind_Generic, mi, data, images);
 	}
 
 	if (material.has_pbr_specular_glossiness)
 	{
-		if (pred(material.pbr_specular_glossiness.diffuse_texture))
-			return true;
-
-		if (pred(material.pbr_specular_glossiness.specular_glossiness_texture))
-			return true;
+		analyzeMaterialTexture(material.pbr_specular_glossiness.diffuse_texture, TextureKind_Color, mi, data, images);
+		analyzeMaterialTexture(material.pbr_specular_glossiness.specular_glossiness_texture, TextureKind_Generic, mi, data, images);
 	}
 
 	if (material.has_clearcoat)
 	{
-		if (pred(material.clearcoat.clearcoat_texture))
-			return true;
-
-		if (pred(material.clearcoat.clearcoat_roughness_texture))
-			return true;
-
-		if (pred(material.clearcoat.clearcoat_normal_texture))
-			return true;
+		analyzeMaterialTexture(material.clearcoat.clearcoat_texture, TextureKind_Generic, mi, data, images);
+		analyzeMaterialTexture(material.clearcoat.clearcoat_roughness_texture, TextureKind_Generic, mi, data, images);
+		analyzeMaterialTexture(material.clearcoat.clearcoat_normal_texture, TextureKind_Normal, mi, data, images);
 	}
 
 	if (material.has_transmission)
 	{
-		if (pred(material.transmission.transmission_texture))
-			return true;
+		analyzeMaterialTexture(material.transmission.transmission_texture, TextureKind_Generic, mi, data, images);
 	}
 
 	if (material.has_specular)
 	{
-		if (pred(material.specular.specular_texture))
-			return true;
-
-		if (pred(material.specular.specular_color_texture))
-			return true;
+		analyzeMaterialTexture(material.specular.specular_texture, TextureKind_Generic, mi, data, images);
+		analyzeMaterialTexture(material.specular.specular_color_texture, TextureKind_Color, mi, data, images);
 	}
 
 	if (material.has_sheen)
 	{
-		if (pred(material.sheen.sheen_color_texture))
-			return true;
-
-		if (pred(material.sheen.sheen_roughness_texture))
-			return true;
+		analyzeMaterialTexture(material.sheen.sheen_color_texture, TextureKind_Color, mi, data, images);
+		analyzeMaterialTexture(material.sheen.sheen_roughness_texture, TextureKind_Generic, mi, data, images);
 	}
 
-	if (pred(material.normal_texture))
-		return true;
-
-	if (pred(material.occlusion_texture))
-		return true;
-
-	if (pred(material.emissive_texture))
-		return true;
-
-	return false;
+	analyzeMaterialTexture(material.normal_texture, TextureKind_Normal, mi, data, images);
+	analyzeMaterialTexture(material.occlusion_texture, TextureKind_Generic, mi, data, images);
+	analyzeMaterialTexture(material.emissive_texture, TextureKind_Color, mi, data, images);
 }
 
-struct UsesTextureSet
+void analyzeMaterials(cgltf_data* data, std::vector<MaterialInfo>& materials, std::vector<ImageInfo>& images)
 {
-	int set;
-
-	bool operator()(const cgltf_texture_view& view) const
+	for (size_t i = 0; i < data->materials_count; ++i)
 	{
-		return view.texture && view.texcoord == set;
+		analyzeMaterial(data->materials[i], materials[i], data, images);
 	}
-};
-
-bool usesTextureSet(const cgltf_material& material, int set)
-{
-	UsesTextureSet pred = {set};
-
-	return materialHasProperty(material, pred);
-}
-
-struct UsesTextureTransform
-{
-	bool operator()(const cgltf_texture_view& view) const
-	{
-		return view.has_transform;
-	}
-};
-
-bool usesTextureTransform(const cgltf_material& material)
-{
-	return materialHasProperty(material, UsesTextureTransform());
 }

--- a/gltf/write.cpp
+++ b/gltf/write.cpp
@@ -790,7 +790,7 @@ void writeImage(std::string& json, std::vector<BufferView>& views, const cgltf_i
 				if (!settings.texture_toktx)
 					encoded = basisToKtx(encoded, info.srgb, settings.texture_uastc);
 
-				writeEmbeddedImage(json, views, encoded.c_str(), encoded.size(), settings.texture_ktx2 ? "image/ktx2" : "image/basis");
+				writeEmbeddedImage(json, views, encoded.c_str(), encoded.size(), "image/ktx2");
 			}
 			else
 			{
@@ -807,7 +807,7 @@ void writeImage(std::string& json, std::vector<BufferView>& views, const cgltf_i
 		if (settings.texture_ktx2)
 		{
 			std::string full_path = getFullPath(decodeUri(image.uri).c_str(), input_path);
-			std::string basis_uri = getFileName(image.uri) + (settings.texture_ktx2 ? ".ktx2" : ".basis");
+			std::string basis_uri = getFileName(image.uri) + ".ktx2";
 			std::string basis_full_path = getFullPath(decodeUri(basis_uri.c_str()).c_str(), output_path);
 
 			if (readFile(full_path.c_str(), img_data))

--- a/gltf/write.cpp
+++ b/gltf/write.cpp
@@ -391,6 +391,18 @@ static void writeMaterialComponent(std::string& json, const cgltf_data* data, co
 		append(json, "\"specularTexture\":");
 		writeTextureInfo(json, data, tm.specular_texture, qt);
 	}
+	if (tm.specular_color_texture.texture)
+	{
+		comma(json);
+		append(json, "\"specularColorTexture\":");
+		writeTextureInfo(json, data, tm.specular_color_texture, qt);
+	}
+	if (tm.specular_factor != 1)
+	{
+		comma(json);
+		append(json, "\"specularFactor\":");
+		append(json, tm.specular_factor);
+	}
 	if (memcmp(tm.specular_color_factor, white, 16) != 0)
 	{
 		comma(json);
@@ -401,12 +413,6 @@ static void writeMaterialComponent(std::string& json, const cgltf_data* data, co
 		append(json, ",");
 		append(json, tm.specular_color_factor[2]);
 		append(json, "]");
-	}
-	if (tm.specular_factor != 1)
-	{
-		comma(json);
-		append(json, "\"specularFactor\":");
-		append(json, tm.specular_factor);
 	}
 	append(json, "}");
 }


### PR DESCRIPTION
This change adjusts the implementation of KHR_materials_specular; the
last update to the specification split the single texture (RGB+A) into
two separate texture slots (RGB + A). This requires associated changes
to handle the case when these are separate.

It also takes an opportunity to rework material analysis to consolidate various
material-related queries. This fixes a small corner case where tangents could be
removed from a mesh that's using clearcoat normal map, and paves the way
towards material variants where mesh processing would need to use combined
material info from all variants.
