### PR TITLE
gltfpack: Implement per-class texture compression options and statistics

### DIFF
--- a/gltf/gltfpack.cpp
+++ b/gltf/gltfpack.cpp
@@ -157,6 +157,29 @@ static void printAttributeStats(const std::vector<BufferView>& views, BufferView
 	}
 }
 
+static void printImageStats(const std::vector<BufferView>& views, TextureKind kind, const char* name)
+{
+	size_t bytes = 0;
+	size_t count = 0;
+
+	for (size_t i = 0; i < views.size(); ++i)
+	{
+		const BufferView& view = views[i];
+
+		if (view.kind != BufferView::Kind_Image)
+			continue;
+
+		if (view.variant != -1 - kind)
+			continue;
+
+		count += 1;
+		bytes += view.data.size();
+	}
+
+	if (count)
+		printf("stats: image %s: %d bytes in %d images\n", name, int(bytes), int(count));
+}
+
 static bool printReport(const char* path, cgltf_data* data, const std::vector<BufferView>& views, const std::vector<Mesh>& meshes, size_t node_count, size_t mesh_count, size_t material_count, size_t animation_count, size_t json_size, size_t bin_size)
 {
 	size_t bytes[BufferView::Kind_Count] = {};
@@ -804,6 +827,11 @@ static void process(cgltf_data* data, const char* input_path, const char* output
 		printAttributeStats(views, BufferView::Kind_Index, "index");
 		printAttributeStats(views, BufferView::Kind_Keyframe, "keyframe");
 		printAttributeStats(views, BufferView::Kind_Instance, "instance");
+
+		printImageStats(views, TextureKind_Generic, "generic");
+		printImageStats(views, TextureKind_Color, "color");
+		printImageStats(views, TextureKind_Normal, "normal");
+		printImageStats(views, TextureKind_Attrib, "attrib");
 	}
 
 	if (report_path)

--- a/gltf/gltfpack.h
+++ b/gltf/gltfpack.h
@@ -84,6 +84,14 @@ struct Animation
 	std::vector<Track> tracks;
 };
 
+enum TextureKind
+{
+	TextureKind_Generic,
+	TextureKind_Color,
+	TextureKind_Normal,
+	TextureKind_Attrib,
+};
+
 struct Settings
 {
 	int pos_bits;
@@ -187,6 +195,7 @@ struct MaterialInfo
 
 struct ImageInfo
 {
+	TextureKind kind;
 	bool normal_map;
 	bool srgb;
 };

--- a/gltf/gltfpack.h
+++ b/gltf/gltfpack.h
@@ -90,6 +90,8 @@ enum TextureKind
 	TextureKind_Color,
 	TextureKind_Normal,
 	TextureKind_Attrib,
+
+	TextureKind__Count
 };
 
 struct Settings
@@ -120,14 +122,15 @@ struct Settings
 	int meshlet_debug;
 
 	bool texture_ktx2;
-	bool texture_uastc;
 	bool texture_embed;
 	bool texture_toktx;
 
-	int texture_quality;
-	float texture_scale;
 	bool texture_pow2;
 	bool texture_flipy;
+	float texture_scale;
+
+	bool texture_uastc[TextureKind__Count];
+	int texture_quality[TextureKind__Count];
 
 	bool quantize;
 

