### PR TITLE
gltfpack: Implement a new setting to limit texture dimensions

### DIFF
--- a/gltf/gltfpack.cpp
+++ b/gltf/gltfpack.cpp
@@ -992,6 +992,12 @@ int gltfpack(const char* input, const char* output, const char* report, Settings
 			return 3;
 		}
 
+		if (settings.texture_limit && !settings.texture_toktx)
+		{
+			fprintf(stderr, "Error: -tl option is only supported by toktx\n");
+			return 3;
+		}
+
 		if (settings.texture_scale < 1 && !settings.texture_toktx)
 		{
 			fprintf(stderr, "Error: -ts option is only supported by toktx\n");
@@ -1304,6 +1310,10 @@ int main(int argc, char** argv)
 		{
 			settings.texture_scale = clamp(float(atof(argv[++i])), 0.f, 1.f);
 		}
+		else if (strcmp(arg, "-tl") == 0 && i + 1 < argc && isdigit(argv[i + 1][0]))
+		{
+			settings.texture_limit = atoi(argv[++i]);
+		}
 		else if (strcmp(arg, "-tp") == 0)
 		{
 			settings.texture_pow2 = true;
@@ -1423,6 +1433,7 @@ int main(int argc, char** argv)
 			fprintf(stderr, "\t-tu: use UASTC when encoding textures (much higher quality and much larger size)\n");
 			fprintf(stderr, "\t-tq N: set texture encoding quality (default: 8; N should be between 1 and 10\n");
 			fprintf(stderr, "\t-ts R: scale texture dimensions by the ratio R (default: 1; R should be between 0 and 1)\n");
+			fprintf(stderr, "\t-tl N: limit texture dimensions to N pixels (default: 0 = no limit)\n");
 			fprintf(stderr, "\t-tp: resize textures to nearest power of 2 to conform to WebGL1 restrictions\n");
 			fprintf(stderr, "\t-tfy: flip textures along Y axis during BasisU supercompression\n");
 			fprintf(stderr, "\t-tj N: use N threads when compressing textures\n");
@@ -1468,6 +1479,18 @@ int main(int argc, char** argv)
 			fprintf(stderr, "\nRun gltfpack -h to display a full list of options\n");
 		}
 
+		return 1;
+	}
+
+	if (settings.texture_limit && !settings.texture_ktx2)
+	{
+		fprintf(stderr, "Option -tl is only supported when -tc is set as well\n");
+		return 1;
+	}
+
+	if (settings.texture_pow2 && (settings.texture_limit & (settings.texture_limit - 1)) != 0)
+	{
+		fprintf(stderr, "Option -tp requires the limit specified via -tl to be a power of 2\n");
 		return 1;
 	}
 

--- a/gltf/gltfpack.h
+++ b/gltf/gltfpack.h
@@ -128,6 +128,7 @@ struct Settings
 	bool texture_pow2;
 	bool texture_flipy;
 	float texture_scale;
+	int texture_limit;
 
 	bool texture_uastc[TextureKind__Count];
 	int texture_quality[TextureKind__Count];

--- a/gltf/image.cpp
+++ b/gltf/image.cpp
@@ -282,7 +282,7 @@ static void adjustDimensions(int& width, int& height, const Settings& settings)
 
 	if (settings.texture_limit && (width > settings.texture_limit || height > settings.texture_limit))
 	{
-		float limit_scale = float(settings.texture_limit) / (width > height ? width : height);
+		float limit_scale = float(settings.texture_limit) / float(width > height ? width : height);
 
 		width = int(width * limit_scale);
 		height = int(height * limit_scale);

--- a/gltf/image.cpp
+++ b/gltf/image.cpp
@@ -275,6 +275,23 @@ static int roundBlock(int value, bool pow2)
 	return (value + 3) & ~3;
 }
 
+static void adjustDimensions(int& width, int& height, const Settings& settings)
+{
+	width = int(width * settings.texture_scale);
+	height = int(height * settings.texture_scale);
+
+	if (settings.texture_limit && (width > settings.texture_limit || height > settings.texture_limit))
+	{
+		float limit_scale = float(settings.texture_limit) / (width > height ? width : height);
+
+		width = int(width * limit_scale);
+		height = int(height * limit_scale);
+	}
+
+	width = roundBlock(width, settings.texture_pow2);
+	height = roundBlock(height, settings.texture_pow2);
+}
+
 #ifdef WITH_BASISU
 bool encodeBasisInternal(const char* input, const char* output, bool yflip, bool normal_map, bool linear, bool uastc, int uastc_l, float uastc_q, int etc1s_l, int etc1s_q, int zstd_l, int width, int height);
 
@@ -295,12 +312,11 @@ bool encodeBasis(const std::string& data, const char* mime_type, std::string& re
 	if (!getDimensions(data, mime_type, width, height))
 		return false;
 
-	int newWidth = roundBlock(int(width * settings.texture_scale), settings.texture_pow2);
-	int newHeight = roundBlock(int(height * settings.texture_scale), settings.texture_pow2);
+	adjustDimensions(width, height, settings);
 
 	int zstd = uastc ? 9 : 0;
 
-	bool ok = encodeBasisInternal(temp_input.path.c_str(), temp_output.path.c_str(), settings.texture_flipy, info.normal_map, !info.srgb, uastc, bs.uastc_l, bs.uastc_q, bs.etc1s_l, bs.etc1s_q, zstd, newWidth, newHeight);
+	bool ok = encodeBasisInternal(temp_input.path.c_str(), temp_output.path.c_str(), settings.texture_flipy, info.normal_map, !info.srgb, uastc, bs.uastc_l, bs.uastc_q, bs.etc1s_l, bs.etc1s_q, zstd, width, height);
 
 	return ok && readFile(temp_output.path.c_str(), result);
 }
@@ -498,8 +514,8 @@ bool encodeKtx(const std::string& data, const char* mime_type, std::string& resu
 	cmd += " --genmipmap";
 	cmd += " --nowarn";
 
-	int newWidth = roundBlock(int(width * settings.texture_scale), settings.texture_pow2);
-	int newHeight = roundBlock(int(height * settings.texture_scale), settings.texture_pow2);
+	int newWidth = width, newHeight = height;
+	adjustDimensions(newWidth, newHeight, settings);
 
 	if (newWidth != width || newHeight != height)
 	{


### PR DESCRIPTION
When -tl is set, we rescale textures so that the maximum dimension is within the
specified limit; the scaling preserves aspect ratio, eg 1000x100 texture gets
rescaled to 128x12 with -tl 128.