### PR TITLE
gltfpack: Adjust animation tolerances

### DIFF
--- a/gltf/animation.cpp
+++ b/gltf/animation.cpp
@@ -34,16 +34,16 @@ static float getDeltaTolerance(cgltf_animation_path_type type)
 	switch (type)
 	{
 	case cgltf_animation_path_type_translation:
-		return 0.001f; // linear
+		return 0.0001f; // 0.1mm linear
 
 	case cgltf_animation_path_type_rotation:
-		return 0.1f * (3.1415926f / 180.f); // 0.1 degrees delta
+		return 0.1f * (3.1415926f / 180.f); // 0.1 degrees
 
 	case cgltf_animation_path_type_scale:
-		return 0.001f; // 0.1% delta (ratio)
+		return 0.001f; // 0.1% ratio
 
 	case cgltf_animation_path_type_weights:
-		return 0.001f; // 0.1% delta (linear)
+		return 0.001f; // 0.1% linear
 
 	default:
 		assert(!"Uknown animation path");


### PR DESCRIPTION
This change adjusts the translation tolerance to make it 10x stricter which fixes some edge cases when translation tracks are collapsed erroneously (without affecting the efficiency on regular content), and makes rotation tolerance slightly more lax - we previously used 0.57 degrees and now we use 0.1 degrees to use more round numbers.

This change also reworks the code that estimates deviation to make it easier to debug for future cases like this.

At some point it may make sense to start preserving tracks as is when `-ac` is specified instead of just disabling keyframe collapse; however, most of the constant tracks are also dummy, and so we might need a new command line key to avoid having users who need `-ac` for other reasons to pay the penalty.

Fixes #332.