### PR TITLE
gltfpack: Set locale to C

### DIFF
--- a/gltf/gltfpack.cpp
+++ b/gltf/gltfpack.cpp
@@ -1145,7 +1145,10 @@ unsigned int textureMask(const char* arg)
 
 int main(int argc, char** argv)
 {
+#ifndef __wasi__
 	setlocale(LC_ALL, "C"); // disable locale specific convention for number parsing/printing
+#endif
+
 	meshopt_encodeIndexVersion(1);
 
 	Settings settings = defaults();

--- a/gltf/gltfpack.cpp
+++ b/gltf/gltfpack.cpp
@@ -3,6 +3,7 @@
 
 #include <algorithm>
 
+#include <locale.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -1144,6 +1145,7 @@ unsigned int textureMask(const char* arg)
 
 int main(int argc, char** argv)
 {
+	setlocale(LC_ALL, "C"); // disable locale specific convention for number parsing/printing
 	meshopt_encodeIndexVersion(1);
 
 	Settings settings = defaults();


### PR DESCRIPTION
This makes sure that on Linux, where the locale may be set to non-C when
the program starts, we still use dot as a decimal separator.

Fixes #366 