### PR TITLE
gltfpack: Support compressing files that have compressed textures

### DIFF
--- a/gltf/gltfpack.cpp
+++ b/gltf/gltfpack.cpp
@@ -436,6 +436,7 @@ static void process(cgltf_data* data, const char* input_path, const char* output
 	bool ext_unlit = false;
 	bool ext_instancing = false;
 	bool ext_texture_transform = false;
+	bool ext_texture_basisu = false;
 
 	size_t accr_offset = 0;
 	size_t node_offset = 0;
@@ -503,6 +504,8 @@ static void process(cgltf_data* data, const char* input_path, const char* output
 		append(json_textures, "{");
 		writeTexture(json_textures, texture, data, settings);
 		append(json_textures, "}");
+
+		ext_texture_basisu = ext_texture_basisu || texture.has_basisu;
 	}
 
 	for (size_t i = 0; i < data->materials_count; ++i)
@@ -812,7 +815,7 @@ static void process(cgltf_data* data, const char* input_path, const char* output
 	    {"KHR_materials_unlit", ext_unlit, false},
 	    {"KHR_materials_variants", data->variants_count > 0, false},
 	    {"KHR_lights_punctual", data->lights_count > 0, false},
-	    {"KHR_texture_basisu", !json_textures.empty() && settings.texture_ktx2, true},
+	    {"KHR_texture_basisu", ext_texture_basisu || (!json_textures.empty() && settings.texture_ktx2), true},
 	    {"EXT_mesh_gpu_instancing", ext_instancing, true},
 	};
 

--- a/gltf/image.cpp
+++ b/gltf/image.cpp
@@ -115,17 +115,25 @@ bool readImage(const cgltf_image& image, const char* input_path, std::string& da
 	}
 }
 
-static int readInt16(const std::string& data, size_t offset)
+static int readInt16BE(const std::string& data, size_t offset)
 {
 	return (unsigned char)data[offset] * 256 + (unsigned char)data[offset + 1];
 }
 
-static int readInt32(const std::string& data, size_t offset)
+static int readInt32BE(const std::string& data, size_t offset)
 {
 	return (unsigned((unsigned char)data[offset]) << 24) |
 	       (unsigned((unsigned char)data[offset + 1]) << 16) |
 	       (unsigned((unsigned char)data[offset + 2]) << 8) |
 	       unsigned((unsigned char)data[offset + 3]);
+}
+
+static int readInt32LE(const std::string& data, size_t offset)
+{
+	return unsigned((unsigned char)data[offset]) |
+	       (unsigned((unsigned char)data[offset + 1]) << 8) |
+	       (unsigned((unsigned char)data[offset + 2]) << 16) |
+	       (unsigned((unsigned char)data[offset + 3]) << 24);
 }
 
 static bool getDimensionsPng(const std::string& data, int& width, int& height)
@@ -140,8 +148,8 @@ static bool getDimensionsPng(const std::string& data, int& width, int& height)
 	if (data.compare(12, 4, "IHDR") != 0)
 		return false;
 
-	width = readInt32(data, 16);
-	height = readInt32(data, 20);
+	width = readInt32BE(data, 16);
+	height = readInt32BE(data, 20);
 
 	return true;
 }
@@ -177,13 +185,13 @@ static bool getDimensionsJpeg(const std::string& data, int& width, int& height)
 			if (offset + 10 > data.size())
 				return false;
 
-			width = readInt16(data, offset + 7);
-			height = readInt16(data, offset + 5);
+			width = readInt16BE(data, offset + 7);
+			height = readInt16BE(data, offset + 5);
 
 			return true;
 		}
 
-		offset += 2 + readInt16(data, offset + 2);
+		offset += 2 + readInt16BE(data, offset + 2);
 	}
 
 	return false;
@@ -210,7 +218,7 @@ static bool hasTransparencyPng(const std::string& data)
 
 	while (offset + 12 <= data.size())
 	{
-		int length = readInt32(data, offset);
+		int length = readInt32BE(data, offset);
 
 		if (length < 0)
 			return false;
@@ -232,6 +240,31 @@ static bool hasTransparencyKtx2(const std::string& data)
 	const char* signature = "\xabKTX 20\xbb\r\n\x1a\n";
 	if (data.compare(0, 12, signature) != 0)
 		return false;
+
+	int dfdOffset = readInt32LE(data, 48);
+	int dfdLength = readInt32LE(data, 52);
+
+	if (dfdLength < 4 + 24 + 16 || unsigned(dfdOffset) > data.size() || unsigned(dfdLength) > data.size() - dfdOffset)
+		return false;
+
+	const int KDF_DF_MODEL_ETC1S = 163;
+	const int KDF_DF_MODEL_UASTC = 166;
+	const int KHR_DF_CHANNEL_UASTC_RGBA = 3;
+	const int KHR_DF_CHANNEL_ETC1S_RGB = 0;
+	const int KHR_DF_CHANNEL_ETC1S_AAA = 15;
+
+	int colorModel = readInt32LE(data, dfdOffset + 12) & 0xff;
+	int channelType1 = (readInt32LE(data, dfdOffset + 28) >> 24) & 0xf;
+	int channelType2 = dfdLength >= 4 + 24 + 16 * 2 ? (readInt32LE(data, dfdOffset + 44) >> 24) & 0xf : channelType1;
+
+	if (colorModel == KDF_DF_MODEL_ETC1S)
+	{
+		return channelType1 == KHR_DF_CHANNEL_ETC1S_RGB && channelType2 == KHR_DF_CHANNEL_ETC1S_AAA;
+	}
+	else if (colorModel == KDF_DF_MODEL_UASTC)
+	{
+		return channelType1 == KHR_DF_CHANNEL_UASTC_RGBA;
+	}
 
 	return false;
 }

