### PR TITLE
Optimize output types

### DIFF
--- a/gltf/gltfpack.cpp
+++ b/gltf/gltfpack.cpp
@@ -529,7 +529,7 @@ static void process(cgltf_data* data, const char* input_path, const char* output
 			append(json_meshes, "{\"attributes\":{");
 			writeMeshAttributes(json_meshes, views, json_accessors, accr_offset, prim, 0, qp, qt, settings);
 			append(json_meshes, "}");
-			if (prim.type != 4)
+			if (prim.type != cgltf_primitive_type_triangles)
 			{
 				append(json_meshes, ",\"mode\":");
 				append(json_meshes, size_t(prim.type));

--- a/gltf/gltfpack.cpp
+++ b/gltf/gltfpack.cpp
@@ -529,9 +529,11 @@ static void process(cgltf_data* data, const char* input_path, const char* output
 			append(json_meshes, "{\"attributes\":{");
 			writeMeshAttributes(json_meshes, views, json_accessors, accr_offset, prim, 0, qp, qt, settings);
 			append(json_meshes, "}");
-			append(json_meshes, ",\"mode\":");
-			append(json_meshes, size_t(prim.type));
-
+			if (prim.type != 4)
+			{
+				append(json_meshes, ",\"mode\":");
+				append(json_meshes, size_t(prim.type));
+			}
 			if (mesh.targets)
 			{
 				append(json_meshes, ",\"targets\":[");

--- a/gltf/image.cpp
+++ b/gltf/image.cpp
@@ -198,7 +198,7 @@ static bool hasTransparencyPng(const std::string& data)
 	if (data.compare(12, 4, "IHDR") != 0)
 		return false;
 
-	int ctype = data[27];
+	int ctype = data[25];
 
 	if (ctype != 3)
 		return ctype == 4 || ctype == 6;

--- a/gltf/material.cpp
+++ b/gltf/material.cpp
@@ -332,8 +332,20 @@ void markNeededMaterials(cgltf_data* data, std::vector<MaterialInfo>& materials,
 	}
 }
 
-static void analyzeMaterialTexture(const cgltf_texture_view& view, TextureKind kind, MaterialInfo& mi, cgltf_data* data, std::vector<ImageInfo>& images)
+static void analyzeMaterialTexture(cgltf_texture_view& view, TextureKind kind, MaterialInfo& mi, cgltf_data* data, std::vector<ImageInfo>& images)
 {
+	// if the texture transform is just the default values, disable
+	if (view.has_transform &&
+		view.transform.offset[0] == 0.0f &&
+		view.transform.offset[1] == 0.0f &&
+		view.transform.scale[0] == 1.0f &&
+		view.transform.scale[1] == 1.0f &&
+		view.transform.rotation == 0.0f &&
+		view.transform.texcoord == view.texcoord)
+	{
+		view.has_transform = 0;
+	}
+
 	mi.usesTextureTransform |= bool(view.has_transform);
 
 	if (view.texture && view.texture->image)
@@ -353,7 +365,7 @@ static void analyzeMaterialTexture(const cgltf_texture_view& view, TextureKind k
 	}
 }
 
-static void analyzeMaterial(const cgltf_material& material, MaterialInfo& mi, cgltf_data* data, std::vector<ImageInfo>& images)
+static void analyzeMaterial(cgltf_material& material, MaterialInfo& mi, cgltf_data* data, std::vector<ImageInfo>& images)
 {
 	if (material.has_pbr_metallic_roughness)
 	{

--- a/gltf/write.cpp
+++ b/gltf/write.cpp
@@ -187,8 +187,11 @@ static void writeTextureInfo(std::string& json, const cgltf_data* data, const cg
 
 	append(json, "{\"index\":");
 	append(json, size_t(view.texture - data->textures));
-	append(json, ",\"texCoord\":");
-	append(json, size_t(view.texcoord));
+	if (view.texcoord != 0)
+	{
+		append(json, ",\"texCoord\":");
+		append(json, size_t(view.texcoord));
+	}
 	if (scale && view.scale != 1)
 	{
 		append(json, ",\"");
@@ -638,8 +641,11 @@ void writeBufferView(std::string& json, BufferView::Kind kind, StreamFormat::Fil
 
 	append(json, "{\"buffer\":");
 	append(json, buffer);
-	append(json, ",\"byteOffset\":");
-	append(json, bin_offset);
+	if (bin_offset != 0)
+	{
+		append(json, ",\"byteOffset\":");
+		append(json, bin_offset);
+	}
 	append(json, ",\"byteLength\":");
 	append(json, bin_size);
 	if (kind == BufferView::Kind_Vertex)
@@ -683,8 +689,11 @@ static void writeAccessor(std::string& json, size_t view, size_t offset, cgltf_t
 {
 	append(json, "{\"bufferView\":");
 	append(json, view);
-	append(json, ",\"byteOffset\":");
-	append(json, offset);
+	if (offset != 0)
+	{
+		append(json, ",\"byteOffset\":");
+		append(json, offset);
+	}
 	append(json, ",\"componentType\":");
 	append(json, componentType(component_type));
 	append(json, ",\"count\":");

--- a/gltf/write.cpp
+++ b/gltf/write.cpp
@@ -641,11 +641,8 @@ void writeBufferView(std::string& json, BufferView::Kind kind, StreamFormat::Fil
 
 	append(json, "{\"buffer\":");
 	append(json, buffer);
-	if (bin_offset != 0)
-	{
-		append(json, ",\"byteOffset\":");
-		append(json, bin_offset);
-	}
+	append(json, ",\"byteOffset\":");
+	append(json, bin_offset);
 	append(json, ",\"byteLength\":");
 	append(json, bin_size);
 	if (kind == BufferView::Kind_Vertex)
@@ -689,11 +686,8 @@ static void writeAccessor(std::string& json, size_t view, size_t offset, cgltf_t
 {
 	append(json, "{\"bufferView\":");
 	append(json, view);
-	if (offset != 0)
-	{
-		append(json, ",\"byteOffset\":");
-		append(json, offset);
-	}
+	append(json, ",\"byteOffset\":");
+	append(json, offset);
 	append(json, ",\"componentType\":");
 	append(json, componentType(component_type));
 	append(json, ",\"count\":");


### PR DESCRIPTION
Do not write out several options if at the default values.
Texture view transforms were a bit difficult as several places check for the extension being used - I broke "const" in updating the values during the material analyse phase as I could not easily see another obvious place to change this.

Sorry this also includes the PNG change, I could not figure out how to cherry pick in github easily.

