### PR TITLE
gltfpack: Implement support for KHR_materials_iridescence

### DIFF
--- a/gltf/gltfpack.cpp
+++ b/gltf/gltfpack.cpp
@@ -433,6 +433,7 @@ static void process(cgltf_data* data, const char* input_path, const char* output
 	bool ext_sheen = false;
 	bool ext_volume = false;
 	bool ext_emissive_strength = false;
+	bool ext_iridescence = false;
 	bool ext_unlit = false;
 	bool ext_instancing = false;
 	bool ext_texture_transform = false;
@@ -532,6 +533,7 @@ static void process(cgltf_data* data, const char* input_path, const char* output
 		ext_sheen = ext_sheen || material.has_sheen;
 		ext_volume = ext_volume || material.has_volume;
 		ext_emissive_strength = ext_emissive_strength || material.has_emissive_strength;
+		ext_iridescence = ext_iridescence || material.has_iridescence;
 		ext_unlit = ext_unlit || material.unlit;
 		ext_texture_transform = ext_texture_transform || mi.usesTextureTransform;
 	}
@@ -809,6 +811,7 @@ static void process(cgltf_data* data, const char* input_path, const char* output
 	    {"KHR_materials_sheen", ext_sheen, false},
 	    {"KHR_materials_volume", ext_volume, false},
 	    {"KHR_materials_emissive_strength", ext_emissive_strength, false},
+	    {"KHR_materials_iridescence", ext_iridescence, false},
 	    {"KHR_materials_unlit", ext_unlit, false},
 	    {"KHR_materials_variants", data->variants_count > 0, false},
 	    {"KHR_lights_punctual", data->lights_count > 0, false},

--- a/gltf/material.cpp
+++ b/gltf/material.cpp
@@ -187,6 +187,29 @@ static bool areMaterialComponentsEqual(const cgltf_emissive_strength& lhs, const
 	return true;
 }
 
+static bool areMaterialComponentsEqual(const cgltf_iridescence& lhs, const cgltf_iridescence& rhs)
+{
+	if (lhs.iridescence_factor != rhs.iridescence_factor)
+		return false;
+
+	if (!areTextureViewsEqual(lhs.iridescence_texture, rhs.iridescence_texture))
+		return false;
+
+	if (lhs.iridescence_ior != rhs.iridescence_ior)
+		return false;
+
+	if (lhs.iridescence_thickness_min != rhs.iridescence_thickness_min)
+		return false;
+
+	if (lhs.iridescence_thickness_max != rhs.iridescence_thickness_max)
+		return false;
+
+	if (!areTextureViewsEqual(lhs.iridescence_thickness_texture, rhs.iridescence_thickness_texture))
+		return false;
+
+	return true;
+}
+
 static bool areMaterialsEqual(cgltf_data* data, const cgltf_material& lhs, const cgltf_material& rhs, const Settings& settings)
 {
 	if (lhs.has_pbr_metallic_roughness != rhs.has_pbr_metallic_roughness)
@@ -241,6 +264,12 @@ static bool areMaterialsEqual(cgltf_data* data, const cgltf_material& lhs, const
 		return false;
 
 	if (lhs.has_emissive_strength && !areMaterialComponentsEqual(lhs.emissive_strength, rhs.emissive_strength))
+		return false;
+
+	if (lhs.has_iridescence != rhs.has_iridescence)
+		return false;
+
+	if (lhs.has_iridescence && !areMaterialComponentsEqual(lhs.iridescence, rhs.iridescence))
 		return false;
 
 	if (!areTextureViewsEqual(lhs.normal_texture, rhs.normal_texture))
@@ -424,6 +453,12 @@ static void analyzeMaterial(const cgltf_material& material, MaterialInfo& mi, cg
 	if (material.has_volume)
 	{
 		analyzeMaterialTexture(material.volume.thickness_texture, TextureKind_Attrib, mi, data, images);
+	}
+
+	if (material.has_iridescence)
+	{
+		analyzeMaterialTexture(material.iridescence.iridescence_texture, TextureKind_Attrib, mi, data, images);
+		analyzeMaterialTexture(material.iridescence.iridescence_thickness_texture, TextureKind_Attrib, mi, data, images);
 	}
 
 	analyzeMaterialTexture(material.normal_texture, TextureKind_Normal, mi, data, images);

--- a/gltf/write.cpp
+++ b/gltf/write.cpp
@@ -511,6 +511,49 @@ static void writeMaterialComponent(std::string& json, const cgltf_data* data, co
 	append(json, "}");
 }
 
+static void writeMaterialComponent(std::string& json, const cgltf_data* data, const cgltf_iridescence& tm, const QuantizationTexture* qt)
+{
+	comma(json);
+	append(json, "\"KHR_materials_iridescence\":{");
+	if (tm.iridescence_factor != 0)
+	{
+		comma(json);
+		append(json, "\"iridescenceFactor\":");
+		append(json, tm.iridescence_factor);
+	}
+	if (tm.iridescence_texture.texture)
+	{
+		comma(json);
+		append(json, "\"iridescenceTexture\":");
+		writeTextureInfo(json, data, tm.iridescence_texture, qt);
+	}
+	if (tm.iridescence_ior != 1.3f)
+	{
+		comma(json);
+		append(json, "\"iridescenceIor\":");
+		append(json, tm.iridescence_ior);
+	}
+	if (tm.iridescence_thickness_min != 100.f)
+	{
+		comma(json);
+		append(json, "\"iridescenceThicknessMinimum\":");
+		append(json, tm.iridescence_thickness_min);
+	}
+	if (tm.iridescence_thickness_max != 400.f)
+	{
+		comma(json);
+		append(json, "\"iridescenceThicknessMaximum\":");
+		append(json, tm.iridescence_thickness_max);
+	}
+	if (tm.iridescence_thickness_texture.texture)
+	{
+		comma(json);
+		append(json, "\"iridescenceThicknessTexture\":");
+		writeTextureInfo(json, data, tm.iridescence_thickness_texture, qt);
+	}
+	append(json, "}");
+}
+
 void writeMaterial(std::string& json, const cgltf_data* data, const cgltf_material& material, const QuantizationPosition* qp, const QuantizationTexture* qt)
 {
 	if (material.name && *material.name)
@@ -580,7 +623,7 @@ void writeMaterial(std::string& json, const cgltf_data* data, const cgltf_materi
 		append(json, "\"doubleSided\":true");
 	}
 
-	if (material.has_pbr_specular_glossiness || material.has_clearcoat || material.has_transmission || material.has_ior || material.has_specular || material.has_sheen || material.has_volume || material.has_emissive_strength || material.unlit)
+	if (material.has_pbr_specular_glossiness || material.has_clearcoat || material.has_transmission || material.has_ior || material.has_specular || material.has_sheen || material.has_volume || material.has_emissive_strength || material.has_iridescence || material.unlit)
 	{
 		comma(json);
 		append(json, "\"extensions\":{");
@@ -623,6 +666,11 @@ void writeMaterial(std::string& json, const cgltf_data* data, const cgltf_materi
 		if (material.has_emissive_strength)
 		{
 			writeMaterialComponent(json, data, material.emissive_strength);
+		}
+
+		if (material.has_iridescence)
+		{
+			writeMaterialComponent(json, data, material.iridescence, qt);
 		}
 
 		if (material.unlit)


### PR DESCRIPTION
The extension is effectively finalized and unlikely to change at this point.

Spec: https://github.com/KhronosGroup/glTF/pull/2027