### PR TITLE
gltfpack: Support partial texture compression with -tc

### DIFF
--- a/gltf/basisenc.cpp
+++ b/gltf/basisenc.cpp
@@ -128,7 +128,7 @@ static bool encodeImage(const std::string& data, const char* mime_type, std::str
 		return false;
 
 	int quality = settings.texture_quality[info.kind];
-	bool uastc = settings.texture_uastc[info.kind];
+	bool uastc = settings.texture_mode[info.kind] == TextureMode_UASTC;
 
 	const BasisSettings& bs = kBasisSettings[quality - 1];
 
@@ -154,7 +154,10 @@ void encodeImages(std::string* encoded, const cgltf_data* data, const std::vecto
 		const cgltf_image& image = data->images[i];
 		ImageInfo info = images[i];
 
-		encoded[i].clear();
+		if (settings.texture_mode[info.kind] == TextureMode_Raw)
+			continue;
+
+		encoded[i] = "ERROR:";
 
 		gJobPool->add_job([=]() {
 			std::string img_data;

--- a/gltf/gltfpack.cpp
+++ b/gltf/gltfpack.cpp
@@ -470,10 +470,10 @@ static void process(cgltf_data* data, const char* input_path, const char* output
 
 		comma(json_images);
 		append(json_images, "{");
-		if (encoded_images.size())
+		if (encoded_images.size() && !encoded_images[i].empty())
 		{
-			if (encoded_images[i].empty())
-				fprintf(stderr, "Warning: unable to encode image %d (%s), skipping\n", int(i), image.uri ? image.uri : "?");
+			if (encoded_images[i].compare(0, 6, "ERROR:") == 0)
+				fprintf(stderr, "Warning: unable to encode image %d (%s), skipping (%s)\n", int(i), image.uri ? image.uri : "?", encoded_images[i].c_str() + 6);
 			else
 				writeEncodedImage(json_images, views, image, encoded_images[i], images[i], output_path, settings);
 
@@ -492,7 +492,7 @@ static void process(cgltf_data* data, const char* input_path, const char* output
 
 		comma(json_textures);
 		append(json_textures, "{");
-		writeTexture(json_textures, texture, data, settings);
+		writeTexture(json_textures, texture, texture.image ? &images[texture.image - data->images] : NULL, data, settings);
 		append(json_textures, "}");
 	}
 
@@ -1255,11 +1255,19 @@ int main(int argc, char** argv)
 
 			for (int kind = 0; kind < TextureKind__Count; ++kind)
 				if (mask & (1 << kind))
-					settings.texture_uastc[kind] = true;
+					settings.texture_mode[kind] = TextureMode_UASTC;
 		}
 		else if (strcmp(arg, "-tc") == 0)
 		{
 			settings.texture_ktx2 = true;
+
+			unsigned int mask = ~0u;
+			if (i + 1 < argc && isalpha(argv[i + 1][0]))
+				mask = textureMask(argv[++i]);
+
+			for (int kind = 0; kind < TextureKind__Count; ++kind)
+				if (mask & (1 << kind))
+					settings.texture_mode[kind] = TextureMode_ETC1S;
 		}
 		else if (strcmp(arg, "-tq") == 0 && i + 1 < argc && isdigit(argv[i + 1][0]))
 		{
@@ -1408,6 +1416,7 @@ int main(int argc, char** argv)
 			fprintf(stderr, "\t-tfy: flip textures along Y axis during BasisU supercompression\n");
 			fprintf(stderr, "\t-tj N: use N threads when compressing textures\n");
 			fprintf(stderr, "\tTexture classes:\n");
+			fprintf(stderr, "\t-tc C: use ETC1S when encoding textures of class C\n");
 			fprintf(stderr, "\t-tu C: use UASTC when encoding textures of class C\n");
 			fprintf(stderr, "\t-tq C N: set texture encoding quality for class C\n");
 			fprintf(stderr, "\t... where C is a comma-separated list (no spaces) with valid values color,normal,attrib\n");

--- a/gltf/gltfpack.cpp
+++ b/gltf/gltfpack.cpp
@@ -472,8 +472,8 @@ static void process(cgltf_data* data, const char* input_path, const char* output
 		append(json_images, "{");
 		if (encoded_images.size() && !encoded_images[i].empty())
 		{
-			if (encoded_images[i].compare(0, 6, "ERROR:") == 0)
-				fprintf(stderr, "Warning: unable to encode image %d (%s), skipping (%s)\n", int(i), image.uri ? image.uri : "?", encoded_images[i].c_str() + 6);
+			if (encoded_images[i].compare(0, 5, "error") == 0)
+				fprintf(stderr, "Warning: unable to encode image %d (%s), skipping (%s)\n", int(i), image.uri ? image.uri : "?", encoded_images[i].c_str());
 			else
 				writeEncodedImage(json_images, views, image, encoded_images[i], images[i], output_path, settings);
 

--- a/gltf/gltfpack.h
+++ b/gltf/gltfpack.h
@@ -94,6 +94,13 @@ enum TextureKind
 	TextureKind__Count
 };
 
+enum TextureMode
+{
+	TextureMode_Raw,
+	TextureMode_ETC1S,
+	TextureMode_UASTC,
+};
+
 struct Settings
 {
 	int pos_bits;
@@ -129,7 +136,7 @@ struct Settings
 	float texture_scale;
 	int texture_limit;
 
-	bool texture_uastc[TextureKind__Count];
+	TextureMode texture_mode[TextureKind__Count];
 	int texture_quality[TextureKind__Count];
 
 	int texture_jobs;
@@ -338,7 +345,7 @@ void writeBufferView(std::string& json, BufferView::Kind kind, StreamFormat::Fil
 void writeSampler(std::string& json, const cgltf_sampler& sampler);
 void writeImage(std::string& json, std::vector<BufferView>& views, const cgltf_image& image, const ImageInfo& info, size_t index, const char* input_path, const Settings& settings);
 void writeEncodedImage(std::string& json, std::vector<BufferView>& views, const cgltf_image& image, const std::string& encoded, const ImageInfo& info, const char* output_path, const Settings& settings);
-void writeTexture(std::string& json, const cgltf_texture& texture, cgltf_data* data, const Settings& settings);
+void writeTexture(std::string& json, const cgltf_texture& texture, const ImageInfo* info, cgltf_data* data, const Settings& settings);
 void writeMeshAttributes(std::string& json, std::vector<BufferView>& views, std::string& json_accessors, size_t& accr_offset, const Mesh& mesh, int target, const QuantizationPosition& qp, const QuantizationTexture& qt, const Settings& settings);
 size_t writeMeshIndices(std::vector<BufferView>& views, std::string& json_accessors, size_t& accr_offset, const Mesh& mesh, const Settings& settings);
 size_t writeJointBindMatrices(std::vector<BufferView>& views, std::string& json_accessors, size_t& accr_offset, const cgltf_skin& skin, const QuantizationPosition& qp, const Settings& settings);

--- a/gltf/write.cpp
+++ b/gltf/write.cpp
@@ -853,7 +853,7 @@ void writeImage(std::string& json, std::vector<BufferView>& views, const cgltf_i
 {
 	bool dataUri = image.uri && strncmp(image.uri, "data:", 5) == 0;
 
-	if (image.uri && !dataUri && !settings.texture_embed && !settings.texture_ktx2)
+	if (image.uri && !dataUri && !settings.texture_embed)
 	{
 		// fast-path: we don't need to read the image to memory
 		append(json, "\"uri\":\"");
@@ -899,7 +899,7 @@ void writeEncodedImage(std::string& json, std::vector<BufferView>& views, const 
 	}
 }
 
-void writeTexture(std::string& json, const cgltf_texture& texture, cgltf_data* data, const Settings& settings)
+void writeTexture(std::string& json, const cgltf_texture& texture, const ImageInfo* info, cgltf_data* data, const Settings& settings)
 {
 	if (texture.image)
 	{
@@ -910,7 +910,7 @@ void writeTexture(std::string& json, const cgltf_texture& texture, cgltf_data* d
 			append(json, ",");
 		}
 
-		if (settings.texture_ktx2)
+		if (info && settings.texture_mode[info->kind] != TextureMode_Raw)
 		{
 			append(json, "\"extensions\":{\"KHR_texture_basisu\":{\"source\":");
 			append(json, size_t(texture.image - data->images));


### PR DESCRIPTION
Now -tc option supports the same texture kind/mask specification as
options -tu and -tq; this allows to compress color/attribute textures
but leave normal maps uncompressed.

When only `-tu` option with a mask is specified, we used to compress
the textures not covered by the mask with ETC1S, but we now simply
don't compress them at all - hopefully this doesn't break anyone's
expectations! It's simple to go back to the old behavior by adding `-tc`
before `-tu mask`.

Fixes #438.