--- a/gltf/image.cpp
+++ b/gltf/image.cpp
@@ -19,6 +19,7 @@ static const char* kMimeTypes[][2] = {
     {"image/jpeg", ".jpg"},
     {"image/jpeg", ".jpeg"},
     {"image/png", ".png"},
+    {"image/ktx2", ".ktx2"},
 };
 
 static const BasisSettings kBasisSettings[10] = {
@@ -223,10 +224,24 @@ static bool hasTransparencyPng(const std::string& data)
 	return false;
 }
 
+static bool hasTransparencyKtx2(const std::string& data)
+{
+	if (data.size() < 12 + 17 * 4)
+		return false;
+
+	const char* signature = "\xabKTX 20\xbb\r\n\x1a\n";
+	if (data.compare(0, 12, signature) != 0)
+		return false;
+
+	return false;
+}
+
 bool hasAlpha(const std::string& data, const char* mime_type)
 {
 	if (strcmp(mime_type, "image/png") == 0)
 		return hasTransparencyPng(data);
+	else if (strcmp(mime_type, "image/ktx2") == 0)
+		return hasTransparencyKtx2(data);
 	else
 		return false;
 }

--- a/gltf/image.cpp
+++ b/gltf/image.cpp
@@ -368,12 +368,16 @@ void encodeImages(std::string* encoded, const cgltf_data* data, const std::vecto
 		encodePush([=]() {
 			std::string img_data;
 			std::string mime_type;
+
+			if (!readImage(image, input_path, img_data, mime_type))
+				return;
+
 			std::string result;
 
-			if (readImage(image, input_path, img_data, mime_type) && encodeBasis(img_data, mime_type.c_str(), result, info, settings))
-			{
+			if (mime_type == "image/ktx2")
+				encoded[i].swap(img_data);
+			else if (encodeBasis(img_data, mime_type.c_str(), result, info, settings))
 				encoded[i].swap(result);
-			}
 		});
 	}
 

--- a/gltf/parsegltf.cpp
+++ b/gltf/parsegltf.cpp
@@ -494,8 +494,6 @@ cgltf_data* parseGltf(const char* path, std::vector<Mesh>& meshes, std::vector<A
 		*error = "file requires Draco mesh compression support";
 	else if (requiresExtension(data, "EXT_meshopt_compression"))
 		*error = "file has already been compressed using gltfpack";
-	else if (requiresExtension(data, "KHR_texture_basisu"))
-		*error = "file requires BasisU texture support";
 	else if (requiresExtension(data, "EXT_mesh_gpu_instancing"))
 		*error = "file requires mesh instancing support";
 	else if (needsDummyBuffers(data))

--- a/gltf/write.cpp
+++ b/gltf/write.cpp
@@ -875,26 +875,35 @@ void writeEncodedImage(std::string& json, std::vector<BufferView>& views, const 
 
 void writeTexture(std::string& json, const cgltf_texture& texture, cgltf_data* data, const Settings& settings)
 {
+	if (texture.sampler)
+	{
+		append(json, "\"sampler\":");
+		append(json, size_t(texture.sampler - data->samplers));
+	}
+
 	if (texture.image)
 	{
-		if (texture.sampler)
-		{
-			append(json, "\"sampler\":");
-			append(json, size_t(texture.sampler - data->samplers));
-			append(json, ",");
-		}
-
 		if (settings.texture_ktx2)
 		{
+			comma(json);
 			append(json, "\"extensions\":{\"KHR_texture_basisu\":{\"source\":");
 			append(json, size_t(texture.image - data->images));
 			append(json, "}}");
 		}
 		else
 		{
+			comma(json);
 			append(json, "\"source\":");
 			append(json, size_t(texture.image - data->images));
 		}
+	}
+
+	if (texture.has_basisu)
+	{
+		comma(json);
+		append(json, "\"extensions\":{\"KHR_texture_basisu\":{\"source\":");
+		append(json, size_t(texture.basisu_image - data->images));
+		append(json, "}}");
 	}
 }
 

--- a/gltf/write.cpp
+++ b/gltf/write.cpp
@@ -828,7 +828,7 @@ void writeImage(std::string& json, std::vector<BufferView>& views, const cgltf_i
 	bool (*encode)(const std::string& data, const char* mime_type, std::string& result, const ImageInfo& info, const Settings& settings) = settings.texture_toktx ? encodeKtx : encodeBasis;
 #endif
 
-	if (settings.texture_ktx2)
+	if (settings.texture_ktx2 && mime_type != "image/ktx2")
 	{
 		std::string encoded;
 
@@ -838,7 +838,7 @@ void writeImage(std::string& json, std::vector<BufferView>& views, const cgltf_i
 		}
 		else
 		{
-			fprintf(stderr, "Warning: unable to encode image %d, skipping\n", int(index));
+			fprintf(stderr, "Warning: unable to encode image %d (%s), skipping\n", int(index), image.uri ? image.uri : "?");
 		}
 	}
 	else


### PR DESCRIPTION
Instead of failing to parse files that use KHR_texture_basisu we just ignore these images.

This does mean that various options like -tp and -ts do not work correctly for these inputs, so I'm not certain yet that this is a good change, but it does fix #363.