### PR TITLE
gltfpack: Implement support for texture flipping 

### DIFF
--- a/gltf/basistoktx.cpp
+++ b/gltf/basistoktx.cpp
@@ -169,7 +169,6 @@ std::string basisToKtx(const std::string& data, bool srgb, bool uastc)
 
 	assert(basis_header.m_tex_format == uint32_t(uastc ? basist::cUASTC4x4 : basist::cETC1S));
 	assert(!(basis_header.m_flags & basist::cBASISHeaderFlagETC1S) == uastc);
-	assert(!(basis_header.m_flags & basist::cBASISHeaderFlagYFlipped));
 	assert(basis_header.m_tex_type == basist::cBASISTexType2D);
 
 	if (uastc)

--- a/gltf/gltfpack.cpp
+++ b/gltf/gltfpack.cpp
@@ -1189,6 +1189,10 @@ int main(int argc, char** argv)
 		{
 			settings.texture_pow2 = true;
 		}
+		else if (strcmp(arg, "-tfy") == 0)
+		{
+			settings.texture_flipy = true;
+		}
 		else if (strcmp(arg, "-te") == 0)
 		{
 			fprintf(stderr, "Warning: -te is deprecated and will be removed in the future; gltfpack now automatically embeds textures into GLB files\n");
@@ -1292,6 +1296,7 @@ int main(int argc, char** argv)
 			fprintf(stderr, "\t-tq N: set texture encoding quality (default: 8; N should be between 1 and 10\n");
 			fprintf(stderr, "\t-ts R: scale texture dimensions by the ratio R (default: 1; R should be between 0 and 1)\n");
 			fprintf(stderr, "\t-tp: resize textures to nearest power of 2 to conform to WebGL1 restrictions\n");
+			fprintf(stderr, "\t-tfy: flip textures along Y axis during BasisU supercompression\n");
 			fprintf(stderr, "\nSimplification:\n");
 			fprintf(stderr, "\t-si R: simplify meshes to achieve the ratio R (default: 1; R should be between 0 and 1)\n");
 			fprintf(stderr, "\t-sa: aggressively simplify to the target ratio disregarding quality\n");
@@ -1342,6 +1347,12 @@ int main(int argc, char** argv)
 	if (settings.texture_pow2 && !settings.texture_ktx2)
 	{
 		fprintf(stderr, "Option -tp is only supported when -tc is set as well\n");
+		return 1;
+	}
+
+	if (settings.texture_flipy && !settings.texture_ktx2)
+	{
+		fprintf(stderr, "Option -tfy is only supported when -tc is set as well\n");
 		return 1;
 	}
 

--- a/gltf/gltfpack.cpp
+++ b/gltf/gltfpack.cpp
@@ -1070,6 +1070,12 @@ Settings defaults()
 	return settings;
 }
 
