### PR TITLE
gltfpack: Stop supporting texture compression via external executables

### DIFF
--- a/gltf/README.md
+++ b/gltf/README.md
@@ -4,11 +4,7 @@ gltfpack is a tool that can automatically optimize glTF files to reduce the down
 
 ## Installation
 
-You can download a pre-built binary for gltfpack on [Releases page](https://github.com/zeux/meshoptimizer/releases), or install [npm package](https://www.npmjs.com/package/gltfpack) as follows:
-
-```
-npm install -g gltfpack
-```
+You can download a pre-built binary for gltfpack on [Releases page](https://github.com/zeux/meshoptimizer/releases), or install [npm package](https://www.npmjs.com/package/gltfpack). Native binaries are recommended over npm since they can work with larger files, run faster, and support texture compression.
 
 ## Usage
 

--- a/gltf/basisenc.cpp
+++ b/gltf/basisenc.cpp
@@ -60,7 +60,7 @@ static bool encodeInternal(const char* input, const char* output, bool yflip, bo
 
 	if (uastc)
 	{
-		static const uint32_t s_level_flags[TOTAL_PACK_UASTC_LEVELS] = { cPackUASTCLevelFastest, cPackUASTCLevelFaster, cPackUASTCLevelDefault, cPackUASTCLevelSlower, cPackUASTCLevelVerySlow };
+		static const uint32_t s_level_flags[TOTAL_PACK_UASTC_LEVELS] = {cPackUASTCLevelFastest, cPackUASTCLevelFaster, cPackUASTCLevelDefault, cPackUASTCLevelSlower, cPackUASTCLevelVerySlow};
 
 		params.m_uastc = true;
 

--- a/gltf/basislib.cpp
+++ b/gltf/basislib.cpp
@@ -22,7 +22,7 @@
 #endif
 
 #ifdef _MSC_VER
-#pragma warning(disable: 4702) // unreachable code
+#pragma warning(disable : 4702) // unreachable code
 #endif
 
 #define BASISU_NO_ITERATOR_DEBUG_LEVEL
@@ -35,23 +35,23 @@
 #define BASISU_SUPPORT_SSE 1
 #endif
 
-#include "encoder/basisu_etc.cpp"
-#include "encoder/basisu_resample_filters.cpp"
 #include "encoder/basisu_backend.cpp"
-#include "encoder/basisu_frontend.cpp"
-#include "encoder/basisu_resampler.cpp"
 #include "encoder/basisu_basis_file.cpp"
 #include "encoder/basisu_bc7enc.cpp"
-#include "encoder/basisu_ssim.cpp"
-#include "encoder/basisu_gpu_texture.cpp"
-#include "encoder/basisu_uastc_enc.cpp"
 #include "encoder/basisu_comp.cpp"
+#include "encoder/basisu_enc.cpp"
+#include "encoder/basisu_etc.cpp"
+#include "encoder/basisu_frontend.cpp"
+#include "encoder/basisu_gpu_texture.cpp"
 #include "encoder/basisu_kernels_sse.cpp"
 #include "encoder/basisu_opencl.cpp"
+#include "encoder/basisu_pvrtc1_4.cpp"
+#include "encoder/basisu_resample_filters.cpp"
+#include "encoder/basisu_resampler.cpp"
+#include "encoder/basisu_ssim.cpp"
+#include "encoder/basisu_uastc_enc.cpp"
 #include "encoder/jpgd.cpp"
 #include "encoder/pvpngreader.cpp"
-#include "encoder/basisu_enc.cpp"
-#include "encoder/basisu_pvrtc1_4.cpp"
 #include "transcoder/basisu_transcoder.cpp"
 
 #undef CLAMP

--- a/gltf/basislib.cpp
+++ b/gltf/basislib.cpp
@@ -23,6 +23,7 @@
 
 #ifdef _MSC_VER
 #pragma warning(disable : 4702) // unreachable code
+#pragma warning(disable : 4005) // macro redefinition
 #endif
 
 #define BASISU_NO_ITERATOR_DEBUG_LEVEL
@@ -33,6 +34,11 @@
 
 #if defined(__SSE4_1__)
 #define BASISU_SUPPORT_SSE 1
+#endif
+
+#ifdef _WIN32
+#define WIN32_LEAN_AND_MEAN
+#define NOMINMAX
 #endif
 
 #include "encoder/basisu_backend.cpp"

--- a/gltf/basislib.cpp
+++ b/gltf/basislib.cpp
@@ -18,6 +18,7 @@
 #pragma GCC diagnostic ignored "-Wunused-variable"
 #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
 #pragma GCC diagnostic ignored "-Wstrict-aliasing" // TODO: https://github.com/BinomialLLC/basis_universal/pull/275
+#pragma GCC diagnostic ignored "-Wstringop-overflow"
 #endif
 
 #ifdef _MSC_VER

--- a/gltf/cli.js
+++ b/gltf/cli.js
@@ -3,14 +3,8 @@
 var gltfpack = require('./library.js');
 
 var fs = require('fs');
-var cp = require('child_process');
 
 var args = process.argv.slice(2);
-
-var paths = {
-	"basisu": process.env["BASISU_PATH"],
-	"toktx": process.env["TOKTX_PATH"],
-};
 
 var interface = {
 	read: function (path) {
@@ -18,19 +12,6 @@ var interface = {
 	},
 	write: function (path, data) {
 		fs.writeFileSync(path, data);
-	},
-	execute: function (command) {
-		var arg = command.split(' ');
-		var exe = arg.shift();
-
-		// perform substitution of command executable with environment-specific paths
-		exe = paths[exe] || exe;
-
-		var ret = cp.spawnSync(exe, arg);
-		return ret.status == null ? 256 : ret.status;
-	},
-	unlink: function (path) {
-		fs.unlinkSync(path);
 	},
 };
 

--- a/gltf/gltfpack.cpp
+++ b/gltf/gltfpack.cpp
@@ -468,16 +468,6 @@ static void process(cgltf_data* data, const char* input_path, const char* output
 	{
 		const cgltf_image& image = data->images[i];
 
-#ifndef WITH_BASISU
-		if (settings.verbose == 1 && settings.texture_ktx2)
-		{
-			const char* uri = image.uri;
-			bool embedded = !uri || strncmp(uri, "data:", 5) == 0;
-
-			printf("image %d (%s) is being encoded with %s\n", int(i), embedded ? "embedded" : uri, settings.texture_toktx ? "toktx" : "basisu");
-		}
-#endif
-
 		comma(json_images);
 		append(json_images, "{");
 		if (encoded_images.size())
@@ -491,7 +481,7 @@ static void process(cgltf_data* data, const char* input_path, const char* output
 		}
 		else
 		{
-			writeImage(json_images, views, image, images[i], i, input_path, output_path, settings);
+			writeImage(json_images, views, image, images[i], i, input_path, settings);
 		}
 		append(json_images, "}");
 	}
@@ -984,34 +974,11 @@ int gltfpack(const char* input, const char* output, const char* report, Settings
 #ifndef WITH_BASISU
 	if (data->images_count && settings.texture_ktx2)
 	{
-		if (checkKtx(settings.verbose > 1))
-		{
-			settings.texture_toktx = true;
-		}
-		else if (!checkBasis(settings.verbose > 1))
-		{
-			fprintf(stderr, "Error: toktx is not present in PATH or TOKTX_PATH is not set\n");
-			fprintf(stderr, "Note: toktx must be installed manually from https://github.com/KhronosGroup/KTX-Software/releases\n");
-			return 3;
-		}
-
-		if (settings.texture_limit && !settings.texture_toktx)
-		{
-			fprintf(stderr, "Error: -tl option is only supported by toktx\n");
-			return 3;
-		}
-
-		if (settings.texture_scale < 1 && !settings.texture_toktx)
-		{
-			fprintf(stderr, "Error: -ts option is only supported by toktx\n");
-			return 3;
-		}
-
-		if (settings.texture_pow2 && !settings.texture_toktx)
-		{
-			fprintf(stderr, "Error: -tp option is only supported by toktx\n");
-			return 3;
-		}
+		fprintf(stderr, "Error: gltfpack was built without BasisU support, texture compression is not available\n");
+#ifdef __wasi__
+		fprintf(stderr, "Note: node.js builds do not support BasisU due to lack of platform features; download a native build from https://github.com/zeux/meshoptimizer/releases\n");
+#endif
+		return 3;
 	}
 #endif
 

--- a/gltf/gltfpack.cpp
+++ b/gltf/gltfpack.cpp
@@ -1371,7 +1371,7 @@ int main(int argc, char** argv)
 
 #ifdef WITH_BASISU
 	if (settings.texture_ktx2)
-		encodeBasisInit(settings.texture_jobs);
+		encodeInit(settings.texture_jobs);
 #endif
 
 	if (test)

--- a/gltf/gltfpack.h
+++ b/gltf/gltfpack.h
@@ -123,7 +123,6 @@ struct Settings
 
 	bool texture_ktx2;
 	bool texture_embed;
-	bool texture_toktx;
 
 	bool texture_pow2;
 	bool texture_flipy;
@@ -293,16 +292,12 @@ void optimizeMaterials(cgltf_data* data, const char* input_path, std::vector<Ima
 
 bool readImage(const cgltf_image& image, const char* input_path, std::string& data, std::string& mime_type);
 bool hasAlpha(const std::string& data, const char* mime_type);
+bool getDimensions(const std::string& data, const char* mime_type, int& width, int& height);
 
 #ifdef WITH_BASISU
 void encodeBasisInit(int jobs);
 bool encodeBasis(const std::string& data, const char* mime_type, std::string& result, const ImageInfo& info, const Settings& settings);
 void encodeImages(std::string* encoded, const cgltf_data* data, const std::vector<ImageInfo>& images, const char* input_path, const Settings& settings);
-#else
-bool checkBasis(bool verbose);
-bool encodeBasis(const std::string& data, const char* mime_type, std::string& result, const ImageInfo& info, const Settings& settings);
-bool checkKtx(bool verbose);
-bool encodeKtx(const std::string& data, const char* mime_type, std::string& result, const ImageInfo& info, const Settings& settings);
 #endif
 
 void markScenes(cgltf_data* data, std::vector<NodeInfo>& nodes);
@@ -339,7 +334,7 @@ const char* animationPath(cgltf_animation_path_type type);
 void writeMaterial(std::string& json, const cgltf_data* data, const cgltf_material& material, const QuantizationPosition* qp, const QuantizationTexture* qt);
 void writeBufferView(std::string& json, BufferView::Kind kind, StreamFormat::Filter filter, size_t count, size_t stride, size_t bin_offset, size_t bin_size, BufferView::Compression compression, size_t compressed_offset, size_t compressed_size);
 void writeSampler(std::string& json, const cgltf_sampler& sampler);
-void writeImage(std::string& json, std::vector<BufferView>& views, const cgltf_image& image, const ImageInfo& info, size_t index, const char* input_path, const char* output_path, const Settings& settings);
+void writeImage(std::string& json, std::vector<BufferView>& views, const cgltf_image& image, const ImageInfo& info, size_t index, const char* input_path, const Settings& settings);
 void writeEncodedImage(std::string& json, std::vector<BufferView>& views, const cgltf_image& image, const std::string& encoded, const ImageInfo& info, const char* output_path, const Settings& settings);
 void writeTexture(std::string& json, const cgltf_texture& texture, cgltf_data* data, const Settings& settings);
 void writeMeshAttributes(std::string& json, std::vector<BufferView>& views, std::string& json_accessors, size_t& accr_offset, const Mesh& mesh, int target, const QuantizationPosition& qp, const QuantizationTexture& qt, const Settings& settings);

--- a/gltf/gltfpack.h
+++ b/gltf/gltfpack.h
@@ -293,9 +293,11 @@ void optimizeMaterials(cgltf_data* data, const char* input_path, std::vector<Ima
 bool readImage(const cgltf_image& image, const char* input_path, std::string& data, std::string& mime_type);
 bool hasAlpha(const std::string& data, const char* mime_type);
 bool getDimensions(const std::string& data, const char* mime_type, int& width, int& height);
+void adjustDimensions(int& width, int& height, const Settings& settings);
+const char* mimeExtension(const char* mime_type);
 
 #ifdef WITH_BASISU
-void encodeBasisInit(int jobs);
+void encodeInit(int jobs);
 bool encodeBasis(const std::string& data, const char* mime_type, std::string& result, const ImageInfo& info, const Settings& settings);
 void encodeImages(std::string* encoded, const cgltf_data* data, const std::vector<ImageInfo>& images, const char* input_path, const Settings& settings);
 #endif

--- a/gltf/image.cpp
+++ b/gltf/image.cpp
@@ -1,8 +1,6 @@
 // This file is part of gltfpack; see gltfpack.h for version/license details
 #include "gltfpack.h"
 
-#include <stdio.h>
-#include <stdlib.h>
 #include <string.h>
 
 #include <functional>
@@ -231,16 +229,7 @@ bool hasAlpha(const std::string& data, const char* mime_type)
 		return false;
 }
 
-static const char* mimeExtension(const char* mime_type)
-{
-	for (size_t i = 0; i < sizeof(kMimeTypes) / sizeof(kMimeTypes[0]); ++i)
-		if (strcmp(kMimeTypes[i][0], mime_type) == 0)
-			return kMimeTypes[i][1];
-
-	return ".raw";
-}
-
-static bool getDimensions(const std::string& data, const char* mime_type, int& width, int& height)
+bool getDimensions(const std::string& data, const char* mime_type, int& width, int& height)
 {
 	if (strcmp(mime_type, "image/png") == 0)
 		return getDimensionsPng(data, width, height);
@@ -250,6 +239,7 @@ static bool getDimensions(const std::string& data, const char* mime_type, int& w
 	return false;
 }
 
+#ifdef WITH_BASISU
 static int roundPow2(int value)
 {
 	int result = 1;
@@ -292,7 +282,15 @@ static void adjustDimensions(int& width, int& height, const Settings& settings)
 	height = roundBlock(height, settings.texture_pow2);
 }
 
-#ifdef WITH_BASISU
+static const char* mimeExtension(const char* mime_type)
+{
+	for (size_t i = 0; i < sizeof(kMimeTypes) / sizeof(kMimeTypes[0]); ++i)
+		if (strcmp(kMimeTypes[i][0], mime_type) == 0)
+			return kMimeTypes[i][1];
+
+	return ".raw";
+}
+
 bool encodeBasisInternal(const char* input, const char* output, bool yflip, bool normal_map, bool linear, bool uastc, int uastc_l, float uastc_q, int etc1s_l, int etc1s_q, int zstd_l, int width, int height);
 
 bool encodeBasis(const std::string& data, const char* mime_type, std::string& result, const ImageInfo& info, const Settings& settings)
@@ -348,231 +346,3 @@ void encodeImages(std::string* encoded, const cgltf_data* data, const std::vecto
 	encodeWait();
 }
 #endif
-
-// All code below relies on command-line execution of basisu or toktx
-#ifndef WITH_BASISU
-
-#ifdef __wasi__
-static int execute(const char* cmd, bool ignore_stdout, bool ignore_stderr)
-{
-	return system(cmd);
-}
-
-static std::string getExecutable(const char* name, const char* env)
-{
-	return name;
-}
-#else
-static int execute(const char* cmd_, bool ignore_stdout, bool ignore_stderr)
-{
-#ifdef _WIN32
-	std::string ignore = "nul";
-#else
-	std::string ignore = "/dev/null";
-#endif
-
-	std::string cmd = cmd_;
-
-	if (ignore_stdout)
-		(cmd += " >") += ignore;
-	if (ignore_stderr)
-		(cmd += " 2>") += ignore;
-
-	return system(cmd.c_str());
-}
-
-static std::string getExecutable(const char* name, const char* env)
-{
-	const char* path = getenv(env);
-	path = path ? path : name;
-
-#ifdef _WIN32
-	// when the executable path contains a space, we need to quote the path ourselves
-	if (path[0] != '"' && strchr(path, ' '))
-		return '"' + std::string(path) + '"';
-#endif
-
-	return path;
-}
-#endif
-
-bool checkBasis(bool verbose)
-{
-	std::string cmd = getExecutable("basisu", "BASISU_PATH");
-
-	cmd += " -version";
-
-	int rc = execute(cmd.c_str(), /* ignore_stdout= */ !verbose, /* ignore_stderr= */ !verbose);
-	if (verbose)
-		printf("%s => %d\n", cmd.c_str(), rc);
-
-	return rc == 0;
-}
-
-bool encodeBasis(const std::string& data, const char* mime_type, std::string& result, const ImageInfo& info, const Settings& settings)
-{
-	TempFile temp_input(mimeExtension(mime_type));
-	TempFile temp_output(".ktx2");
-
-	if (!writeFile(temp_input.path.c_str(), data))
-		return false;
-
-	int quality = settings.texture_quality[info.kind];
-	bool uastc = settings.texture_uastc[info.kind];
-
-	const BasisSettings& bs = kBasisSettings[quality - 1];
-
-	// TODO: Support texture_scale and texture_pow2 via new -resample switch from https://github.com/BinomialLLC/basis_universal/pull/226
-	std::string cmd = getExecutable("basisu", "BASISU_PATH");
-
-	cmd += " -mipmap";
-
-	if (settings.texture_flipy)
-		cmd += " -y_flip";
-
-	if (info.normal_map)
-	{
-		cmd += " -normal_map";
-		// for optimal quality we should specify seperate_rg_to_color_alpha but this requires renderer awareness
-	}
-	else if (!info.srgb)
-	{
-		cmd += " -linear";
-	}
-
-	if (uastc)
-	{
-		char cs[128];
-		sprintf(cs, " -uastc_level %d -uastc_rdo_l %.2f", bs.uastc_l, bs.uastc_q);
-
-		cmd += " -uastc";
-		cmd += cs;
-		cmd += " -uastc_rdo_d 1024";
-	}
-	else
-	{
-		char cs[128];
-		sprintf(cs, " -comp_level %d -q %d", bs.etc1s_l, bs.etc1s_q);
-
-		cmd += cs;
-	}
-
-	cmd += " -ktx2";
-
-	if (uastc)
-		cmd += " -ktx2_zstandard_level 9";
-
-	if (settings.texture_jobs == 1)
-		cmd += " -no_multithreading";
-
-	cmd += " -file ";
-	cmd += temp_input.path;
-	cmd += " -output_file ";
-	cmd += temp_output.path;
-
-	int rc = execute(cmd.c_str(), /* ignore_stdout= */ true, /* ignore_stderr= */ false);
-	if (settings.verbose > 1)
-		printf("%s => %d\n", cmd.c_str(), rc);
-
-	return rc == 0 && readFile(temp_output.path.c_str(), result);
-}
-
-bool checkKtx(bool verbose)
-{
-	std::string cmd = getExecutable("toktx", "TOKTX_PATH");
-
-	cmd += " --version";
-
-	int rc = execute(cmd.c_str(), /* ignore_stdout= */ !verbose, /* ignore_stderr= */ !verbose);
-	if (verbose)
-		printf("%s => %d\n", cmd.c_str(), rc);
-
-	return rc == 0;
-}
-
-bool encodeKtx(const std::string& data, const char* mime_type, std::string& result, const ImageInfo& info, const Settings& settings)
-{
-	int width = 0, height = 0;
-	if (!getDimensions(data, mime_type, width, height))
-		return false;
-
-	TempFile temp_input(mimeExtension(mime_type));
-	TempFile temp_output(".ktx2");
-
-	if (!writeFile(temp_input.path.c_str(), data))
-		return false;
-
-	std::string cmd = getExecutable("toktx", "TOKTX_PATH");
-
-	int quality = settings.texture_quality[info.kind];
-	bool uastc = settings.texture_uastc[info.kind];
-
-	const BasisSettings& bs = kBasisSettings[quality - 1];
-
-	cmd += " --t2";
-	cmd += " --2d";
-	cmd += " --genmipmap";
-	cmd += " --nowarn";
-
-	int newWidth = width, newHeight = height;
-	adjustDimensions(newWidth, newHeight, settings);
-
-	if (newWidth != width || newHeight != height)
-	{
-		char wh[128];
-		sprintf(wh, " --resize %dx%d", newWidth, newHeight);
-		cmd += wh;
-	}
-
-	if (settings.texture_flipy)
-		cmd += " --lower_left_maps_to_s0t0";
-
-	if (uastc)
-	{
-		char cs[128];
-		sprintf(cs, " %d --uastc_rdo_l %.2f", bs.uastc_l, bs.uastc_q);
-
-		cmd += " --uastc";
-		cmd += cs;
-		cmd += " --uastc_rdo_d 1024";
-		cmd += " --zcmp 9";
-	}
-	else
-	{
-		char cs[128];
-		sprintf(cs, " --clevel %d --qlevel %d", bs.etc1s_l, bs.etc1s_q);
-
-		cmd += " --bcmp";
-		cmd += cs;
-
-		// for optimal quality we should specify separate_rg_to_color_alpha but this requires renderer awareness
-		if (info.normal_map)
-			cmd += " --normal_map";
-	}
-
-	if (info.srgb)
-		cmd += " --srgb";
-	else
-		cmd += " --linear";
-
-	if (settings.texture_jobs)
-	{
-		char cs[128];
-		sprintf(cs, " --threads %d", settings.texture_jobs);
-
-		cmd += cs;
-	}
-
-	cmd += " -- ";
-	cmd += temp_output.path;
-	cmd += " ";
-	cmd += temp_input.path;
-
-	int rc = execute(cmd.c_str(), /* ignore_stdout= */ false, /* ignore_stderr= */ false);
-	if (settings.verbose > 1)
-		printf("%s => %d\n", cmd.c_str(), rc);
-
-	return rc == 0 && readFile(temp_output.path.c_str(), result);
-}
-
-#endif // !WITH_BASISU

--- a/gltf/library.js
+++ b/gltf/library.js
@@ -32,10 +32,6 @@ function init(wasm) {
  * iface should contain the following methods:
  * read(path): Given a path, return a Uint8Array with the contents of that path
  * write(path, data): Write the specified Uint8Array to the provided path
- *
- * When texture compression is requested using external compressor such as toktx, iface must provide two additional methods:
- * execute(command): Run the requested command and return the return code
- * unlink(path): Remove the requested file (will be called with paths to temp files after texture compression finishes)
  */
 function pack(args, iface) {
 	if (!ready) {
@@ -152,22 +148,6 @@ var wasi = {
 
 		heap.setUint32(opened_fd, fd, true);
 		return 0;
-	},
-
-	path_unlink_file: function(parent_fd, path, path_len) {
-		if (!fds[parent_fd] || fds[parent_fd].path === undefined) {
-			return WASI_EBADF;
-		}
-
-		var heap = getHeap();
-		var name = fds[parent_fd].path + getString(heap.buffer, path, path_len);
-
-		try {
-			interface.unlink(name);
-			return 0;
-		} catch (err) {
-			return WASI_EIO;
-		}
 	},
 
 	path_filestat_get: function(parent_fd, flags, path, path_len, buf) {
@@ -307,21 +287,6 @@ var wasi = {
 
 		heap.setUint32(nwritten, written, true);
 		return 0;
-	},
-
-	path_readlink: function(fd, path, path_len, buf, buf_len, bufused) {
-		if (fd !== -1) {
-			return WASI_ENOSYS;
-		}
-
-		var heap = getHeap();
-		var command = getString(heap.buffer, path, path_len);
-
-		try {
-			return interface.execute(command);
-		} catch (err) {
-			return WASI_ENOSYS;
-		}
 	},
 };
 

--- a/gltf/wasistubs.cpp
+++ b/gltf/wasistubs.cpp
@@ -42,11 +42,4 @@ extern "C" int32_t __imported_wasi_snapshot_preview1_clock_time_get(int32_t arg0
 	return __WASI_ERRNO_NOSYS;
 }
 
-extern "C" int system(const char* command)
-{
-	// WASI doesn't provide a system() equivalent; we highjack readlink here, the reasoning being that if we run against a real WASI implementation,
-	// the effect is more likely to be benign.
-	return __wasi_path_readlink(-1, command, 0, 0, 0);
-}
-
 #endif

--- a/gltf/write.cpp
+++ b/gltf/write.cpp
@@ -849,7 +849,7 @@ void writeSampler(std::string& json, const cgltf_sampler& sampler)
 	}
 }
 
-void writeImage(std::string& json, std::vector<BufferView>& views, const cgltf_image& image, const ImageInfo& info, size_t index, const char* input_path, const char* output_path, const Settings& settings)
+void writeImage(std::string& json, std::vector<BufferView>& views, const cgltf_image& image, const ImageInfo& info, size_t index, const char* input_path, const Settings& settings)
 {
 	bool dataUri = image.uri && strncmp(image.uri, "data:", 5) == 0;
 
@@ -870,29 +870,7 @@ void writeImage(std::string& json, std::vector<BufferView>& views, const cgltf_i
 		return;
 	}
 
-#ifdef WITH_BASISU
-	bool (*encode)(const std::string& data, const char* mime_type, std::string& result, const ImageInfo& info, const Settings& settings) = encodeBasis;
-#else
-	bool (*encode)(const std::string& data, const char* mime_type, std::string& result, const ImageInfo& info, const Settings& settings) = settings.texture_toktx ? encodeKtx : encodeBasis;
-#endif
-
-	if (settings.texture_ktx2)
-	{
-		std::string encoded;
-
-		if (encode(img_data, mime_type.c_str(), encoded, info, settings))
-		{
-			writeEncodedImage(json, views, image, encoded, info, output_path, settings);
-		}
-		else
-		{
-			fprintf(stderr, "Warning: unable to encode image %d, skipping\n", int(index));
-		}
-	}
-	else
-	{
-		writeEmbeddedImage(json, views, img_data.c_str(), img_data.size(), mime_type.c_str(), info.kind);
-	}
+	writeEmbeddedImage(json, views, img_data.c_str(), img_data.size(), mime_type.c_str(), info.kind);
 }
 
 void writeEncodedImage(std::string& json, std::vector<BufferView>& views, const cgltf_image& image, const std::string& encoded, const ImageInfo& info, const char* output_path, const Settings& settings)


### PR DESCRIPTION
The rationale for this is described in #418. At this point builtin support for BasisU compression is superior in terms of ease of distribution and performance, and the maintenance burden of executable-assisted compression is too high.

The most notable change here is that gltfpack loses support for texture compression from node.js builds. When texture compression is required, using a native build of gltfpack fixes this and provides greater performance over currently available options anyway.

Fixes #418.