### PR TITLE
gltfpack: Add support for KHR_materials_volume

### DIFF
--- a/gltf/gltfpack.cpp
+++ b/gltf/gltfpack.cpp
@@ -380,6 +380,7 @@ static void process(cgltf_data* data, const char* input_path, const char* output
 	bool ext_ior = false;
 	bool ext_specular = false;
 	bool ext_sheen = false;
+	bool ext_volume = false;
 	bool ext_unlit = false;
 	bool ext_instancing = false;
 	bool ext_texture_transform = false;
@@ -442,6 +443,7 @@ static void process(cgltf_data* data, const char* input_path, const char* output
 		ext_ior = ext_ior || material.has_ior;
 		ext_specular = ext_specular || material.has_specular;
 		ext_sheen = ext_sheen || material.has_sheen;
+		ext_volume = ext_volume || material.has_volume;
 		ext_unlit = ext_unlit || material.unlit;
 		ext_texture_transform = ext_texture_transform || mi.usesTextureTransform;
 	}
@@ -676,6 +678,7 @@ static void process(cgltf_data* data, const char* input_path, const char* output
 	    {"KHR_materials_ior", ext_ior, false},
 	    {"KHR_materials_specular", ext_specular, false},
 	    {"KHR_materials_sheen", ext_sheen, false},
+	    {"KHR_materials_volume", ext_volume, false},
 	    {"KHR_materials_unlit", ext_unlit, false},
 	    {"KHR_lights_punctual", data->lights_count > 0, false},
 	    {"KHR_texture_basisu", !json_textures.empty() && settings.texture_ktx2, true},

--- a/gltf/material.cpp
+++ b/gltf/material.cpp
@@ -162,6 +162,23 @@ static bool areMaterialComponentsEqual(const cgltf_sheen& lhs, const cgltf_sheen
 	return true;
 }
 
+static bool areMaterialComponentsEqual(const cgltf_volume& lhs, const cgltf_volume& rhs)
+{
+	if (!areTextureViewsEqual(lhs.thickness_texture, rhs.thickness_texture))
+		return false;
+
+	if (lhs.thickness_factor != rhs.thickness_factor)
+		return false;
+
+	if (memcmp(lhs.attenuation_color, rhs.attenuation_color, sizeof(cgltf_float) * 3) != 0)
+		return false;
+
+	if (lhs.attenuation_distance != rhs.attenuation_distance)
+		return false;
+
+	return true;
+}
+
 static bool areMaterialsEqual(cgltf_data* data, const cgltf_material& lhs, const cgltf_material& rhs, const Settings& settings)
 {
 	if (lhs.has_pbr_metallic_roughness != rhs.has_pbr_metallic_roughness)
@@ -204,6 +221,12 @@ static bool areMaterialsEqual(cgltf_data* data, const cgltf_material& lhs, const
 		return false;
 
 	if (lhs.has_sheen && !areMaterialComponentsEqual(lhs.sheen, rhs.sheen))
+		return false;
+
+	if (lhs.has_volume != rhs.has_volume)
+		return false;
+
+	if (lhs.has_volume && !areMaterialComponentsEqual(lhs.volume, rhs.volume))
 		return false;
 
 	if (!areTextureViewsEqual(lhs.normal_texture, rhs.normal_texture))
@@ -349,6 +372,11 @@ static void analyzeMaterial(const cgltf_material& material, MaterialInfo& mi, cg
 	{
 		analyzeMaterialTexture(material.sheen.sheen_color_texture, TextureKind_Color, mi, data, images);
 		analyzeMaterialTexture(material.sheen.sheen_roughness_texture, TextureKind_Generic, mi, data, images);
+	}
+
+	if (material.has_volume)
+	{
+		analyzeMaterialTexture(material.volume.thickness_texture, TextureKind_Generic, mi, data, images);
 	}
 
 	analyzeMaterialTexture(material.normal_texture, TextureKind_Normal, mi, data, images);


### PR DESCRIPTION
This extension is in draft but the specification is reasonably complete.
This change adds support for the extension as well as fixing a bug with
KHR_materials_specular writing.