+template <typename T>
+T clamp(T v, T min, T max)
+{
+	return v < min ? min : v > max ? max : v;
+}
+
 int main(int argc, char** argv)
 {
 	meshopt_encodeIndexVersion(1);
@@ -1090,35 +1096,35 @@ int main(int argc, char** argv)
 
 		if (strcmp(arg, "-vp") == 0 && i + 1 < argc && isdigit(argv[i + 1][0]))
 		{
-			settings.pos_bits = atoi(argv[++i]);
+			settings.pos_bits = clamp(atoi(argv[++i]), 1, 16);
 		}
 		else if (strcmp(arg, "-vt") == 0 && i + 1 < argc && isdigit(argv[i + 1][0]))
 		{
-			settings.tex_bits = atoi(argv[++i]);
+			settings.tex_bits = clamp(atoi(argv[++i]), 1, 16);
 		}
 		else if (strcmp(arg, "-vn") == 0 && i + 1 < argc && isdigit(argv[i + 1][0]))
 		{
-			settings.nrm_bits = atoi(argv[++i]);
+			settings.nrm_bits = clamp(atoi(argv[++i]), 1, 16);
 		}
 		else if (strcmp(arg, "-vc") == 0 && i + 1 < argc && isdigit(argv[i + 1][0]))
 		{
-			settings.col_bits = atoi(argv[++i]);
+			settings.col_bits = clamp(atoi(argv[++i]), 1, 16);
 		}
 		else if (strcmp(arg, "-at") == 0 && i + 1 < argc && isdigit(argv[i + 1][0]))
 		{
-			settings.trn_bits = atoi(argv[++i]);
+			settings.trn_bits = clamp(atoi(argv[++i]), 1, 24);
 		}
 		else if (strcmp(arg, "-ar") == 0 && i + 1 < argc && isdigit(argv[i + 1][0]))
 		{
-			settings.rot_bits = atoi(argv[++i]);
+			settings.rot_bits = clamp(atoi(argv[++i]), 4, 16);
 		}
 		else if (strcmp(arg, "-as") == 0 && i + 1 < argc && isdigit(argv[i + 1][0]))
 		{
-			settings.scl_bits = atoi(argv[++i]);
+			settings.scl_bits = clamp(atoi(argv[++i]), 1, 24);
 		}
 		else if (strcmp(arg, "-af") == 0 && i + 1 < argc && isdigit(argv[i + 1][0]))
 		{
-			settings.anim_freq = atoi(argv[++i]);
+			settings.anim_freq = clamp(atoi(argv[++i]), 1, 100);
 		}
 		else if (strcmp(arg, "-ac") == 0)
 		{
@@ -1146,7 +1152,7 @@ int main(int argc, char** argv)
 		}
 		else if (strcmp(arg, "-si") == 0 && i + 1 < argc && isdigit(argv[i + 1][0]))
 		{
-			settings.simplify_threshold = float(atof(argv[++i]));
+			settings.simplify_threshold = clamp(float(atof(argv[++i])), 0.f, 1.f);
 		}
 		else if (strcmp(arg, "-sa") == 0)
 		{
@@ -1155,11 +1161,11 @@ int main(int argc, char** argv)
 #ifndef NDEBUG
 		else if (strcmp(arg, "-sd") == 0 && i + 1 < argc && isdigit(argv[i + 1][0]))
 		{
-			settings.simplify_debug = float(atof(argv[++i]));
+			settings.simplify_debug = clamp(float(atof(argv[++i])), 0.f, 1.f);
 		}
 		else if (strcmp(arg, "-md") == 0 && i + 1 < argc && isdigit(argv[i + 1][0]))
 		{
-			settings.meshlet_debug = atoi(argv[++i]);
+			settings.meshlet_debug = clamp(atoi(argv[++i]), 3, 255);
 		}
 #endif
 		else if (strcmp(arg, "-tu") == 0)
@@ -1173,11 +1179,11 @@ int main(int argc, char** argv)
 		}
 		else if (strcmp(arg, "-tq") == 0 && i + 1 < argc && isdigit(argv[i + 1][0]))
 		{
-			settings.texture_quality = atoi(argv[++i]);
+			settings.texture_quality = clamp(atoi(argv[++i]), 1, 10);
 		}
 		else if (strcmp(arg, "-ts") == 0 && i + 1 < argc && isdigit(argv[i + 1][0]))
 		{
-			settings.texture_scale = float(atof(argv[++i]));
+			settings.texture_scale = clamp(float(atof(argv[++i])), 0.f, 1.f);
 		}
 		else if (strcmp(arg, "-tp") == 0)
 		{

--- a/gltf/gltfpack.h
+++ b/gltf/gltfpack.h
@@ -272,11 +272,10 @@ void analyzeMaterials(cgltf_data* data, std::vector<MaterialInfo>& materials, st
 
 const char* inferMimeType(const char* path);
 bool checkBasis(bool verbose);
-bool encodeBasis(const std::string& data, const char* mime_type, std::string& result, bool normal_map, bool srgb, int quality, float scale, bool pow2, bool uastc, bool verbose);
+bool encodeBasis(const std::string& data, const char* mime_type, std::string& result, const ImageInfo& info, const Settings& settings);
 std::string basisToKtx(const std::string& data, bool srgb, bool uastc);
 bool checkKtx(bool verbose);
-bool encodeKtx(const std::string& data, const char* mime_type, std::string& result, bool normal_map, bool srgb, int quality, float scale, bool pow2, bool uastc, bool verbose);
-
+bool encodeKtx(const std::string& data, const char* mime_type, std::string& result, const ImageInfo& info, const Settings& settings);
 void markScenes(cgltf_data* data, std::vector<NodeInfo>& nodes);
 void markAnimated(cgltf_data* data, std::vector<NodeInfo>& nodes, const std::vector<Animation>& animations);
 void markNeededNodes(cgltf_data* data, std::vector<NodeInfo>& nodes, const std::vector<Mesh>& meshes, const std::vector<Animation>& animations, const Settings& settings);

--- a/gltf/gltfpack.h
+++ b/gltf/gltfpack.h
@@ -119,6 +119,7 @@ struct Settings
 	int texture_quality;
 	float texture_scale;
 	bool texture_pow2;
+	bool texture_flipy;
 
 	bool quantize;
 

--- a/gltf/image.cpp
+++ b/gltf/image.cpp
@@ -124,6 +124,9 @@ bool encodeBasis(const std::string& data, const char* mime_type, std::string& re
 
 	cmd += " -mipmap";
 
+	if (settings.texture_flipy)
+		cmd += " -y_flip";
+
 	if (info.normal_map)
 	{
 		cmd += " -normal_map";
@@ -307,6 +310,9 @@ bool encodeKtx(const std::string& data, const char* mime_type, std::string& resu
 		sprintf(wh, " --resize %dx%d", newWidth, newHeight);
 		cmd += wh;
 	}
+
+	if (settings.texture_flipy)
+		cmd += " --lower_left_maps_to_s0t0";
 
 	if (settings.texture_uastc)
 	{

--- a/gltf/write.cpp
+++ b/gltf/write.cpp
@@ -830,7 +830,7 @@ void writeImage(std::string& json, std::vector<BufferView>& views, const cgltf_i
 	if (image.mime_type)
 		mime_type = image.mime_type;
 
-	bool (*encodeImage)(const std::string& data, const char* mime_type, std::string& result, bool normal_map, bool srgb, int quality, float scale, bool pow2, bool uastc, bool verbose) =
+	bool (*encodeImage)(const std::string& data, const char* mime_type, std::string& result, const ImageInfo& info, const Settings& settings) =
 	    settings.texture_toktx ? encodeKtx : encodeBasis;
 
 	if (!img_data.empty())
@@ -839,7 +839,7 @@ void writeImage(std::string& json, std::vector<BufferView>& views, const cgltf_i
 		{
 			std::string encoded;
 
-			if (encodeImage(img_data, mime_type.c_str(), encoded, info.normal_map, info.srgb, settings.texture_quality, settings.texture_scale, settings.texture_pow2, settings.texture_uastc, settings.verbose > 1))
+			if (encodeImage(img_data, mime_type.c_str(), encoded, info, settings))
 			{
 				if (!settings.texture_toktx)
 					encoded = basisToKtx(encoded, info.srgb, settings.texture_uastc);
@@ -868,7 +868,7 @@ void writeImage(std::string& json, std::vector<BufferView>& views, const cgltf_i
 			{
 				std::string encoded;
 
-				if (encodeImage(img_data, mime_type.c_str(), encoded, info.normal_map, info.srgb, settings.texture_quality, settings.texture_scale, settings.texture_pow2, settings.texture_uastc, settings.verbose > 1))
+				if (encodeImage(img_data, mime_type.c_str(), encoded, info, settings))
 				{
 					if (!settings.texture_toktx)
 						encoded = basisToKtx(encoded, info.srgb, settings.texture_uastc);


### PR DESCRIPTION
When -tfy is specified, textures are flipped alongside Y axis during
texture compression by passing an extra argument to toktx or basisu.
This is helpful for some applications that expect a different coordinate
system.

Fixes #241