### PR TITLE
fix checks in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,10 @@
 cmake_minimum_required(VERSION 3.0)
 
-if (NOT CMAKE_VERSION VERSION_LESS 3.12)
+if (CMAKE_VERSION VERSION_GREATER_EQUAL 3.13)
     cmake_policy(SET CMP0077 NEW) # Enables override of options from parent CMakeLists.txt
 endif()
 
-if (NOT CMAKE_VERSION VERSION_LESS 3.15)
+if (CMAKE_VERSION VERSION_GREATER_EQUAL 3.15)
     cmake_policy(SET CMP0091 NEW) # Enables use of MSVC_RUNTIME_LIBRARY
     cmake_policy(SET CMP0092 NEW) # Enables clean /W4 override for MSVC
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,11 +1,13 @@
 cmake_minimum_required(VERSION 3.0)
 
-if (CMAKE_VERSION VERSION_GREATER_EQUAL 3.13)
+if(POLICY CMP0077)
     cmake_policy(SET CMP0077 NEW) # Enables override of options from parent CMakeLists.txt
 endif()
 
-if (CMAKE_VERSION VERSION_GREATER_EQUAL 3.15)
+if(POLICY CMP0091)
     cmake_policy(SET CMP0091 NEW) # Enables use of MSVC_RUNTIME_LIBRARY
+endif()
+if(POLICY CMP0092)
     cmake_policy(SET CMP0092 NEW) # Enables clean /W4 override for MSVC
 endif()
 


### PR DESCRIPTION
CMP0077 requires >= 3.13
CMP0091 + CMP0092 requires >= 3.15

we hit this bug here: https://github.com/spring/spring/pull/559/files#diff-48b508d8a5702095973f36f384be2a8b74834092bb7ed47c536f1af80015b20bR4