### PR TITLE
gltfpack: Implement support for KHR_materials_variants

### DIFF
--- a/extern/cgltf.h
+++ b/extern/cgltf.h
@@ -805,7 +805,7 @@ cgltf_result cgltf_copy_extras_json(const cgltf_data* data, const cgltf_extras* 
 #include <string.h> /* For strncpy */
 #include <stdio.h>  /* For fopen */
 #include <limits.h> /* For UINT_MAX etc */
-#include <float.h>  /* For FLT_MAX etc */
+#include <float.h>  /* For FLT_MAX */
 
 #if !defined(CGLTF_MALLOC) || !defined(CGLTF_FREE) || !defined(CGLTF_ATOI) || !defined(CGLTF_ATOF)
 #include <stdlib.h> /* For malloc, free, atoi, atof */
@@ -2687,7 +2687,7 @@ static int cgltf_parse_json_material_mapping_data(cgltf_options* options, jsmnto
 
 		int material = -1;
 		int variants_tok = -1;
-		cgltf_extras extras = {};
+		cgltf_extras extras = {0, 0};
 
 		for (int k = 0; k < obj_size; ++k)
 		{

--- a/gltf/gltfpack.cpp
+++ b/gltf/gltfpack.cpp
@@ -342,7 +342,15 @@ static void process(cgltf_data* data, const char* input_path, const char* output
 	{
 		Mesh& mesh = meshes[i];
 		MaterialInfo mi = mesh.material ? materials[mesh.material - data->materials] : MaterialInfo();
-		// TODO: variants
+
+		// merge material requirements across all variants
+		for (size_t j = 0; j < mesh.variants.size(); ++j)
+		{
+			MaterialInfo vi = materials[mesh.variants[j].material - data->materials];
+
+			mi.needsTangents |= vi.needsTangents;
+			mi.textureSetMask |= vi.textureSetMask;
+		}
 
 		processMesh(mesh, mi, settings);
 	}

--- a/gltf/gltfpack.cpp
+++ b/gltf/gltfpack.cpp
@@ -342,6 +342,7 @@ static void process(cgltf_data* data, const char* input_path, const char* output
 	{
 		Mesh& mesh = meshes[i];
 		MaterialInfo mi = mesh.material ? materials[mesh.material - data->materials] : MaterialInfo();
+		// TODO: variants
 
 		processMesh(mesh, mi, settings);
 	}
@@ -473,6 +474,7 @@ static void process(cgltf_data* data, const char* input_path, const char* output
 				break;
 
 			const QuantizationTexture& qt = prim.material ? qt_materials[prim.material - data->materials] : qt_dummy;
+			// TODO: variants
 
 			comma(json_meshes);
 			append(json_meshes, "{\"attributes\":{");
@@ -511,20 +513,21 @@ static void process(cgltf_data* data, const char* input_path, const char* output
 				append(json_meshes, size_t(mi.remap));
 			}
 
-			if (mesh.variants.size())
+			if (prim.variants.size())
 			{
 				append(json_meshes, ",\"extensions\":{\"KHR_materials_variants\":{\"mappings\":[");
 
-				for (size_t j = 0; j < mesh.variants.size(); ++j)
+				for (size_t j = 0; j < prim.variants.size(); ++j)
 				{
-					MaterialInfo& mi = materials[mesh.variants[j].material - data->materials];
+					const cgltf_material_mapping& variant = prim.variants[j];
+					MaterialInfo& mi = materials[variant.material - data->materials];
 
 					assert(mi.keep);
 					comma(json_meshes);
 					append(json_meshes, "{\"material\":");
 					append(json_meshes, size_t(mi.remap));
 					append(json_meshes, ",\"variants\":[");
-					append(json_meshes, size_t(mesh.variants[j].variant));
+					append(json_meshes, size_t(variant.variant));
 					append(json_meshes, "]}");
 				}
 

--- a/gltf/gltfpack.cpp
+++ b/gltf/gltfpack.cpp
@@ -364,7 +364,8 @@ static void process(cgltf_data* data, const char* input_path, const char* output
 	QuantizationPosition qp = prepareQuantizationPosition(meshes, settings);
 
 	std::vector<QuantizationTexture> qt_materials(materials.size());
-	prepareQuantizationTexture(data, qt_materials, meshes, settings);
+	std::vector<size_t> qt_meshes(meshes.size(), size_t(-1));
+	prepareQuantizationTexture(data, qt_materials, qt_meshes, meshes, settings);
 
 	QuantizationTexture qt_dummy = {};
 	qt_dummy.bits = settings.tex_bits;
@@ -481,8 +482,7 @@ static void process(cgltf_data* data, const char* input_path, const char* output
 			if (!compareMeshTargets(mesh, prim))
 				break;
 
-			const QuantizationTexture& qt = prim.material ? qt_materials[prim.material - data->materials] : qt_dummy;
-			// TODO: variants
+			const QuantizationTexture& qt = qt_meshes[pi] == size_t(-1) ? qt_dummy : qt_materials[qt_meshes[pi]];
 
 			comma(json_meshes);
 			append(json_meshes, "{\"attributes\":{");

--- a/gltf/gltfpack.cpp
+++ b/gltf/gltfpack.cpp
@@ -511,6 +511,26 @@ static void process(cgltf_data* data, const char* input_path, const char* output
 				append(json_meshes, size_t(mi.remap));
 			}
 
+			if (mesh.variants.size())
+			{
+				append(json_meshes, ",\"extensions\":{\"KHR_materials_variants\":{\"mappings\":[");
+
+				for (size_t j = 0; j < mesh.variants.size(); ++j)
+				{
+					MaterialInfo& mi = materials[mesh.variants[j].material - data->materials];
+
+					assert(mi.keep);
+					comma(json_meshes);
+					append(json_meshes, "{\"material\":");
+					append(json_meshes, size_t(mi.remap));
+					append(json_meshes, ",\"variants\":[");
+					append(json_meshes, size_t(mesh.variants[j].variant));
+					append(json_meshes, "]}");
+				}
+
+				append(json_meshes, "]}}");
+			}
+
 			append(json_meshes, "}");
 		}
 
@@ -661,6 +681,24 @@ static void process(cgltf_data* data, const char* input_path, const char* output
 		append(json_extensions, "]}");
 	}
 
+	if (data->variants_count > 0)
+	{
+		comma(json_extensions);
+		append(json_extensions, "\"KHR_materials_variants\":{\"variants\":[");
+
+		for (size_t i = 0; i < data->variants_count; ++i)
+		{
+			const cgltf_material_variant& variant = data->variants[i];
+
+			comma(json_extensions);
+			append(json_extensions, "{\"name\":\"");
+			append(json_extensions, variant.name);
+			append(json_extensions, "\"}");
+		}
+
+		append(json_extensions, "]}");
+	}
+
 	append(json, "\"asset\":{");
 	append(json, "\"version\":\"2.0\",\"generator\":\"gltfpack ");
 	append(json, getVersion());
@@ -680,6 +718,7 @@ static void process(cgltf_data* data, const char* input_path, const char* output
 	    {"KHR_materials_sheen", ext_sheen, false},
 	    {"KHR_materials_volume", ext_volume, false},
 	    {"KHR_materials_unlit", ext_unlit, false},
+	    {"KHR_materials_variants", data->variants_count > 0, false},
 	    {"KHR_lights_punctual", data->lights_count > 0, false},
 	    {"KHR_texture_basisu", !json_textures.empty() && settings.texture_ktx2, true},
 	    {"EXT_mesh_gpu_instancing", ext_instancing, true},

--- a/gltf/gltfpack.h
+++ b/gltf/gltfpack.h
@@ -283,7 +283,7 @@ void remapNodes(cgltf_data* data, std::vector<NodeInfo>& nodes, size_t& node_off
 void decomposeTransform(float translation[3], float rotation[4], float scale[3], const float* transform);
 
 QuantizationPosition prepareQuantizationPosition(const std::vector<Mesh>& meshes, const Settings& settings);
-void prepareQuantizationTexture(cgltf_data* data, std::vector<QuantizationTexture>& result, const std::vector<Mesh>& meshes, const Settings& settings);
+void prepareQuantizationTexture(cgltf_data* data, std::vector<QuantizationTexture>& result, std::vector<size_t>& indices, const std::vector<Mesh>& meshes, const Settings& settings);
 void getPositionBounds(float min[3], float max[3], const Stream& stream, const QuantizationPosition* qp);
 
 StreamFormat writeVertexStream(std::string& bin, const Stream& stream, const QuantizationPosition& qp, const QuantizationTexture& qt, const Settings& settings);

--- a/gltf/gltfpack.h
+++ b/gltf/gltfpack.h
@@ -54,6 +54,8 @@ struct Mesh
 	size_t targets;
 	std::vector<float> target_weights;
 	std::vector<const char*> target_names;
+
+	std::vector<cgltf_material_mapping> variants;
 };
 
 struct Track
@@ -255,7 +257,9 @@ void debugSimplify(const Mesh& mesh, const MaterialInfo& mi, Mesh& kinds, Mesh& 
 void debugMeshlets(const Mesh& mesh, Mesh& meshlets, Mesh& bounds, int max_vertices, bool scan);
 
 bool compareMeshTargets(const Mesh& lhs, const Mesh& rhs);
+bool compareMeshVariants(const Mesh& lhs, const Mesh& rhs);
 bool compareMeshNodes(const Mesh& lhs, const Mesh& rhs);
+
 void mergeMeshInstances(Mesh& mesh);
 void mergeMeshes(std::vector<Mesh>& meshes, const Settings& settings);
 void filterEmptyMeshes(std::vector<Mesh>& meshes);

--- a/gltf/material.cpp
+++ b/gltf/material.cpp
@@ -282,6 +282,9 @@ void mergeMeshMaterials(cgltf_data* data, std::vector<Mesh>& meshes, const Setti
 				break;
 			}
 		}
+
+		// TODO: merge variants
+		// TODO: clip useless variants
 	}
 }
 
@@ -295,6 +298,13 @@ void markNeededMaterials(cgltf_data* data, std::vector<MaterialInfo>& materials,
 		if (mesh.material)
 		{
 			MaterialInfo& mi = materials[mesh.material - data->materials];
+
+			mi.keep = true;
+		}
+
+		for (size_t j = 0; j < mesh.variants.size(); ++j)
+		{
+			MaterialInfo& mi = materials[mesh.variants[j].material - data->materials];
 
 			mi.keep = true;
 		}

--- a/gltf/material.cpp
+++ b/gltf/material.cpp
@@ -261,30 +261,37 @@ static bool areMaterialsEqual(cgltf_data* data, const cgltf_material& lhs, const
 
 void mergeMeshMaterials(cgltf_data* data, std::vector<Mesh>& meshes, const Settings& settings)
 {
-	for (size_t i = 0; i < meshes.size(); ++i)
+	std::vector<cgltf_material*> material_remap(data->materials_count);
+
+	for (size_t i = 0; i < data->materials_count; ++i)
 	{
-		Mesh& mesh = meshes[i];
+		material_remap[i] = &data->materials[i];
 
-		if (!mesh.material)
+		if (settings.keep_materials && data->materials[i].name && *data->materials[i].name)
 			continue;
 
-		if (settings.keep_materials && mesh.material->name && *mesh.material->name)
-			continue;
-
-		for (int j = 0; j < mesh.material - data->materials; ++j)
+		for (size_t j = 0; j < i; ++j)
 		{
 			if (settings.keep_materials && data->materials[j].name && *data->materials[j].name)
 				continue;
 
-			if (areMaterialsEqual(data, *mesh.material, data->materials[j], settings))
+			if (areMaterialsEqual(data, data->materials[i], data->materials[j], settings))
 			{
-				mesh.material = &data->materials[j];
+				material_remap[i] = &data->materials[j];
 				break;
 			}
 		}
+	}
 
-		// TODO: merge variants
-		// TODO: clip useless variants
+	for (size_t i = 0; i < meshes.size(); ++i)
+	{
+		Mesh& mesh = meshes[i];
+
+		if (mesh.material)
+			mesh.material = material_remap[mesh.material - data->materials];
+
+		for (size_t j = 0; j < mesh.variants.size(); ++j)
+			mesh.variants[j].material = material_remap[mesh.variants[j].material - data->materials];
 	}
 }
 

--- a/gltf/mesh.cpp
+++ b/gltf/mesh.cpp
@@ -131,6 +131,23 @@ bool compareMeshTargets(const Mesh& lhs, const Mesh& rhs)
 	return true;
 }
 
+bool compareMeshVariants(const Mesh& lhs, const Mesh& rhs)
+{
+	if (lhs.variants.size() != rhs.variants.size())
+		return false;
+
+	for (size_t i = 0; i < lhs.variants.size(); ++i)
+	{
+		if (lhs.variants[i].variant != rhs.variants[i].variant)
+			return false;
+
+		if (lhs.variants[i].material != rhs.variants[i].material)
+			return false;
+	}
+
+	return true;
+}
+
 bool compareMeshNodes(const Mesh& lhs, const Mesh& rhs)
 {
 	if (lhs.nodes.size() != rhs.nodes.size())
@@ -196,6 +213,9 @@ static bool canMergeMeshes(const Mesh& lhs, const Mesh& rhs, const Settings& set
 		return false;
 
 	if (!compareMeshTargets(lhs, rhs))
+		return false;
+
+	if (!compareMeshVariants(lhs, rhs))
 		return false;
 
 	if (lhs.indices.empty() != rhs.indices.empty())

--- a/gltf/parsegltf.cpp
+++ b/gltf/parsegltf.cpp
@@ -244,6 +244,8 @@ static void parseMeshesGltf(cgltf_data* data, std::vector<Mesh>& meshes, std::ve
 			result.targets = primitive.targets_count;
 			result.target_weights.assign(mesh.weights, mesh.weights + mesh.weights_count);
 			result.target_names.assign(mesh.target_names, mesh.target_names + mesh.target_names_count);
+
+			result.variants.assign(primitive.mappings, primitive.mappings + primitive.mappings_count);
 		}
 
 		mesh_remap[mi] = std::make_pair(remap_offset, meshes.size());

--- a/gltf/stream.cpp
+++ b/gltf/stream.cpp
@@ -114,6 +114,7 @@ void prepareQuantizationTexture(cgltf_data* data, std::vector<QuantizationTextur
 		assert(mi < bounds.size());
 
 		updateAttributeBounds(mesh, cgltf_attribute_type_texcoord, bounds[mi]);
+		// TODO: variants
 	}
 
 	for (size_t i = 0; i < result.size(); ++i)


### PR DESCRIPTION
We now process all variant materials similarly to other materials and emit material mapping and variant data in the output.
Mesh merging is restricted to cases when the variant set is identical.

Fixes #233.