### PR TITLE
gltfpack: Switch to token-based pool from basis_universal fork

### DIFF
--- a/gltf/gltfpack.cpp
+++ b/gltf/gltfpack.cpp
@@ -459,10 +459,7 @@ static void process(cgltf_data* data, const char* input_path, const char* output
 	{
 		encoded_images.resize(data->images_count);
 
-		for (size_t i = 0; i < data->images_count; ++i)
-			encodeImageAsync(encoded_images[i], data->images[i], images[i], input_path, settings);
-
-		encodeImageWait();
+		encodeImages(encoded_images.data(), data, images, input_path, settings);
 	}
 #endif
 

--- a/gltf/gltfpack.h
+++ b/gltf/gltfpack.h
@@ -296,8 +296,7 @@ bool hasAlpha(const std::string& data, const char* mime_type);
 #ifdef WITH_BASISU
 void encodeBasisInit(int jobs);
 bool encodeBasis(const std::string& data, const char* mime_type, std::string& result, const ImageInfo& info, const Settings& settings);
-void encodeImageAsync(std::string& encoded, const cgltf_image& image, const ImageInfo& info, const char* input_path, const Settings& settings);
-void encodeImageWait();
+void encodeImages(std::string* encoded, const cgltf_data* data, const std::vector<ImageInfo>& images, const char* input_path, const Settings& settings);
 #else
 bool checkBasis(bool verbose);
 bool encodeBasis(const std::string& data, const char* mime_type, std::string& result, const ImageInfo& info, const Settings& settings);


### PR DESCRIPTION
This change builds on top of https://github.com/zeux/basis_universal/commit/3c5d651357e75f854f60aa5a65acda4e79e45148
and merges two pools which results in much better scalability, before
this the CPU utilization of gltfpack on large scenes was ~80% during
texture compression and now it's ~100%.