### PR TITLE
Add LICENSE.md to npm packages

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -111,18 +111,6 @@ jobs:
         wc -c pirate.glb pirate-repack.glb
         node js/meshopt_decoder.test.js
         node js/meshopt_encoder.test.js
-    - name: npm pack
-      run: |
-        cd gltf && npm pack && cd ..
-        cd js && npm pack && cd ..
-    - uses: actions/upload-artifact@v2
-      with:
-        name: gltfpack-npm
-        path: gltf/gltfpack-*.tgz
-    - uses: actions/upload-artifact@v2
-      with:
-        name: meshoptimizer-npm
-        path: js/meshoptimizer-*.tgz
 
   arm64:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,3 +34,39 @@ jobs:
         name: gltfpack-${{matrix.os}}
         path: gltfpack
       if: matrix.os != 'windows'
+
+  nodejs:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - uses: actions/setup-node@v1
+      with:
+        node-version: '14.x'
+    - name: install wasi
+      run: |
+        curl -sL https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-$VERSION/wasi-sdk-$VERSION.0-linux.tar.gz | tar xz
+        curl -sL https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-$VERSION/libclang_rt.builtins-wasm32-wasi-$VERSION.0.tar.gz | tar xz -C wasi-sdk-$VERSION.0
+        curl -sL https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-$VERSION/wasi-sysroot-$VERSION.0.tar.gz | tar xz
+        mv wasi-sdk-$VERSION.0 wasi-sdk
+      env:
+        VERSION: 16
+    - name: build
+      run: |
+        make -B WASMCC=wasi-sdk/bin/clang++ WASI_SDK=./wasi-sysroot gltf/library.wasm
+        make -B WASMCC=wasi-sdk/bin/clang++ WASI_SDK=./wasi-sysroot js/meshopt_decoder.js js/meshopt_decoder.module.js
+        make -B WASMCC=wasi-sdk/bin/clang++ WASI_SDK=./wasi-sysroot js/meshopt_encoder.js js/meshopt_encoder.module.js
+        git status
+    - name: npm pack
+      run: |
+        cp LICENSE.md gltf/
+        cp LICENSE.md js/
+        cd gltf && npm pack && cd ..
+        cd js && npm pack && cd ..
+    - uses: actions/upload-artifact@v2
+      with:
+        name: gltfpack-npm
+        path: gltf/gltfpack-*.tgz
+    - uses: actions/upload-artifact@v2
+      with:
+        name: meshoptimizer-npm
+        path: js/meshoptimizer-*.tgz


### PR DESCRIPTION
Unfortunately npm doesn't seem to allow using external files as part of
the package, so we need to copy the file into the folders before
building, which makes it so that npm picks it up.

This change also moves the build actions that actually produce NPM
artifacts to release workflow to more cleanly isolate that from
build/test.

Fixes #434.