### PR TITLE
Pass textures' samplers to optimized files

### DIFF
--- a/gltf/gltfpack.cpp
+++ b/gltf/gltfpack.cpp
@@ -413,8 +413,6 @@ static void process(cgltf_data* data, const char* input_path, const char* output
 		comma(json_samplers);
 		append(json_samplers, "{");
 		writeSampler(json_samplers, sampler);
-		if (settings.keep_extras)
-			writeExtras(json_samplers, extras, sampler.extras);
 		append(json_samplers, "}");
 	}
 

--- a/gltf/gltfpack.cpp
+++ b/gltf/gltfpack.cpp
@@ -406,7 +406,7 @@ static void process(cgltf_data* data, const char* input_path, const char* output
 	size_t mesh_offset = 0;
 	size_t material_offset = 0;
 
-	for (size_t i = 0u; i < data->samplers_count; ++i)
+	for (size_t i = 0; i < data->samplers_count; ++i)
 	{
 		const cgltf_sampler& sampler = data->samplers[i];
 

--- a/gltf/gltfpack.cpp
+++ b/gltf/gltfpack.cpp
@@ -376,6 +376,7 @@ static void process(cgltf_data* data, const char* input_path, const char* output
 	qt_dummy.bits = settings.tex_bits;
 
 	std::string json_images;
+	std::string json_samplers;
 	std::string json_textures;
 	std::string json_materials;
 	std::string json_accessors;
@@ -404,6 +405,18 @@ static void process(cgltf_data* data, const char* input_path, const char* output
 	size_t node_offset = 0;
 	size_t mesh_offset = 0;
 	size_t material_offset = 0;
+
+	for (size_t i = 0u; i < data->samplers_count; ++i)
+	{
+		const cgltf_sampler& sampler = data->samplers[i];
+
+		comma(json_samplers);
+		append(json_samplers, "{");
+		writeSampler(json_samplers, sampler);
+		if (settings.keep_extras)
+			writeExtras(json_samplers, extras, sampler.extras);
+		append(json_samplers, "}");
+	}
 
 	for (size_t i = 0; i < data->images_count; ++i)
 	{
@@ -747,6 +760,7 @@ static void process(cgltf_data* data, const char* input_path, const char* output
 
 	writeArray(json, "bufferViews", json_views);
 	writeArray(json, "accessors", json_accessors);
+	writeArray(json, "samplers", json_samplers);
 	writeArray(json, "images", json_images);
 	writeArray(json, "textures", json_textures);
 	writeArray(json, "materials", json_materials);

--- a/gltf/gltfpack.h
+++ b/gltf/gltfpack.h
@@ -310,6 +310,7 @@ const char* animationPath(cgltf_animation_path_type type);
 
 void writeMaterial(std::string& json, const cgltf_data* data, const cgltf_material& material, const QuantizationTexture* qt);
 void writeBufferView(std::string& json, BufferView::Kind kind, StreamFormat::Filter filter, size_t count, size_t stride, size_t bin_offset, size_t bin_size, BufferView::Compression compression, size_t compressed_offset, size_t compressed_size);
+void writeSampler(std::string& json, const cgltf_sampler& sampler);
 void writeImage(std::string& json, std::vector<BufferView>& views, const cgltf_image& image, const ImageInfo& info, size_t index, const char* input_path, const char* output_path, const Settings& settings);
 void writeTexture(std::string& json, const cgltf_texture& texture, cgltf_data* data, const Settings& settings);
 void writeMeshAttributes(std::string& json, std::vector<BufferView>& views, std::string& json_accessors, size_t& accr_offset, const Mesh& mesh, int target, const QuantizationPosition& qp, const QuantizationTexture& qt, const Settings& settings);

--- a/gltf/write.cpp
+++ b/gltf/write.cpp
@@ -911,18 +911,22 @@ void writeTexture(std::string& json, const cgltf_texture& texture, cgltf_data* d
 {
 	if (texture.image)
 	{
-		append(json, "\"sampler\":");
-		append(json, size_t(texture.sampler - data->samplers));
+		if (texture.sampler)
+		{
+			append(json, "\"sampler\":");
+			append(json, size_t(texture.sampler - data->samplers));
+			append(json, ",");
+		}
 
 		if (settings.texture_ktx2)
 		{
-			append(json, ",\"extensions\":{\"KHR_texture_basisu\":{\"source\":");
+			append(json, "\"extensions\":{\"KHR_texture_basisu\":{\"source\":");
 			append(json, size_t(texture.image - data->images));
 			append(json, "}}");
 		}
 		else
 		{
-			append(json, ",\"source\":");
+			append(json, "\"source\":");
 			append(json, size_t(texture.image - data->images));
 		}
 	}

--- a/gltf/write.cpp
+++ b/gltf/write.cpp
@@ -785,6 +785,18 @@ static std::string decodeUri(const char* uri)
 	return result;
 }
 
+void writeSampler(std::string& json, const cgltf_sampler& sampler)
+{
+	append(json, "\"magFilter\":");
+	append(json, size_t(sampler.mag_filter));
+	append(json, ",\"minFilter\":");
+	append(json, size_t(sampler.min_filter));
+	append(json, ",\"wrapS\":");
+	append(json, size_t(sampler.wrap_s));
+	append(json, ",\"wrapT\":");
+	append(json, size_t(sampler.wrap_t));
+}
+
 void writeImage(std::string& json, std::vector<BufferView>& views, const cgltf_image& image, const ImageInfo& info, size_t index, const char* input_path, const char* output_path, const Settings& settings)
 {
 	std::string img_data;
@@ -899,15 +911,18 @@ void writeTexture(std::string& json, const cgltf_texture& texture, cgltf_data* d
 {
 	if (texture.image)
 	{
+		append(json, "\"sampler\":");
+		append(json, size_t(texture.sampler - data->samplers));
+
 		if (settings.texture_ktx2)
 		{
-			append(json, "\"extensions\":{\"KHR_texture_basisu\":{\"source\":");
+			append(json, ",\"extensions\":{\"KHR_texture_basisu\":{\"source\":");
 			append(json, size_t(texture.image - data->images));
 			append(json, "}}");
 		}
 		else
 		{
-			append(json, "\"source\":");
+			append(json, ",\"source\":");
 			append(json, size_t(texture.image - data->images));
 		}
 	}


### PR DESCRIPTION
Currently, meshoptimizer completely ignores information about textures' samplers stored in the glTF file. The attempt of this pull request is to fix that.