### PR TITLE
Add meshopt_encodeFilter* function family

### DIFF
--- a/demo/tests.cpp
+++ b/demo/tests.cpp
@@ -648,6 +648,13 @@ void encodeFilterOct8()
 	meshopt_encodeFilterOct(encoded, 4, 4, 8, data);
 
 	assert(memcmp(encoded, expected, sizeof(expected)) == 0);
+
+	char decoded[4 * 4];
+	memcpy(decoded, encoded, sizeof(decoded));
+	meshopt_decodeFilterOct(decoded, 4, 4);
+
+	for (size_t i = 0; i < 4 * 4; ++i)
+		assert(fabsf(decoded[i] / 127.f - data[i]) < 1e-2f);
 }
 
 void encodeFilterOct12()
@@ -662,14 +669,21 @@ void encodeFilterOct12()
 	const unsigned short expected[4 * 4] = {
 	    0x7ff, 0, 0x7ff, 0,
 	    0x0, 0xf801, 0x7ff, 0,
-	    0x3ff, 0, 0x7ff, 0x7ff,
-	    0xf801, 0x400, 0x7ff, 0x7ff, // clang-format :-/
+	    0x3ff, 0, 0x7ff, 0x7fff,
+	    0xf801, 0x400, 0x7ff, 0x7fff, // clang-format :-/
 	};
 
 	unsigned short encoded[4 * 4];
 	meshopt_encodeFilterOct(encoded, 4, 8, 12, data);
 
 	assert(memcmp(encoded, expected, sizeof(expected)) == 0);
+
+	short decoded[4 * 4];
+	memcpy(decoded, encoded, sizeof(decoded));
+	meshopt_decodeFilterOct(decoded, 4, 8);
+
+	for (size_t i = 0; i < 4 * 4; ++i)
+		assert(fabsf(decoded[i] / 32767.f - data[i]) < 1e-3f);
 }
 
 void encodeFilterQuat12()
@@ -692,6 +706,26 @@ void encodeFilterQuat12()
 	meshopt_encodeFilterQuat(encoded, 4, 8, 12, data);
 
 	assert(memcmp(encoded, expected, sizeof(expected)) == 0);
+
+	short decoded[4 * 4];
+	memcpy(decoded, encoded, sizeof(decoded));
+	meshopt_decodeFilterQuat(decoded, 4, 8);
+
+	for (size_t i = 0; i < 4; ++i)
+	{
+		float dx = decoded[i * 4 + 0] / 32767.f;
+		float dy = decoded[i * 4 + 1] / 32767.f;
+		float dz = decoded[i * 4 + 2] / 32767.f;
+		float dw = decoded[i * 4 + 3] / 32767.f;
+
+		float dp =
+		    data[i * 4 + 0] * dx +
+		    data[i * 4 + 1] * dy +
+		    data[i * 4 + 2] * dz +
+		    data[i * 4 + 3] * dw;
+
+		assert(fabsf(fabsf(dp) - 1.f) < 1e-4f);
+	}
 }
 
 void encodeFilterExp()

--- a/demo/tests.cpp
+++ b/demo/tests.cpp
@@ -1,6 +1,7 @@
 #include "../src/meshoptimizer.h"
 
 #include <assert.h>
+#include <math.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -627,6 +628,92 @@ static void decodeFilterExp()
 	assert(memcmp(tail, expected, sizeof(tail)) == 0);
 }
 
