### PR TITLE
gltfpack: Compress textures in parallel

### DIFF
--- a/gltf/basisenc.cpp
+++ b/gltf/basisenc.cpp
@@ -23,10 +23,13 @@ void encodeBasisInit(int jobs)
 	basisu_encoder_init();
 
 	uint32_t num_threads = jobs == 0 ? std::thread::hardware_concurrency() : jobs;
-	uint32_t num_threads_enc = num_threads * 3 / 4;
+	uint32_t num_threads_enc = num_threads * 2 / 3;
 
-	gJobPool.reset(new job_pool(std::max(1u, num_threads - num_threads_enc)));
-	gEncPool.reset(new job_pool(std::max(1u, num_threads_enc)));
+	// This is a little difficult to reason about. We want to distribute the pool capacity so that it adds up to num_threads.
+	// We don't really know what the ratio of J:E work is (it's dependent on the mode among other things), but also encoding
+	// work uses job threads as helpers if necessary, which is where "1+" is coming from.
+	gJobPool.reset(new job_pool(num_threads - num_threads_enc));
+	gEncPool.reset(new job_pool(1 + num_threads_enc));
 }
 
 bool encodeBasisInternal(const char* input, const char* output, bool yflip, bool normal_map, bool linear, bool uastc, int uastc_l, float uastc_q, int etc1s_l, int etc1s_q, int zstd_l, int width, int height)

--- a/gltf/gltfpack.h
+++ b/gltf/gltfpack.h
@@ -296,6 +296,8 @@ bool hasAlpha(const std::string& data, const char* mime_type);
 #ifdef WITH_BASISU
 void encodeBasisInit(int jobs);
 bool encodeBasis(const std::string& data, const char* mime_type, std::string& result, const ImageInfo& info, const Settings& settings);
+void encodeImageAsync(std::string& encoded, const cgltf_image& image, const ImageInfo& info, const char* input_path, const Settings& settings);
+void encodeImageWait();
 #else
 bool checkBasis(bool verbose);
 bool encodeBasis(const std::string& data, const char* mime_type, std::string& result, const ImageInfo& info, const Settings& settings);


### PR DESCRIPTION
Instead of encoding one image at a time and letting Basis do internal
threading we now encode images in parallel using two job pools, one for
actual encoding and another one for farming out Basis encoding jobs.

As a result the compression is much faster, eg jrat.gltf encodes in ~20
seconds before this change and in ~7.5 seconds after it on Ryzen 5900X.

Note that we use two pools but their use isn't very well balanced;
depending on the mode we aren't running as fast as we possibly could, eg
changing both pools to max out logical processor count gets us to 5.5
seconds on the same input. However this would mean that we'd overload
the system so for now we're going to stay conservative.
