### PR TITLE
gltfpack: Switch to C++11

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,6 +86,7 @@ endif()
 
 if(MESHOPT_BUILD_GLTFPACK)
     add_executable(gltfpack ${GLTF_SOURCES} tools/meshloader.cpp)
+    set_target_properties(gltfpack PROPERTIES CXX_STANDARD 11)
     target_link_libraries(gltfpack meshoptimizer)
     list(APPEND TARGETS gltfpack)
 

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,8 @@ CFLAGS=-g -Wall -Wextra -Werror -std=c89
 CXXFLAGS=-g -Wall -Wextra -Wshadow -Wno-missing-field-initializers -Werror -std=c++98
 LDFLAGS=
 
+$(GLTFPACK_OBJECTS): CXXFLAGS+=-std=c++11
+
 WASMCC=clang++
 WASI_SDK=
 


### PR DESCRIPTION
This is going to make Basis integration easier; there's no real reason
to keep using C++98 for gltfpack. Note that meshoptimizer continues to
use C++98 and that is unlikely to change.