--- a/gltf/image.cpp
+++ b/gltf/image.cpp
@@ -120,7 +120,10 @@ bool encodeBasis(const std::string& data, const char* mime_type, std::string& re
 
 	std::string cmd = getExecutable("basisu", "BASISU_PATH");
 
-	const BasisSettings& bs = kBasisSettings[settings.texture_quality - 1];
+	int quality = settings.texture_quality[info.kind];
+	bool uastc = settings.texture_uastc[info.kind];
+
+	const BasisSettings& bs = kBasisSettings[quality - 1];
 
 	cmd += " -mipmap";
 
@@ -137,7 +140,7 @@ bool encodeBasis(const std::string& data, const char* mime_type, std::string& re
 		cmd += " -linear";
 	}
 
-	if (settings.texture_uastc)
+	if (uastc)
 	{
 		char cs[128];
 		sprintf(cs, " -uastc_level %d -uastc_rdo_q %.2f", bs.uastc_l, bs.uastc_q);
@@ -294,7 +297,10 @@ bool encodeKtx(const std::string& data, const char* mime_type, std::string& resu
 
 	std::string cmd = getExecutable("toktx", "TOKTX_PATH");
 
-	const BasisSettings& bs = kBasisSettings[settings.texture_quality - 1];
+	int quality = settings.texture_quality[info.kind];
+	bool uastc = settings.texture_uastc[info.kind];
+
+	const BasisSettings& bs = kBasisSettings[quality - 1];
 
 	cmd += " --t2";
 	cmd += " --2d";
@@ -314,7 +320,7 @@ bool encodeKtx(const std::string& data, const char* mime_type, std::string& resu
 	if (settings.texture_flipy)
 		cmd += " --lower_left_maps_to_s0t0";
 
-	if (settings.texture_uastc)
+	if (uastc)
 	{
 		char cs[128];
 		sprintf(cs, " %d --uastc_rdo_q %.2f", bs.uastc_l, bs.uastc_q);

--- a/gltf/material.cpp
+++ b/gltf/material.cpp
@@ -332,24 +332,24 @@ void markNeededMaterials(cgltf_data* data, std::vector<MaterialInfo>& materials,
 	}
 }
 
-enum TextureKind
-{
-	TextureKind_Generic,
-	TextureKind_Color,
-	TextureKind_Normal,
-};
-
 static void analyzeMaterialTexture(const cgltf_texture_view& view, TextureKind kind, MaterialInfo& mi, cgltf_data* data, std::vector<ImageInfo>& images)
 {
 	mi.usesTextureTransform |= bool(view.has_transform);
 
 	if (view.texture && view.texture->image)
 	{
+		ImageInfo& info = images[view.texture->image - data->images];
+
 		mi.textureSetMask |= 1u << view.texcoord;
 		mi.needsTangents |= (kind == TextureKind_Normal);
 
-		images[view.texture->image - data->images].srgb |= (kind == TextureKind_Color);
-		images[view.texture->image - data->images].normal_map |= (kind == TextureKind_Normal);
+		if (info.kind == TextureKind_Generic)
+			info.kind = kind;
+		else if (info.kind > kind) // this is useful to keep color textures that have attrib data in alpha tagged as color
+			info.kind = kind;
+
+		info.normal_map |= (kind == TextureKind_Normal);
+		info.srgb |= (kind == TextureKind_Color);
 	}
 }
 
@@ -358,46 +358,46 @@ static void analyzeMaterial(const cgltf_material& material, MaterialInfo& mi, cg
 	if (material.has_pbr_metallic_roughness)
 	{
 		analyzeMaterialTexture(material.pbr_metallic_roughness.base_color_texture, TextureKind_Color, mi, data, images);
-		analyzeMaterialTexture(material.pbr_metallic_roughness.metallic_roughness_texture, TextureKind_Generic, mi, data, images);
+		analyzeMaterialTexture(material.pbr_metallic_roughness.metallic_roughness_texture, TextureKind_Attrib, mi, data, images);
 	}
 
 	if (material.has_pbr_specular_glossiness)
 	{
 		analyzeMaterialTexture(material.pbr_specular_glossiness.diffuse_texture, TextureKind_Color, mi, data, images);
-		analyzeMaterialTexture(material.pbr_specular_glossiness.specular_glossiness_texture, TextureKind_Generic, mi, data, images);
+		analyzeMaterialTexture(material.pbr_specular_glossiness.specular_glossiness_texture, TextureKind_Attrib, mi, data, images);
 	}
 
 	if (material.has_clearcoat)
 	{
-		analyzeMaterialTexture(material.clearcoat.clearcoat_texture, TextureKind_Generic, mi, data, images);
-		analyzeMaterialTexture(material.clearcoat.clearcoat_roughness_texture, TextureKind_Generic, mi, data, images);
+		analyzeMaterialTexture(material.clearcoat.clearcoat_texture, TextureKind_Attrib, mi, data, images);
+		analyzeMaterialTexture(material.clearcoat.clearcoat_roughness_texture, TextureKind_Attrib, mi, data, images);
 		analyzeMaterialTexture(material.clearcoat.clearcoat_normal_texture, TextureKind_Normal, mi, data, images);
 	}
 
 	if (material.has_transmission)
 	{
-		analyzeMaterialTexture(material.transmission.transmission_texture, TextureKind_Generic, mi, data, images);
+		analyzeMaterialTexture(material.transmission.transmission_texture, TextureKind_Attrib, mi, data, images);
 	}
 
 	if (material.has_specular)
 	{
-		analyzeMaterialTexture(material.specular.specular_texture, TextureKind_Generic, mi, data, images);
+		analyzeMaterialTexture(material.specular.specular_texture, TextureKind_Attrib, mi, data, images);
 		analyzeMaterialTexture(material.specular.specular_color_texture, TextureKind_Color, mi, data, images);
 	}
 
 	if (material.has_sheen)
 	{
 		analyzeMaterialTexture(material.sheen.sheen_color_texture, TextureKind_Color, mi, data, images);
-		analyzeMaterialTexture(material.sheen.sheen_roughness_texture, TextureKind_Generic, mi, data, images);
+		analyzeMaterialTexture(material.sheen.sheen_roughness_texture, TextureKind_Attrib, mi, data, images);
 	}
 
 	if (material.has_volume)
 	{
-		analyzeMaterialTexture(material.volume.thickness_texture, TextureKind_Generic, mi, data, images);
+		analyzeMaterialTexture(material.volume.thickness_texture, TextureKind_Attrib, mi, data, images);
 	}
 
 	analyzeMaterialTexture(material.normal_texture, TextureKind_Normal, mi, data, images);
-	analyzeMaterialTexture(material.occlusion_texture, TextureKind_Generic, mi, data, images);
+	analyzeMaterialTexture(material.occlusion_texture, TextureKind_Attrib, mi, data, images);
 	analyzeMaterialTexture(material.emissive_texture, TextureKind_Color, mi, data, images);
 }
 

--- a/gltf/write.cpp
+++ b/gltf/write.cpp
@@ -758,9 +758,9 @@ static bool parseDataUri(const char* uri, std::string& mime_type, std::string& r
 	return false;
 }
 
-static void writeEmbeddedImage(std::string& json, std::vector<BufferView>& views, const char* data, size_t size, const char* mime_type)
+static void writeEmbeddedImage(std::string& json, std::vector<BufferView>& views, const char* data, size_t size, const char* mime_type, TextureKind kind)
 {
-	size_t view = getBufferView(views, BufferView::Kind_Image, StreamFormat::Filter_None, BufferView::Compression_None, 1, -1);
+	size_t view = getBufferView(views, BufferView::Kind_Image, StreamFormat::Filter_None, BufferView::Compression_None, 1, -1 - kind);
 
 	assert(views[view].data.empty());
 	views[view].data.assign(data, size);
@@ -844,7 +844,7 @@ void writeImage(std::string& json, std::vector<BufferView>& views, const cgltf_i
 				if (!settings.texture_toktx)
 					encoded = basisToKtx(encoded, info.srgb, settings.texture_uastc);
 
-				writeEmbeddedImage(json, views, encoded.c_str(), encoded.size(), "image/ktx2");
+				writeEmbeddedImage(json, views, encoded.c_str(), encoded.size(), "image/ktx2", info.kind);
 			}
 			else
 			{
@@ -853,7 +853,7 @@ void writeImage(std::string& json, std::vector<BufferView>& views, const cgltf_i
 		}
 		else
 		{
-			writeEmbeddedImage(json, views, img_data.c_str(), img_data.size(), mime_type.c_str());
+			writeEmbeddedImage(json, views, img_data.c_str(), img_data.size(), mime_type.c_str(), info.kind);
 		}
 	}
 	else if (image.uri)

--- a/gltf/write.cpp
+++ b/gltf/write.cpp
@@ -842,7 +842,7 @@ void writeImage(std::string& json, std::vector<BufferView>& views, const cgltf_i
 			if (encodeImage(img_data, mime_type.c_str(), encoded, info, settings))
 			{
 				if (!settings.texture_toktx)
-					encoded = basisToKtx(encoded, info.srgb, settings.texture_uastc);
+					encoded = basisToKtx(encoded, info.srgb, settings.texture_uastc[info.kind]);
 
 				writeEmbeddedImage(json, views, encoded.c_str(), encoded.size(), "image/ktx2", info.kind);
 			}
@@ -871,7 +871,7 @@ void writeImage(std::string& json, std::vector<BufferView>& views, const cgltf_i
 				if (encodeImage(img_data, mime_type.c_str(), encoded, info, settings))
 				{
 					if (!settings.texture_toktx)
-						encoded = basisToKtx(encoded, info.srgb, settings.texture_uastc);
+						encoded = basisToKtx(encoded, info.srgb, settings.texture_uastc[info.kind]);
 
 					if (writeFile(basis_full_path.c_str(), encoded))
 					{


### PR DESCRIPTION
You can now specify the texture class with `-tu` and `-tq` options to customize compression parameters for different types of textures - for example, this makes it possible to use UASTC for normal maps but keep ETC1S for other textures.

The set of classes is specified after the relevant option as a comma-separated list and can consist of `color`, `normal` and `attrib`. The parameters are parsed left to right and override each other in that order, so a class-less option should be specified before options with classes.

Fixes #273.