### PR TITLE
gltfpack: Restructure mesh processing to filter streams first

### DIFF
--- a/gltf/gltfpack.h
+++ b/gltf/gltfpack.h
@@ -251,9 +251,9 @@ cgltf_data* parseObj(const char* path, std::vector<Mesh>& meshes, const char** e
 cgltf_data* parseGltf(const char* path, std::vector<Mesh>& meshes, std::vector<Animation>& animations, std::string& extras, const char** error);
 
 void processAnimation(Animation& animation, const Settings& settings);
-void processMesh(Mesh& mesh, const MaterialInfo& mi, const Settings& settings);
+void processMesh(Mesh& mesh, const Settings& settings);
 
-void debugSimplify(const Mesh& mesh, const MaterialInfo& mi, Mesh& kinds, Mesh& loops, float ratio);
+void debugSimplify(const Mesh& mesh, Mesh& kinds, Mesh& loops, float ratio);
 void debugMeshlets(const Mesh& mesh, Mesh& meshlets, Mesh& bounds, int max_vertices, bool scan);
 
 bool compareMeshTargets(const Mesh& lhs, const Mesh& rhs);
@@ -263,6 +263,7 @@ bool compareMeshNodes(const Mesh& lhs, const Mesh& rhs);
 void mergeMeshInstances(Mesh& mesh);
 void mergeMeshes(std::vector<Mesh>& meshes, const Settings& settings);
 void filterEmptyMeshes(std::vector<Mesh>& meshes);
+void filterStreams(Mesh& mesh, const MaterialInfo& mi);
 
 void mergeMeshMaterials(cgltf_data* data, std::vector<Mesh>& meshes, const Settings& settings);
 void markNeededMaterials(cgltf_data* data, std::vector<MaterialInfo>& materials, const std::vector<Mesh>& meshes, const Settings& settings);

--- a/gltf/mesh.cpp
+++ b/gltf/mesh.cpp
@@ -398,7 +398,7 @@ static bool hasDeltas(const std::vector<Attr>& data)
 	return false;
 }
 
-static void filterStreams(Mesh& mesh, const MaterialInfo& mi)
+void filterStreams(Mesh& mesh, const MaterialInfo& mi)
 {
 	bool morph_normal = false;
 	bool morph_tangent = false;
@@ -473,6 +473,9 @@ static void reindexMesh(Mesh& mesh)
 		meshopt_Stream stream = {&mesh.streams[i].data[0], sizeof(Attr), sizeof(Attr)};
 		streams.push_back(stream);
 	}
+
+	if (streams.empty())
+		return;
 
 	std::vector<unsigned int> remap(total_vertices);
 	size_t unique_vertices = meshopt_generateVertexRemapMulti(&remap[0], &mesh.indices[0], total_indices, total_vertices, &streams[0], streams.size());
@@ -745,10 +748,8 @@ static void sortPointMesh(Mesh& mesh)
 	}
 }
 
-void processMesh(Mesh& mesh, const MaterialInfo& mi, const Settings& settings)
+void processMesh(Mesh& mesh, const Settings& settings)
 {
-	filterStreams(mesh, mi);
-
 	switch (mesh.type)
 	{
 	case cgltf_primitive_type_points:
@@ -779,14 +780,13 @@ extern unsigned char* meshopt_simplifyDebugKind;
 extern unsigned int* meshopt_simplifyDebugLoop;
 extern unsigned int* meshopt_simplifyDebugLoopBack;
 
-void debugSimplify(const Mesh& source, const MaterialInfo& mi, Mesh& kinds, Mesh& loops, float ratio)
+void debugSimplify(const Mesh& source, Mesh& kinds, Mesh& loops, float ratio)
 {
 	Mesh mesh = source;
 	assert(mesh.type == cgltf_primitive_type_triangles);
 
 	// note: it's important to follow the same pipeline as processMesh
 	// otherwise the result won't match
-	filterStreams(mesh, mi);
 	filterBones(mesh);
 	reindexMesh(mesh);
 	filterTriangles(mesh);


### PR DESCRIPTION
While filtering redundant streams during mesh optimization almost always
works well, there are rare cases where the input meshes have
inconsistent redundant streams (that block merging), and even though
these streams are removed that happens too late after the merging has
already been done.

This change splits off stream filtering from general mesh processing so
that we can run it early. This also slightly simplifies the flow since
we only need combined material information for filtering anyhow.

Reported in https://github.com/zeux/meshoptimizer/discussions/262.