### PR TITLE
gltfpack: Remove BLEND mode from materials that don't need it

### DIFF
--- a/gltf/gltfpack.cpp
+++ b/gltf/gltfpack.cpp
@@ -324,10 +324,9 @@ static void process(cgltf_data* data, const char* input_path, const char* output
 	std::vector<MaterialInfo> materials(data->materials_count);
 	std::vector<ImageInfo> images(data->images_count);
 
-	analyzeImages(data, input_path, images);
 	analyzeMaterials(data, materials, images);
 
-	optimizeMaterials(data, images);
+	optimizeMaterials(data, input_path, images);
 
 	// streams need to be filtered before mesh merging (or processing) to make sure we can merge meshes with redundant streams
 	for (size_t i = 0; i < meshes.size(); ++i)

--- a/gltf/gltfpack.cpp
+++ b/gltf/gltfpack.cpp
@@ -324,7 +324,10 @@ static void process(cgltf_data* data, const char* input_path, const char* output
 	std::vector<MaterialInfo> materials(data->materials_count);
 	std::vector<ImageInfo> images(data->images_count);
 
+	analyzeImages(data, input_path, images);
 	analyzeMaterials(data, materials, images);
+
+	optimizeMaterials(data, images);
 
 	// streams need to be filtered before mesh merging (or processing) to make sure we can merge meshes with redundant streams
 	for (size_t i = 0; i < meshes.size(); ++i)

--- a/gltf/gltfpack.h
+++ b/gltf/gltfpack.h
@@ -283,7 +283,7 @@ void markNeededMaterials(cgltf_data* data, std::vector<MaterialInfo>& materials,
 
 void analyzeMaterials(cgltf_data* data, std::vector<MaterialInfo>& materials, std::vector<ImageInfo>& images);
 
-const char* inferMimeType(const char* path);
+bool readImage(const cgltf_image& image, const char* input_path, std::string& data, std::string& mime_type);
 
 bool checkBasis(bool verbose);
 bool encodeBasis(const std::string& data, const char* mime_type, std::string& result, const ImageInfo& info, const Settings& settings);

--- a/gltf/gltfpack.h
+++ b/gltf/gltfpack.h
@@ -202,8 +202,7 @@ struct ImageInfo
 	bool normal_map;
 	bool srgb;
 
-	int width, height;
-	bool alpha;
+	int channels;
 };
 
 struct ExtensionInfo
@@ -285,10 +284,10 @@ void mergeMeshMaterials(cgltf_data* data, std::vector<Mesh>& meshes, const Setti
 void markNeededMaterials(cgltf_data* data, std::vector<MaterialInfo>& materials, const std::vector<Mesh>& meshes, const Settings& settings);
 
 void analyzeMaterials(cgltf_data* data, std::vector<MaterialInfo>& materials, std::vector<ImageInfo>& images);
-void optimizeMaterials(cgltf_data* data, const std::vector<ImageInfo>& images);
+void optimizeMaterials(cgltf_data* data, const char* input_path, std::vector<ImageInfo>& images);
 
 bool readImage(const cgltf_image& image, const char* input_path, std::string& data, std::string& mime_type);
-void analyzeImages(const cgltf_data* data, const char* input_path, std::vector<ImageInfo>& images);
+bool hasAlpha(const std::string& data, const char* mime_type);
 
 bool checkBasis(bool verbose);
 bool encodeBasis(const std::string& data, const char* mime_type, std::string& result, const ImageInfo& info, const Settings& settings);

--- a/gltf/gltfpack.h
+++ b/gltf/gltfpack.h
@@ -201,6 +201,9 @@ struct ImageInfo
 	TextureKind kind;
 	bool normal_map;
 	bool srgb;
+
+	int width, height;
+	bool alpha;
 };
 
 struct ExtensionInfo
@@ -282,8 +285,10 @@ void mergeMeshMaterials(cgltf_data* data, std::vector<Mesh>& meshes, const Setti
 void markNeededMaterials(cgltf_data* data, std::vector<MaterialInfo>& materials, const std::vector<Mesh>& meshes, const Settings& settings);
 
 void analyzeMaterials(cgltf_data* data, std::vector<MaterialInfo>& materials, std::vector<ImageInfo>& images);
+void optimizeMaterials(cgltf_data* data, const std::vector<ImageInfo>& images);
 
 bool readImage(const cgltf_image& image, const char* input_path, std::string& data, std::string& mime_type);
+void analyzeImages(const cgltf_data* data, const char* input_path, std::vector<ImageInfo>& images);
 
 bool checkBasis(bool verbose);
 bool encodeBasis(const std::string& data, const char* mime_type, std::string& result, const ImageInfo& info, const Settings& settings);

--- a/gltf/image.cpp
+++ b/gltf/image.cpp
@@ -119,11 +119,10 @@ static int readInt16(const std::string& data, size_t offset)
 
 static int readInt32(const std::string& data, size_t offset)
 {
-	return
-		((unsigned)(unsigned char)data[offset] << 24) |
-		((unsigned)(unsigned char)data[offset + 1] << 16) |
-		((unsigned)(unsigned char)data[offset + 2] << 8) |
-		(unsigned)(unsigned char)data[offset + 3];
+	return (unsigned((unsigned char)data[offset]) << 24) |
+	       (unsigned((unsigned char)data[offset + 1]) << 16) |
+	       (unsigned((unsigned char)data[offset + 2]) << 8) |
+	       unsigned((unsigned char)data[offset + 3]);
 }
 
 static bool getDimensionsPng(const std::string& data, int& width, int& height)
@@ -138,8 +137,8 @@ static bool getDimensionsPng(const std::string& data, int& width, int& height)
 	if (data.compare(12, 4, "IHDR") != 0)
 		return false;
 
-	width = readInt16(data, 18);
-	height = readInt16(data, 22);
+	width = readInt32(data, 18);
+	height = readInt32(data, 22);
 
 	return true;
 }

--- a/gltf/image.cpp
+++ b/gltf/image.cpp
@@ -248,6 +248,31 @@ static bool getDimensions(const std::string& data, const char* mime_type, int& w
 	return false;
 }
 
+static int roundPow2(int value)
+{
+	int result = 1;
+
+	while (result < value)
+		result <<= 1;
+
+	// to prevent odd texture sizes from increasing the size too much, we round to nearest power of 2 above a certain size
+	if (value > 128 && result * 3 / 4 > value)
+		result >>= 1;
+
+	return result;
+}
+
+static int roundBlock(int value, bool pow2)
+{
+	if (value == 0)
+		return 4;
+
+	if (pow2 && value > 4)
+		return roundPow2(value);
+
+	return (value + 3) & ~3;
+}
+
 #ifdef __wasi__
 static int execute(const char* cmd, bool ignore_stdout, bool ignore_stderr)
 {
@@ -381,31 +406,6 @@ bool checkKtx(bool verbose)
 		printf("%s => %d\n", cmd.c_str(), rc);
 
 	return rc == 0;
-}
-
-static int roundPow2(int value)
-{
-	int result = 1;
-
-	while (result < value)
-		result <<= 1;
-
-	// to prevent odd texture sizes from increasing the size too much, we round to nearest power of 2 above a certain size
-	if (value > 128 && result * 3 / 4 > value)
-		result >>= 1;
-
-	return result;
-}
-
-static int roundBlock(int value, bool pow2)
-{
-	if (value == 0)
-		return 4;
-
-	if (pow2 && value > 4)
-		return roundPow2(value);
-
-	return (value + 3) & ~3;
 }
 
 bool encodeKtx(const std::string& data, const char* mime_type, std::string& result, const ImageInfo& info, const Settings& settings)

--- a/gltf/image.cpp
+++ b/gltf/image.cpp
@@ -222,27 +222,12 @@ static bool hasTransparencyPng(const std::string& data)
 	return false;
 }
 
-void analyzeImages(const cgltf_data* data, const char* input_path, std::vector<ImageInfo>& images)
+bool hasAlpha(const std::string& data, const char* mime_type)
 {
-	for (size_t i = 0; i < data->images_count; ++i)
-	{
-		std::string img_data, mime_type;
-		if (!readImage(data->images[i], input_path, img_data, mime_type))
-			continue;
-
-		ImageInfo& info = images[i];
-
-		if (mime_type == "image/png")
-		{
-			getDimensionsPng(img_data, info.width, info.height);
-			info.alpha = hasTransparencyPng(img_data);
-		}
-		else if (mime_type == "image/jpeg")
-		{
-			getDimensionsJpeg(img_data, info.width, info.height);
-			info.alpha = false;
-		}
-	}
+	if (strcmp(mime_type, "image/png") == 0)
+		return hasTransparencyPng(data);
+	else
+		return false;
 }
 
 static const char* mimeExtension(const char* mime_type)

--- a/src/clusterizer.cpp
+++ b/src/clusterizer.cpp
@@ -368,8 +368,7 @@ static size_t kdtreeBuild(size_t offset, KDNode* nodes, size_t node_count, const
 	}
 
 	// split axis is one where the variance is largest
-	unsigned int axis = vars[0] >= vars[1] && vars[0] >= vars[2] ? 0 : vars[1] >= vars[2] ? 1
-	                                                                                      : 2;
+	unsigned int axis = vars[0] >= vars[1] && vars[0] >= vars[2] ? 0 : vars[1] >= vars[2] ? 1 : 2;
 
 	float split = mean[axis];
 	size_t middle = kdtreePartition(indices, count, points, stride, axis, split);

--- a/src/simplifier.cpp
+++ b/src/simplifier.cpp
@@ -952,8 +952,8 @@ static size_t performEdgeCollapses(unsigned int* collapse_remap, unsigned char* 
 	float error_goal_perfect = edge_collapse_goal < collapse_count ? collapses[collapse_order[edge_collapse_goal]].error : 0.f;
 
 	printf("removed %d triangles, error %e (goal %e); evaluated %d/%d collapses (done %d, skipped %d, invalid %d)\n",
-		int(triangle_collapses), sqrtf(result_error), sqrtf(error_goal_perfect),
-		int(stats[0]), int(collapse_count), int(edge_collapses), int(stats[1]), int(stats[2]));
+	       int(triangle_collapses), sqrtf(result_error), sqrtf(error_goal_perfect),
+	       int(stats[0]), int(collapse_count), int(edge_collapses), int(stats[1]), int(stats[2]));
 #endif
 
 	return edge_collapses;

--- a/src/vertexfilter.cpp
+++ b/src/vertexfilter.cpp
@@ -160,7 +160,8 @@ static void decodeFilterExp(unsigned int* data, size_t count)
 #endif
 
 #if defined(SIMD_SSE) || defined(SIMD_NEON) || defined(SIMD_WASM)
-template <typename T> static void dispatchSimd(void (*process)(T*, size_t), T* data, size_t count, size_t stride)
+template <typename T>
+static void dispatchSimd(void (*process)(T*, size_t), T* data, size_t count, size_t stride)
 {
 	assert(stride <= 4);
 


### PR DESCRIPTION
This relies on extracting image metadata from all images, which means we
now always read image data at least once when processing scenes; but the
benefit is that we can now remove incorrect BLEND modes from materials
which seems worth it.
