### PR TITLE
gltfpack: Fix various issues with texture compression

### DIFF
--- a/gltf/cli.js
+++ b/gltf/cli.js
@@ -20,16 +20,13 @@ var interface = {
 		fs.writeFileSync(path, data);
 	},
 	execute: function (command) {
-		// perform substitution of command executable with environment-specific paths
-		var pk = Object.keys(paths);
-		for (var pi = 0; pi < pk.length; ++pi) {
-			if (command.startsWith(pk[pi] + " ")) {
-				command = paths[pk[pi]] + command.substr(pk[pi].length);
-				break;
-			}
-		}
+		var arg = command.split(' ');
+		var exe = arg.shift();
 
-		var ret = cp.spawnSync(command, [], {shell:true});
+		// perform substitution of command executable with environment-specific paths
+		exe = paths[exe] || exe;
+
+		var ret = cp.spawnSync(exe, arg);
 		return ret.status == null ? 256 : ret.status;
 	},
 	unlink: function (path) {

--- a/gltf/gltfpack.cpp
+++ b/gltf/gltfpack.cpp
@@ -900,6 +900,7 @@ int gltfpack(const char* input, const char* output, const char* report, Settings
 		else if (!checkBasis(settings.verbose > 1))
 		{
 			fprintf(stderr, "Error: toktx is not present in PATH or TOKTX_PATH is not set\n");
+			fprintf(stderr, "Note: toktx must be installed manually from https://github.com/KhronosGroup/KTX-Software/releases\n");
 			return 3;
 		}
 

--- a/gltf/image.cpp
+++ b/gltf/image.cpp
@@ -94,7 +94,7 @@ bool checkBasis(bool verbose)
 
 	cmd += " -version";
 
-	int rc = execute(cmd.c_str(), /* ignore_stdout= */ true, /* ignore_stderr= */ true);
+	int rc = execute(cmd.c_str(), /* ignore_stdout= */ !verbose, /* ignore_stderr= */ !verbose);
 	if (verbose)
 		printf("%s => %d\n", cmd.c_str(), rc);
 
@@ -165,7 +165,7 @@ bool checkKtx(bool verbose)
 
 	cmd += " --version";
 
-	int rc = execute(cmd.c_str(), /* ignore_stdout= */ true, /* ignore_stderr= */ true);
+	int rc = execute(cmd.c_str(), /* ignore_stdout= */ !verbose, /* ignore_stderr= */ !verbose);
 	if (verbose)
 		printf("%s => %d\n", cmd.c_str(), rc);
 


### PR DESCRIPTION
We had multiple bugs around handling texture compression via an external executable.

One, on node.js the environment variable *had* to be set (just adding executable to PATH didn't work because of a bug in the JavaScript wrapper); when the variable contained a path with spaces on Windows, the executable couldn't be found because the spaces weren't quoted in the shell execution.

Two, on Windows when the environment variable was set to a path with spaces, the executable couldn't be found either due to quotation issues.

We now correctly quote the paths on Windows and handle the executable spawning with a bit more care in node.js.

Originally raised in https://github.com/zeux/meshoptimizer/discussions/247.