### PR TITLE
gltfpack: Add -tj command line option

### DIFF
--- a/gltf/gltfpack.cpp
+++ b/gltf/gltfpack.cpp
@@ -1286,6 +1286,10 @@ int main(int argc, char** argv)
 		{
 			fprintf(stderr, "Warning: -te is deprecated and will be removed in the future; gltfpack now automatically embeds textures into GLB files\n");
 		}
+		else if (strcmp(arg, "-tj") == 0 && i + 1 < argc && isdigit(argv[i + 1][0]))
+		{
+			settings.texture_jobs = clamp(atoi(argv[++i]), 0, 128);
+		}
 		else if (strcmp(arg, "-noq") == 0)
 		{
 			settings.quantize = false;
@@ -1386,6 +1390,7 @@ int main(int argc, char** argv)
 			fprintf(stderr, "\t-ts R: scale texture dimensions by the ratio R (default: 1; R should be between 0 and 1)\n");
 			fprintf(stderr, "\t-tp: resize textures to nearest power of 2 to conform to WebGL1 restrictions\n");
 			fprintf(stderr, "\t-tfy: flip textures along Y axis during BasisU supercompression\n");
+			fprintf(stderr, "\t-tj N: use N threads when compressing textures\n");
 			fprintf(stderr, "\tTexture classes:\n");
 			fprintf(stderr, "\t-tu C: use UASTC when encoding textures of class C\n");
 			fprintf(stderr, "\t-tq C N: set texture encoding quality for class C\n");
@@ -1448,6 +1453,11 @@ int main(int argc, char** argv)
 		fprintf(stderr, "Option -tfy is only supported when -tc is set as well\n");
 		return 1;
 	}
+
+#ifdef WITH_BASISU
+	if (settings.texture_ktx2)
+		encodeBasisInit(settings.texture_jobs);
+#endif
 
 	return gltfpack(input, output, report, settings);
 }

--- a/gltf/gltfpack.h
+++ b/gltf/gltfpack.h
@@ -132,6 +132,8 @@ struct Settings
 	bool texture_uastc[TextureKind__Count];
 	int texture_quality[TextureKind__Count];
 
+	int texture_jobs;
+
 	bool quantize;
 
 	bool compress;
@@ -290,6 +292,8 @@ void optimizeMaterials(cgltf_data* data, const char* input_path, std::vector<Ima
 
 bool readImage(const cgltf_image& image, const char* input_path, std::string& data, std::string& mime_type);
 bool hasAlpha(const std::string& data, const char* mime_type);
+
+void encodeBasisInit(int jobs);
 
 bool checkBasis(bool verbose);
 bool encodeBasis(const std::string& data, const char* mime_type, std::string& result, const ImageInfo& info, const Settings& settings);

--- a/gltf/image.cpp
+++ b/gltf/image.cpp
@@ -404,6 +404,9 @@ bool encodeBasis(const std::string& data, const char* mime_type, std::string& re
 	if (uastc)
 		cmd += " -ktx2_zstandard_level 9";
 
+	if (settings.texture_jobs == 1)
+		cmd += " -no_multithreading";
+
 	cmd += " -file ";
 	cmd += temp_input.path;
 	cmd += " -output_file ";
@@ -499,6 +502,14 @@ bool encodeKtx(const std::string& data, const char* mime_type, std::string& resu
 		cmd += " --srgb";
 	else
 		cmd += " --linear";
+
+	if (settings.texture_jobs)
+	{
+		char cs[128];
+		sprintf(cs, " --threads %d", settings.texture_jobs);
+
+		cmd += cs;
+	}
 
 	cmd += " -- ";
 	cmd += temp_output.path;


### PR DESCRIPTION
This option allows overriding the number of jobs used to compress
textures. For now we simply forward the option to the respective command
line tool.

When Basis is compiled in, this change switches to a shared job pool
which avoids the overhead of reinitializing it for every compression
job.