### PR TITLE
gltfpack: Fix quantization interaction with KHR_materials_volume

### DIFF
--- a/gltf/gltfpack.h
+++ b/gltf/gltfpack.h
@@ -325,7 +325,7 @@ void appendJson(std::string& s, const char* begin, const char* end);
 const char* attributeType(cgltf_attribute_type type);
 const char* animationPath(cgltf_animation_path_type type);
 
-void writeMaterial(std::string& json, const cgltf_data* data, const cgltf_material& material, const QuantizationTexture* qt);
+void writeMaterial(std::string& json, const cgltf_data* data, const cgltf_material& material, const QuantizationPosition* qp, const QuantizationTexture* qt);
 void writeBufferView(std::string& json, BufferView::Kind kind, StreamFormat::Filter filter, size_t count, size_t stride, size_t bin_offset, size_t bin_size, BufferView::Compression compression, size_t compressed_offset, size_t compressed_size);
 void writeSampler(std::string& json, const cgltf_sampler& sampler);
 void writeImage(std::string& json, std::vector<BufferView>& views, const cgltf_image& image, const ImageInfo& info, size_t index, const char* input_path, const char* output_path, const Settings& settings);

--- a/gltf/write.cpp
+++ b/gltf/write.cpp
@@ -454,7 +454,7 @@ static void writeMaterialComponent(std::string& json, const cgltf_data* data, co
 	append(json, "}");
 }
 
-static void writeMaterialComponent(std::string& json, const cgltf_data* data, const cgltf_volume& tm, const QuantizationTexture* qt)
+static void writeMaterialComponent(std::string& json, const cgltf_data* data, const cgltf_volume& tm, const QuantizationPosition* qp, const QuantizationTexture* qt)
 {
 	comma(json);
 	append(json, "\"KHR_materials_volume\":{");
@@ -466,9 +466,12 @@ static void writeMaterialComponent(std::string& json, const cgltf_data* data, co
 	}
 	if (tm.thickness_factor != 0)
 	{
+		// thickness is in mesh coordinate space which is rescaled by quantization
+		float node_scale = qp ? qp->scale / float((1 << qp->bits) - 1) : 1.f;
+
 		comma(json);
 		append(json, "\"thicknessFactor\":");
-		append(json, tm.thickness_factor);
+		append(json, tm.thickness_factor / node_scale);
 	}
 	if (memcmp(tm.attenuation_color, white, 12) != 0)
 	{
@@ -490,7 +493,7 @@ static void writeMaterialComponent(std::string& json, const cgltf_data* data, co
 	append(json, "}");
 }
 
-void writeMaterial(std::string& json, const cgltf_data* data, const cgltf_material& material, const QuantizationTexture* qt)
+void writeMaterial(std::string& json, const cgltf_data* data, const cgltf_material& material, const QuantizationPosition* qp, const QuantizationTexture* qt)
 {
 	if (material.name && *material.name)
 	{
@@ -596,7 +599,7 @@ void writeMaterial(std::string& json, const cgltf_data* data, const cgltf_materi
 
 		if (material.has_volume)
 		{
-			writeMaterialComponent(json, data, material.volume, qt);
+			writeMaterialComponent(json, data, material.volume, qp, qt);
 		}
 
 		if (material.unlit)


### PR DESCRIPTION
The volume thickness factor is specified in coordinate space of the mesh
-- changing this coordinate space results in a different thickness. As
such, we can't transform the mesh so when instancing is disabled we need
to keep the mesh attached to the original node, and we need to adjust
the thickness factor in all volume materials by the quantization scale.

Fixes #328.