+void encodeFilterOct8()
+{
+	const float data[4 * 4] = {
+	    1, 0, 0, 0,
+	    0, -1, 0, 0,
+	    0.7071068f, 0, 0.707168f, 1,
+	    -0.7071068f, 0, -0.707168f, 1, // clang-format :-/
+	};
+
+	const unsigned char expected[4 * 4] = {
+	    0x7f, 0, 0x7f, 0,
+	    0, 0x81, 0x7f, 0,
+	    0x3f, 0, 0x7f, 0x7f,
+	    0x81, 0x40, 0x7f, 0x7f, // clang-format :-/
+	};
+
+	unsigned char encoded[4 * 4];
+	meshopt_encodeFilterOct(encoded, 4, 4, 8, data);
+
+	assert(memcmp(encoded, expected, sizeof(expected)) == 0);
+}
+
+void encodeFilterOct12()
+{
+	const float data[4 * 4] = {
+	    1, 0, 0, 0,
+	    0, -1, 0, 0,
+	    0.7071068f, 0, 0.707168f, 1,
+	    -0.7071068f, 0, -0.707168f, 1, // clang-format :-/
+	};
+
+	const unsigned short expected[4 * 4] = {
+	    0x7ff, 0, 0x7ff, 0,
+	    0x0, 0xf801, 0x7ff, 0,
+	    0x3ff, 0, 0x7ff, 0x7ff,
+	    0xf801, 0x400, 0x7ff, 0x7ff, // clang-format :-/
+	};
+
+	unsigned short encoded[4 * 4];
+	meshopt_encodeFilterOct(encoded, 4, 8, 12, data);
+
+	assert(memcmp(encoded, expected, sizeof(expected)) == 0);
+}
+
+void encodeFilterQuat12()
+{
+	const float data[4 * 4] = {
+	    1, 0, 0, 0,
+	    0, -1, 0, 0,
+	    0.7071068f, 0, 0, 0.707168f,
+	    -0.7071068f, 0, 0, -0.707168f, // clang-format :-/
+	};
+
+	const unsigned short expected[4 * 4] = {
+	    0, 0, 0, 0x7fc,
+	    0, 0, 0, 0x7fd,
+	    0x7ff, 0, 0, 0x7ff,
+	    0x7ff, 0, 0, 0x7ff, // clang-format :-/
+	};
+
+	unsigned short encoded[4 * 4];
+	meshopt_encodeFilterQuat(encoded, 4, 8, 12, data);
+
+	assert(memcmp(encoded, expected, sizeof(expected)) == 0);
+}
+
+void encodeFilterExp()
+{
+	const float data[3] = {
+	    1,
+	    -23.4f,
+	    -0.1f,
+	};
+
+	const unsigned int expected[3] = {
+	    0xf7000200,
+	    0xf7ffd133,
+	    0xf7ffffcd,
+	};
+
+	unsigned int encoded[3];
+	meshopt_encodeFilterExp(encoded, 1, 12, 15, data);
+
+	assert(memcmp(encoded, expected, sizeof(expected)) == 0);
+}
+
 static void clusterBoundsDegenerate()
 {
 	const float vbd[] = {0, 0, 0, 0, 0, 0, 0, 0, 0};
@@ -919,6 +1006,11 @@ static void runTestsOnce()
 	decodeFilterOct12();
 	decodeFilterQuat12();
 	decodeFilterExp();
+
+	encodeFilterOct8();
+	encodeFilterOct12();
+	encodeFilterQuat12();
+	encodeFilterExp();
 
 	clusterBoundsDegenerate();
 

--- a/demo/tests.cpp
+++ b/demo/tests.cpp
@@ -649,7 +649,7 @@ void encodeFilterOct8()
 
 	assert(memcmp(encoded, expected, sizeof(expected)) == 0);
 
-	char decoded[4 * 4];
+	signed char decoded[4 * 4];
 	memcpy(decoded, encoded, sizeof(decoded));
 	meshopt_decodeFilterOct(decoded, 4, 4);
 

--- a/demo/tests.cpp
+++ b/demo/tests.cpp
@@ -746,6 +746,13 @@ void encodeFilterExp()
 	meshopt_encodeFilterExp(encoded, 1, 12, 15, data);
 
 	assert(memcmp(encoded, expected, sizeof(expected)) == 0);
+
+	float decoded[3];
+	memcpy(decoded, encoded, sizeof(decoded));
+	meshopt_decodeFilterExp(decoded, 3, 4);
+
+	for (size_t i = 0; i < 3; ++i)
+		assert(fabsf(decoded[i] - data[i]) < 1e-3f);
 }
 
 static void clusterBoundsDegenerate()

