### PR TITLE
gltfpack: Preserve interpolation type for STEP tracks

### DIFF
--- a/gltf/write.cpp
+++ b/gltf/write.cpp
@@ -1330,6 +1330,8 @@ void writeAnimation(std::string& json, std::vector<BufferView>& views, std::stri
 		append(json_samplers, range ? range_accr : track.constant ? pose_accr : time_accr);
 		append(json_samplers, ",\"output\":");
 		append(json_samplers, data_accr);
+		if (track.interpolation == cgltf_interpolation_type_step)
+			append(json_samplers, ",\"interpolation\":\"STEP\"");
 		append(json_samplers, "}");
 
 		const NodeInfo& tni = nodes[track.node - data->nodes];


### PR DESCRIPTION
This fixes issues for some animations where because we didn't preserve
STEP, during playback different keyframes that were never supposed to be
interpolated would be interpolated resulting in unexpected values.

Note that we only need to do this for STEP because LINEAR is the
default, and we resample CUBICSPLINE to LINEAR.

Fixes #341.