### PR TITLE
simplify: Fix classification around degenerate triangles

### DIFF
--- a/demo/tests.cpp
+++ b/demo/tests.cpp
@@ -952,6 +952,39 @@ static void simplifyScale()
 	assert(meshopt_simplifyScale(vb, 4, 12) == 3.f);
 }
 
+static void simplifyDegenerate()
+{
+	float vb[] = {
+	    0.000000f, 0.000000f, 0.000000f,
+	    0.000000f, 1.000000f, 0.000000f,
+	    0.000000f, 2.000000f, 0.000000f,
+	    1.000000f, 0.000000f, 0.000000f,
+	    2.000000f, 0.000000f, 0.000000f,
+	    1.000000f, 1.000000f, 0.000000f, // clang-format :-/
+	};
+
+	// 0 1 2
+	// 3 5
+	// 4
+
+	unsigned int ib[] = {
+	    0, 1, 3,
+	    3, 1, 5,
+	    1, 2, 5,
+	    3, 5, 4,
+	    1, 0, 1, // these two degenerate triangles create a fake reverse edge
+	    0, 3, 0, // which breaks border classification
+	};
+
+	unsigned int expected[] = {
+		0, 1, 4,
+		4, 1, 2, // clang-format :-/
+	};
+
+	assert(meshopt_simplify(ib, ib, 18, vb, 6, 12, 3, 1e-3f) == 6);
+	assert(memcmp(ib, expected, sizeof(expected)) == 0);
+}
+
 static void adjacency()
 {
 	// 0 1/4
@@ -1064,6 +1097,7 @@ void runTests()
 	simplifyPointsStuck();
 	simplifyFlip();
 	simplifyScale();
+	simplifyDegenerate();
 
 	adjacency();
 	tessellation();

--- a/src/simplifier.cpp
+++ b/src/simplifier.cpp
@@ -274,7 +274,15 @@ static void classifyVertices(unsigned char* result, unsigned int* loop, unsigned
 		{
 			unsigned int target = edges[j].next;
 
-			if (!hasEdge(adjacency, target, vertex))
+			if (target == vertex)
+			{
+				// degenerate triangles have two distinct edges instead of three, and the self edge
+				// is bi-directional by definition; this can break border/seam classification by "closing"
+				// the open edge from another triangle and falsely marking the vertex as manifold
+				// instead we mark the vertex as having >1 open edges which turns it into locked/complex
+				openinc[vertex] = openout[vertex] = vertex;
+			}
+			else if (!hasEdge(adjacency, target, vertex))
 			{
 				openinc[target] = (openinc[target] == ~0u) ? vertex : target;
 				openout[vertex] = (openout[vertex] == ~0u) ? target : vertex;


### PR DESCRIPTION
When a triangle is topologically degenerate, it has three edges, two of them
degenerate and one normal. The normal edge can close an adjacent open edge.
Normally this is fine because the extra two edges extend the boundary for
topological analysis, but when the extra two edges are degenerate, they are
considered closed by definition, as such degenerate triangles around borders
or seams may result in classifying some of the vertices as manifold.

This can be solved by pruning degenerate triangles during updateEdgeAdjacency,
but for now this change suggests a simpler fix that effectively locks the
degenerate vertex.

Fixes #312.