--- a/src/meshoptimizer.h
+++ b/src/meshoptimizer.h
@@ -290,7 +290,7 @@ MESHOPTIMIZER_EXPERIMENTAL void meshopt_decodeFilterExp(void* buffer, size_t cou
  * Each component is stored as an 8-bit or 16-bit normalized integer; stride must be equal to 4 or 8. W is preserved as is.
  * Input data must contain 4 floats for every vector (count*4 total).
  * 
- * meshopt_encodeFilterQuad encodes unit quaternions with K-bit (4 <= K <= 16) component encoding.
+ * meshopt_encodeFilterQuat encodes unit quaternions with K-bit (4 <= K <= 16) component encoding.
  * Each component is stored as an 16-bit integer; stride must be equal to 8.
  * Input data must contain 4 floats for every quaternion (count*4 total).
  * 
@@ -321,7 +321,7 @@ MESHOPTIMIZER_EXPERIMENTAL size_t meshopt_simplify(unsigned int* destination, co
 
 /**
  * Experimental: Mesh simplifier (sloppy)
- * Reduces the number of triangles in the mesh, sacrificing mesh apperance for simplification performance
+ * Reduces the number of triangles in the mesh, sacrificing mesh appearance for simplification performance
  * The algorithm doesn't preserve mesh topology but can stop short of the target goal based on target error.
  * Returns the number of indices after simplification, with destination containing new index data
  * The resulting index buffer references vertices from the original vertex buffer.

--- a/src/meshoptimizer.h
+++ b/src/meshoptimizer.h
@@ -295,17 +295,13 @@ MESHOPTIMIZER_EXPERIMENTAL void meshopt_decodeFilterExp(void* buffer, size_t cou
  * Input data must contain 4 floats for every quaternion (count*4 total).
  * 
  * meshopt_encodeFilterExp encodes arbitrary (finite) floating-point data with 8-bit exponent and K-bit integer mantissa (1 <= K <= 24).
- * Each component is encoded in isolation; stride must be divisible by 4.
- * Input data must contain stride/4 floats for every vector (count*stride/4 total).
- * 
- * meshopt_encodeFilterExpShared encodes arbitrary (finite) floating-point data with 8-bit exponent and K-bit integer mantissa (1 <= K <= 24).
  * Mantissa is shared between all components of a given vector as defined by stride; stride must be divisible by 4.
  * Input data must contain stride/4 floats for every vector (count*stride/4 total).
+ * When individual (scalar) encoding is desired, simply pass stride=4 and adjust count accordingly.
  */
 MESHOPTIMIZER_EXPERIMENTAL void meshopt_encodeFilterOct(void* destination, size_t count, size_t stride, int bits, const float* data);
 MESHOPTIMIZER_EXPERIMENTAL void meshopt_encodeFilterQuat(void* destination, size_t count, size_t stride, int bits, const float* data);
 MESHOPTIMIZER_EXPERIMENTAL void meshopt_encodeFilterExp(void* destination, size_t count, size_t stride, int bits, const float* data);
-MESHOPTIMIZER_EXPERIMENTAL void meshopt_encodeFilterExpShared(void* destination, size_t count, size_t stride, int bits, const float* data);
 
 /**
  * Experimental: Mesh simplifier

--- a/src/meshoptimizer.h
+++ b/src/meshoptimizer.h
@@ -278,9 +278,34 @@ MESHOPTIMIZER_API int meshopt_decodeVertexBuffer(void* destination, size_t verte
  * meshopt_decodeFilterExp decodes exponential encoding of floating-point data with 8-bit exponent and 24-bit integer mantissa as 2^E*M.
  * Each 32-bit component is decoded in isolation; stride must be divisible by 4.
  */
-MESHOPTIMIZER_EXPERIMENTAL void meshopt_decodeFilterOct(void* buffer, size_t vertex_count, size_t vertex_size);
-MESHOPTIMIZER_EXPERIMENTAL void meshopt_decodeFilterQuat(void* buffer, size_t vertex_count, size_t vertex_size);
-MESHOPTIMIZER_EXPERIMENTAL void meshopt_decodeFilterExp(void* buffer, size_t vertex_count, size_t vertex_size);
+MESHOPTIMIZER_EXPERIMENTAL void meshopt_decodeFilterOct(void* buffer, size_t count, size_t stride);
+MESHOPTIMIZER_EXPERIMENTAL void meshopt_decodeFilterQuat(void* buffer, size_t count, size_t stride);
+MESHOPTIMIZER_EXPERIMENTAL void meshopt_decodeFilterExp(void* buffer, size_t count, size_t stride);
+
+/**
+ * Vertex buffer filter encoders
+ * These functions can be used to encode data in a format that meshopt_decodeFilter can decode
+ * 
+ * meshopt_encodeFilterOct encodes unit vectors with K-bit (K <= 16) signed X/Y as an output.
+ * Each component is stored as an 8-bit or 16-bit normalized integer; stride must be equal to 4 or 8. W is preserved as is.
+ * Input data must contain 4 floats for every vector (count*4 total).
+ * 
+ * meshopt_encodeFilterQuad encodes unit quaternions with K-bit (4 <= K <= 16) component encoding.
+ * Each component is stored as an 16-bit integer; stride must be equal to 8.
+ * Input data must contain 4 floats for every quaternion (count*4 total).
+ * 
+ * meshopt_encodeFilterExp encodes arbitrary (finite) floating-point data with 8-bit exponent and K-bit integer mantissa (1 <= K <= 24).
+ * Each component is encoded in isolation; stride must be divisible by 4.
+ * Input data must contain stride/4 floats for every vector (count*stride/4 total).
+ * 
+ * meshopt_encodeFilterExpShared encodes arbitrary (finite) floating-point data with 8-bit exponent and K-bit integer mantissa (1 <= K <= 24).
+ * Mantissa is shared between all components of a given vector as defined by stride; stride must be divisible by 4.
+ * Input data must contain stride/4 floats for every vector (count*stride/4 total).
+ */
+MESHOPTIMIZER_EXPERIMENTAL void meshopt_encodeFilterOct(void* destination, size_t count, size_t stride, int bits, const float* data);
+MESHOPTIMIZER_EXPERIMENTAL void meshopt_encodeFilterQuat(void* destination, size_t count, size_t stride, int bits, const float* data);
+MESHOPTIMIZER_EXPERIMENTAL void meshopt_encodeFilterExp(void* destination, size_t count, size_t stride, int bits, const float* data);
+MESHOPTIMIZER_EXPERIMENTAL void meshopt_encodeFilterExpShared(void* destination, size_t count, size_t stride, int bits, const float* data);
 
 /**
  * Experimental: Mesh simplifier

--- a/src/vertexfilter.cpp
+++ b/src/vertexfilter.cpp
@@ -792,50 +792,191 @@ static void decodeFilterExpSimd(unsigned int* data, size_t count)
 
 } // namespace meshopt
 
-void meshopt_decodeFilterOct(void* buffer, size_t vertex_count, size_t vertex_size)
+void meshopt_decodeFilterOct(void* buffer, size_t count, size_t stride)
 {
 	using namespace meshopt;
 
-	assert(vertex_size == 4 || vertex_size == 8);
+	assert(stride == 4 || stride == 8);
 
 #if defined(SIMD_SSE) || defined(SIMD_NEON) || defined(SIMD_WASM)
-	if (vertex_size == 4)
-		dispatchSimd(decodeFilterOctSimd, static_cast<signed char*>(buffer), vertex_count, 4);
+	if (stride == 4)
+		dispatchSimd(decodeFilterOctSimd, static_cast<signed char*>(buffer), count, 4);
 	else
-		dispatchSimd(decodeFilterOctSimd, static_cast<short*>(buffer), vertex_count, 4);
+		dispatchSimd(decodeFilterOctSimd, static_cast<short*>(buffer), count, 4);
 #else
-	if (vertex_size == 4)
-		decodeFilterOct(static_cast<signed char*>(buffer), vertex_count);
+	if (stride == 4)
+		decodeFilterOct(static_cast<signed char*>(buffer), count);
 	else
-		decodeFilterOct(static_cast<short*>(buffer), vertex_count);
+		decodeFilterOct(static_cast<short*>(buffer), count);
 #endif
 }
 
-void meshopt_decodeFilterQuat(void* buffer, size_t vertex_count, size_t vertex_size)
+void meshopt_decodeFilterQuat(void* buffer, size_t count, size_t stride)
 {
 	using namespace meshopt;
 
-	assert(vertex_size == 8);
-	(void)vertex_size;
+	assert(stride == 8);
+	(void)stride;
 
 #if defined(SIMD_SSE) || defined(SIMD_NEON) || defined(SIMD_WASM)
-	dispatchSimd(decodeFilterQuatSimd, static_cast<short*>(buffer), vertex_count, 4);
+	dispatchSimd(decodeFilterQuatSimd, static_cast<short*>(buffer), count, 4);
 #else
-	decodeFilterQuat(static_cast<short*>(buffer), vertex_count);
+	decodeFilterQuat(static_cast<short*>(buffer), count);
 #endif
 }
 
-void meshopt_decodeFilterExp(void* buffer, size_t vertex_count, size_t vertex_size)
+void meshopt_decodeFilterExp(void* buffer, size_t count, size_t stride)
 {
 	using namespace meshopt;
 
-	assert(vertex_size % 4 == 0);
+	assert(stride > 0 && stride % 4 == 0);
 
 #if defined(SIMD_SSE) || defined(SIMD_NEON) || defined(SIMD_WASM)
-	dispatchSimd(decodeFilterExpSimd, static_cast<unsigned int*>(buffer), vertex_count * (vertex_size / 4), 1);
+	dispatchSimd(decodeFilterExpSimd, static_cast<unsigned int*>(buffer), count * (stride / 4), 1);
 #else
-	decodeFilterExp(static_cast<unsigned int*>(buffer), vertex_count * (vertex_size / 4));
+	decodeFilterExp(static_cast<unsigned int*>(buffer), count * (stride / 4));
 #endif
+}
+
+void meshopt_encodeFilterOct(void* destination, size_t count, size_t stride, int bits, const float* data)
+{
+	assert(stride == 4 || stride == 8);
+	assert(bits >= 1 && bits <= 16);
+
+	char* d8 = static_cast<char*>(destination);
+	short* d16 = static_cast<short*>(destination);
+
+	for (size_t i = 0; i < count; ++i)
+	{
+		const float* n = &data[i * 4];
+
+		// octahedral encoding of a unit vector
+		float nx = n[0], ny = n[1], nz = n[2], nw = n[3];
+		float nl = fabsf(nx) + fabsf(ny) + fabsf(nz);
+		float ns = nl == 0.f ? 0.f : 1.f / nl;
+
+		nx *= ns;
+		ny *= ns;
+
+		float u = (nz >= 0.f) ? nx : (1 - fabsf(ny)) * (nx >= 0.f ? 1.f : -1.f);
+		float v = (nz >= 0.f) ? ny : (1 - fabsf(nx)) * (ny >= 0.f ? 1.f : -1.f);
+
+		int fu = meshopt_quantizeSnorm(u, bits);
+		int fv = meshopt_quantizeSnorm(v, bits);
+		int fo = meshopt_quantizeSnorm(1.f, bits);
+		int fw = meshopt_quantizeSnorm(nw, bits);
+
+		if (stride == 4)
+		{
+			d8[i * 4 + 0] = char(fu);
+			d8[i * 4 + 1] = char(fv);
+			d8[i * 4 + 2] = char(fo);
+			d8[i * 4 + 3] = char(fw);
+		}
+		else
+		{
+			d16[i * 4 + 0] = short(fu);
+			d16[i * 4 + 1] = short(fv);
+			d16[i * 4 + 2] = short(fo);
+			d16[i * 4 + 3] = short(fw);
+		}
+	}
+}
+
+void meshopt_encodeFilterQuat(void* destination_, size_t count, size_t stride, int bits, const float* data)
+{
+	assert(stride == 8);
+	assert(bits >= 4 && bits <= 16);
+	(void)stride;
+
+	short* destination = static_cast<short*>(destination_);
+
+	const float scaler = sqrtf(2.f);
+
+	for (size_t i = 0; i < count; ++i)
+	{
+		const float* q = &data[i * 4];
+		short* d = &destination[i * 4];
+
+		// establish maximum quaternion component
+		int qc = 0;
+		qc = fabsf(q[1]) > fabsf(q[qc]) ? 1 : qc;
+		qc = fabsf(q[2]) > fabsf(q[qc]) ? 2 : qc;
+		qc = fabsf(q[3]) > fabsf(q[qc]) ? 3 : qc;
+
+		// we use double-cover properties to discard the sign
+		float sign = q[qc] < 0.f ? -1.f : 1.f;
+
+		// note: we always encode a cyclical swizzle to be able to recover the order via rotation
+		d[0] = short(meshopt_quantizeSnorm(q[(qc + 1) & 3] * scaler * sign, bits));
+		d[1] = short(meshopt_quantizeSnorm(q[(qc + 2) & 3] * scaler * sign, bits));
+		d[2] = short(meshopt_quantizeSnorm(q[(qc + 3) & 3] * scaler * sign, bits));
+		d[3] = short((meshopt_quantizeSnorm(1.f, bits) & ~3) | qc);
+	}
+}
+
+void meshopt_encodeFilterExp(void* destination_, size_t count, size_t stride, int bits, const float* data)
+{
+	assert(stride > 0 && stride % 4 == 0);
+	assert(bits >= 1 && bits <= 24);
+
+	unsigned int* destination = static_cast<unsigned int*>(destination_);
+
+	for (size_t i = 0; i < count * stride; ++i)
+	{
+		float v = data[i];
+
+		int exp;
+		frexp(v, &exp);
+
+		// note that we additionally scale the mantissa to make it a K-bit signed integer (K-1 bits for magnitude)
+		exp -= (bits - 1);
+
+		// compute renormalized rounded mantissa and encode it
+		int m = int(ldexp(v, -exp) + (v >= 0 ? 0.5f : -0.5f));
+		int mmask = (1 << 24) - 1;
+
+		destination[i] = (m & mmask) | (unsigned(exp) << 24);
+	}
+}
+
+void meshopt_encodeFilterExpShared(void* destination_, size_t count, size_t stride, int bits, const float* data)
+{
+	assert(stride > 0 && stride % 4 == 0);
+	assert(bits >= 1 && bits <= 24);
+
+	unsigned int* destination = static_cast<unsigned int*>(destination_);
+	size_t stride_float = stride / sizeof(float);
+
+	for (size_t i = 0; i < count; ++i)
+	{
+		const float* v = &data[i * stride_float];
+		unsigned int* d = &destination[i * stride_float];
+
+		// use maximum exponent to encode values; this guarantess that mantissa is [-1, 1]
+		int exp = -256;
+
+		for (size_t j = 0; j < stride_float; ++j)
+		{
+			int e;
+			frexp(v[j], &e);
+
+			exp = (exp < e) ? e : exp;
+		}
+
+		// note that we additionally scale the mantissa to make it a K-bit signed integer (K-1 bits for magnitude)
+		exp -= (bits - 1);
+
+		// compute renormalized rounded mantissa for each component
+		int mmask = (1 << 24) - 1;
+
+		for (size_t j = 0; j < stride_float; ++j)
+		{
+			int m = int(ldexp(v[j], -exp) + (v[j] >= 0 ? 0.5f : -0.5f));
+
+			d[j] = (m & mmask) | (unsigned(exp) << 24);
+		}
+	}
 }
 
 #undef SIMD_SSE

--- a/src/vertexfilter.cpp
+++ b/src/vertexfilter.cpp
@@ -929,7 +929,7 @@ void meshopt_encodeFilterExp(void* destination_, size_t count, size_t stride, in
 		unsigned int* d = &destination[i * stride_float];
 
 		// use maximum exponent to encode values; this guarantess that mantissa is [-1, 1]
-		int exp = -256;
+		int exp = -100;
 
 		for (size_t j = 0; j < stride_float; ++j)
 		{

--- a/src/vertexfilter.cpp
+++ b/src/vertexfilter.cpp
@@ -843,7 +843,7 @@ void meshopt_encodeFilterOct(void* destination, size_t count, size_t stride, int
 	assert(stride == 4 || stride == 8);
 	assert(bits >= 1 && bits <= 16);
 
-	char* d8 = static_cast<char*>(destination);
+	signed char* d8 = static_cast<signed char*>(destination);
 	short* d16 = static_cast<short*>(destination);
 
 	int bytebits = int(stride * 2);
@@ -870,10 +870,10 @@ void meshopt_encodeFilterOct(void* destination, size_t count, size_t stride, int
 
 		if (stride == 4)
 		{
-			d8[i * 4 + 0] = char(fu);
-			d8[i * 4 + 1] = char(fv);
-			d8[i * 4 + 2] = char(fo);
-			d8[i * 4 + 3] = char(fw);
+			d8[i * 4 + 0] = (signed char)(fu);
+			d8[i * 4 + 1] = (signed char)(fv);
+			d8[i * 4 + 2] = (signed char)(fo);
+			d8[i * 4 + 3] = (signed char)(fw);
 		}
 		else
 		{

--- a/src/vertexfilter.cpp
+++ b/src/vertexfilter.cpp
@@ -846,6 +846,8 @@ void meshopt_encodeFilterOct(void* destination, size_t count, size_t stride, int
 	char* d8 = static_cast<char*>(destination);
 	short* d16 = static_cast<short*>(destination);
 
+	int bytebits = int(stride * 2);
+
 	for (size_t i = 0; i < count; ++i)
 	{
 		const float* n = &data[i * 4];
@@ -864,7 +866,7 @@ void meshopt_encodeFilterOct(void* destination, size_t count, size_t stride, int
 		int fu = meshopt_quantizeSnorm(u, bits);
 		int fv = meshopt_quantizeSnorm(v, bits);
 		int fo = meshopt_quantizeSnorm(1.f, bits);
-		int fw = meshopt_quantizeSnorm(nw, bits);
+		int fw = meshopt_quantizeSnorm(nw, bytebits);
 
 		if (stride == 4)
 		{

--- a/src/vertexfilter.cpp
+++ b/src/vertexfilter.cpp
@@ -921,31 +921,6 @@ void meshopt_encodeFilterExp(void* destination_, size_t count, size_t stride, in
 	assert(bits >= 1 && bits <= 24);
 
 	unsigned int* destination = static_cast<unsigned int*>(destination_);
-
-	for (size_t i = 0; i < count * stride; ++i)
-	{
-		float v = data[i];
-
-		int exp;
-		frexp(v, &exp);
-
-		// note that we additionally scale the mantissa to make it a K-bit signed integer (K-1 bits for magnitude)
-		exp -= (bits - 1);
-
-		// compute renormalized rounded mantissa and encode it
-		int m = int(ldexp(v, -exp) + (v >= 0 ? 0.5f : -0.5f));
-		int mmask = (1 << 24) - 1;
-
-		destination[i] = (m & mmask) | (unsigned(exp) << 24);
-	}
-}
-
-void meshopt_encodeFilterExpShared(void* destination_, size_t count, size_t stride, int bits, const float* data)
-{
-	assert(stride > 0 && stride % 4 == 0);
-	assert(bits >= 1 && bits <= 24);
-
-	unsigned int* destination = static_cast<unsigned int*>(destination_);
 	size_t stride_float = stride / sizeof(float);
 
 	for (size_t i = 0; i < count; ++i)


### PR DESCRIPTION
These allow encoding data from a floating-point source into the format that meshopt_decodeFilter* will recognize.

gltfpack doesn't use these yet since it also needs basic quantization methods that might be exposed as meshopt_encode* in a separate change.