### PR TITLE
gltfpack: Implement support for normalized attributes

### DIFF
--- a/gltf/gltfpack.cpp
+++ b/gltf/gltfpack.cpp
@@ -657,7 +657,7 @@ static void process(cgltf_data* data, const char* input_path, const char* output
 				assert(ni.keep);
 				ni.meshes.push_back(node_offset);
 
-				writeMeshNode(json_nodes, mesh_offset, mesh.nodes[j], mesh.skin, data, settings.quantize ? &qp : NULL);
+				writeMeshNode(json_nodes, mesh_offset, mesh.nodes[j], mesh.skin, data, settings.quantize ? &qp : NULL, settings);
 
 				node_offset++;
 			}
@@ -681,7 +681,7 @@ static void process(cgltf_data* data, const char* input_path, const char* output
 			comma(json_roots[mesh.scene]);
 			append(json_roots[mesh.scene], node_offset);
 
-			writeMeshNode(json_nodes, mesh_offset, NULL, mesh.skin, data, settings.quantize ? &qp : NULL);
+			writeMeshNode(json_nodes, mesh_offset, NULL, mesh.skin, data, settings.quantize ? &qp : NULL, settings);
 
 			node_offset++;
 		}
@@ -1187,6 +1187,10 @@ int main(int argc, char** argv)
 		{
 			settings.col_bits = clamp(atoi(argv[++i]), 1, 16);
 		}
+		else if (strcmp(arg, "-vpn") == 0)
+		{
+			settings.pos_normalized = true;
+		}
 		else if (strcmp(arg, "-at") == 0 && i + 1 < argc && isdigit(argv[i + 1][0]))
 		{
 			settings.trn_bits = clamp(atoi(argv[++i]), 1, 24);
@@ -1428,6 +1432,7 @@ int main(int argc, char** argv)
 			fprintf(stderr, "\t-vt N: use N-bit quantization for texture coordinates (default: 12; N should be between 1 and 16)\n");
 			fprintf(stderr, "\t-vn N: use N-bit quantization for normals and tangents (default: 8; N should be between 1 and 16)\n");
 			fprintf(stderr, "\t-vc N: use N-bit quantization for colors (default: 8; N should be between 1 and 16)\n");
+			fprintf(stderr, "\t-vpn: use normalized attributes for positions instead of using integers\n");
 			fprintf(stderr, "\nAnimations:\n");
 			fprintf(stderr, "\t-at N: use N-bit quantization for translations (default: 16; N should be between 1 and 24)\n");
 			fprintf(stderr, "\t-ar N: use N-bit quantization for rotations (default: 12; N should be between 4 and 16)\n");

--- a/gltf/gltfpack.cpp
+++ b/gltf/gltfpack.cpp
@@ -657,7 +657,7 @@ static void process(cgltf_data* data, const char* input_path, const char* output
 				assert(ni.keep);
 				ni.meshes.push_back(node_offset);
 
-				writeMeshNode(json_nodes, mesh_offset, mesh.nodes[j], mesh.skin, data, settings.quantize ? &qp : NULL, settings);
+				writeMeshNode(json_nodes, mesh_offset, mesh.nodes[j], mesh.skin, data, settings.quantize ? &qp : NULL);
 
 				node_offset++;
 			}
@@ -681,7 +681,7 @@ static void process(cgltf_data* data, const char* input_path, const char* output
 			comma(json_roots[mesh.scene]);
 			append(json_roots[mesh.scene], node_offset);
 
-			writeMeshNode(json_nodes, mesh_offset, NULL, mesh.skin, data, settings.quantize ? &qp : NULL, settings);
+			writeMeshNode(json_nodes, mesh_offset, NULL, mesh.skin, data, settings.quantize ? &qp : NULL);
 
 			node_offset++;
 		}

--- a/gltf/gltfpack.h
+++ b/gltf/gltfpack.h
@@ -157,6 +157,7 @@ struct QuantizationPosition
 	float offset[3];
 	float scale;
 	int bits;
+	bool normalized;
 };
 
 struct QuantizationTexture
@@ -164,6 +165,7 @@ struct QuantizationTexture
 	float offset[2];
 	float scale[2];
 	int bits;
+	bool normalized;
 };
 
 struct StreamFormat
@@ -319,7 +321,7 @@ void decomposeTransform(float translation[3], float rotation[4], float scale[3],
 
 QuantizationPosition prepareQuantizationPosition(const std::vector<Mesh>& meshes, const Settings& settings);
 void prepareQuantizationTexture(cgltf_data* data, std::vector<QuantizationTexture>& result, std::vector<size_t>& indices, const std::vector<Mesh>& meshes, const Settings& settings);
-void getPositionBounds(float min[3], float max[3], const Stream& stream, const QuantizationPosition* qp, const Settings& settings);
+void getPositionBounds(float min[3], float max[3], const Stream& stream, const QuantizationPosition* qp);
 
 StreamFormat writeVertexStream(std::string& bin, const Stream& stream, const QuantizationPosition& qp, const QuantizationTexture& qt, const Settings& settings);
 StreamFormat writeIndexStream(std::string& bin, const std::vector<unsigned int>& stream);
@@ -352,7 +354,7 @@ void writeMeshAttributes(std::string& json, std::vector<BufferView>& views, std:
 size_t writeMeshIndices(std::vector<BufferView>& views, std::string& json_accessors, size_t& accr_offset, const Mesh& mesh, const Settings& settings);
 size_t writeJointBindMatrices(std::vector<BufferView>& views, std::string& json_accessors, size_t& accr_offset, const cgltf_skin& skin, const QuantizationPosition& qp, const Settings& settings);
 size_t writeInstances(std::vector<BufferView>& views, std::string& json_accessors, size_t& accr_offset, const std::vector<Transform>& transforms, const QuantizationPosition& qp, const Settings& settings);
-void writeMeshNode(std::string& json, size_t mesh_offset, cgltf_node* node, cgltf_skin* skin, cgltf_data* data, const QuantizationPosition* qp, const Settings& settings);
+void writeMeshNode(std::string& json, size_t mesh_offset, cgltf_node* node, cgltf_skin* skin, cgltf_data* data, const QuantizationPosition* qp);
 void writeMeshNodeInstanced(std::string& json, size_t mesh_offset, size_t accr_offset);
 void writeSkin(std::string& json, const cgltf_skin& skin, size_t matrix_accr, const std::vector<NodeInfo>& nodes, cgltf_data* data);
 void writeNode(std::string& json, const cgltf_node& node, const std::vector<NodeInfo>& nodes, cgltf_data* data);

--- a/gltf/gltfpack.h
+++ b/gltf/gltfpack.h
@@ -108,6 +108,8 @@ struct Settings
 	int nrm_bits;
 	int col_bits;
 
+	bool pos_normalized;
+
 	int trn_bits;
 	int rot_bits;
 	int scl_bits;
@@ -317,7 +319,7 @@ void decomposeTransform(float translation[3], float rotation[4], float scale[3],
 
 QuantizationPosition prepareQuantizationPosition(const std::vector<Mesh>& meshes, const Settings& settings);
 void prepareQuantizationTexture(cgltf_data* data, std::vector<QuantizationTexture>& result, std::vector<size_t>& indices, const std::vector<Mesh>& meshes, const Settings& settings);
-void getPositionBounds(float min[3], float max[3], const Stream& stream, const QuantizationPosition* qp);
+void getPositionBounds(float min[3], float max[3], const Stream& stream, const QuantizationPosition* qp, const Settings& settings);
 
 StreamFormat writeVertexStream(std::string& bin, const Stream& stream, const QuantizationPosition& qp, const QuantizationTexture& qt, const Settings& settings);
 StreamFormat writeIndexStream(std::string& bin, const std::vector<unsigned int>& stream);
@@ -350,7 +352,7 @@ void writeMeshAttributes(std::string& json, std::vector<BufferView>& views, std:
 size_t writeMeshIndices(std::vector<BufferView>& views, std::string& json_accessors, size_t& accr_offset, const Mesh& mesh, const Settings& settings);
 size_t writeJointBindMatrices(std::vector<BufferView>& views, std::string& json_accessors, size_t& accr_offset, const cgltf_skin& skin, const QuantizationPosition& qp, const Settings& settings);
 size_t writeInstances(std::vector<BufferView>& views, std::string& json_accessors, size_t& accr_offset, const std::vector<Transform>& transforms, const QuantizationPosition& qp, const Settings& settings);
-void writeMeshNode(std::string& json, size_t mesh_offset, cgltf_node* node, cgltf_skin* skin, cgltf_data* data, const QuantizationPosition* qp);
+void writeMeshNode(std::string& json, size_t mesh_offset, cgltf_node* node, cgltf_skin* skin, cgltf_data* data, const QuantizationPosition* qp, const Settings& settings);
 void writeMeshNodeInstanced(std::string& json, size_t mesh_offset, size_t accr_offset);
 void writeSkin(std::string& json, const cgltf_skin& skin, size_t matrix_accr, const std::vector<NodeInfo>& nodes, cgltf_data* data);
 void writeNode(std::string& json, const cgltf_node& node, const std::vector<NodeInfo>& nodes, cgltf_data* data);

--- a/gltf/stream.cpp
+++ b/gltf/stream.cpp
@@ -368,7 +368,7 @@ StreamFormat writeVertexStream(std::string& bin, const Stream& stream, const Qua
 			bin.append(reinterpret_cast<const char*>(v), sizeof(v));
 		}
 
-		StreamFormat format = {cgltf_type_vec2, cgltf_component_type_r_16u, false, 4};
+		StreamFormat format = {cgltf_type_vec2, cgltf_component_type_r_16u, true, 4};
 		return format;
 	}
 	else if (stream.type == cgltf_attribute_type_normal)

--- a/gltf/stream.cpp
+++ b/gltf/stream.cpp
@@ -80,6 +80,7 @@ QuantizationPosition prepareQuantizationPosition(const std::vector<Mesh>& meshes
 	QuantizationPosition result = {};
 
 	result.bits = settings.pos_bits;
+	result.normalized = settings.pos_normalized;
 
 	Bounds b;
 
@@ -160,6 +161,7 @@ void prepareQuantizationTexture(cgltf_data* data, std::vector<QuantizationTextur
 		QuantizationTexture& qt = result[i];
 
 		qt.bits = settings.tex_bits;
+		qt.normalized = true;
 
 		const Bounds& b = bounds[follow(parents, i)];
 
@@ -173,7 +175,7 @@ void prepareQuantizationTexture(cgltf_data* data, std::vector<QuantizationTextur
 	}
 }
 
-void getPositionBounds(float min[3], float max[3], const Stream& stream, const QuantizationPosition* qp, const Settings& settings)
+void getPositionBounds(float min[3], float max[3], const Stream& stream, const QuantizationPosition* qp)
 {
 	assert(stream.type == cgltf_attribute_type_position);
 	assert(stream.data.size() > 0);
@@ -194,7 +196,7 @@ void getPositionBounds(float min[3], float max[3], const Stream& stream, const Q
 
 	if (qp)
 	{
-		float pos_rscale = qp->scale == 0.f ? 0.f : 1.f / qp->scale * (stream.target > 0 && settings.pos_normalized ? 32767.f / 65535.f : 1.f);
+		float pos_rscale = qp->scale == 0.f ? 0.f : 1.f / qp->scale * (stream.target > 0 && qp->normalized ? 32767.f / 65535.f : 1.f);
 
 		for (int k = 0; k < 3; ++k)
 		{
@@ -293,12 +295,12 @@ StreamFormat writeVertexStream(std::string& bin, const Stream& stream, const Qua
 				bin.append(reinterpret_cast<const char*>(v), sizeof(v));
 			}
 
-			StreamFormat format = {cgltf_type_vec3, cgltf_component_type_r_16u, settings.pos_normalized, 8};
+			StreamFormat format = {cgltf_type_vec3, cgltf_component_type_r_16u, qp.normalized, 8};
 			return format;
 		}
 		else
 		{
-			float pos_rscale = qp.scale == 0.f ? 0.f : 1.f / qp.scale * (settings.pos_normalized ? 32767.f / 65535.f : 1.f);
+			float pos_rscale = qp.scale == 0.f ? 0.f : 1.f / qp.scale * (qp.normalized ? 32767.f / 65535.f : 1.f);
 
 			int maxv = 0;
 
@@ -311,7 +313,7 @@ StreamFormat writeVertexStream(std::string& bin, const Stream& stream, const Qua
 				maxv = std::max(maxv, meshopt_quantizeUnorm(fabsf(a.f[2]) * pos_rscale, qp.bits));
 			}
 
-			if (maxv <= 127 && !settings.pos_normalized)
+			if (maxv <= 127 && !qp.normalized)
 			{
 				for (size_t i = 0; i < stream.data.size(); ++i)
 				{
@@ -342,7 +344,7 @@ StreamFormat writeVertexStream(std::string& bin, const Stream& stream, const Qua
 					bin.append(reinterpret_cast<const char*>(v), sizeof(v));
 				}
 
-				StreamFormat format = {cgltf_type_vec3, cgltf_component_type_r_16, settings.pos_normalized, 8};
+				StreamFormat format = {cgltf_type_vec3, cgltf_component_type_r_16, qp.normalized, 8};
 				return format;
 			}
 		}
@@ -368,7 +370,7 @@ StreamFormat writeVertexStream(std::string& bin, const Stream& stream, const Qua
 			bin.append(reinterpret_cast<const char*>(v), sizeof(v));
 		}
 
-		StreamFormat format = {cgltf_type_vec2, cgltf_component_type_r_16u, true, 4};
+		StreamFormat format = {cgltf_type_vec2, cgltf_component_type_r_16u, qt.normalized, 4};
 		return format;
 	}
 	else if (stream.type == cgltf_attribute_type_normal)

--- a/gltf/write.cpp
+++ b/gltf/write.cpp
@@ -178,10 +178,13 @@ static void writeTextureInfo(std::string& json, const cgltf_data* data, const cg
 
 	if (qt)
 	{
+		// UV streams use normalized unsigned 16-bit data, so we need to cancel division by 65535 and apply current bitcount we use
+		const float kRescale = 65535.f / float((1 << qt->bits) - 1);
+
 		transform.offset[0] += qt->offset[0];
 		transform.offset[1] += qt->offset[1];
-		transform.scale[0] *= qt->scale[0] / float((1 << qt->bits) - 1);
-		transform.scale[1] *= qt->scale[1] / float((1 << qt->bits) - 1);
+		transform.scale[0] *= qt->scale[0] * kRescale;
+		transform.scale[1] *= qt->scale[1] * kRescale;
 		has_transform = true;
 	}
 


### PR DESCRIPTION
This change adds -vpn flag that enables the use of normalized position
accessors instead of integer (unnormalized) ones, and switches texture
coordinates to normalized attributes unconditionally.

Currently gltfpack quantizes positions and texture coordinates using
integers; this results in very small scaling values that are required to
transform the values back into 0..1 range.

While this is generally not a problem, there are some contexts in which
the scale values are too small and may be truncated to 0, eg if the shader
is using medium precision. Additionally, for native GPU backends like
WebGPU the shader may need to match the logical type of the vertex
attribute with the shader declaration - for unnormalized integers to
work, one must use i32/u32 types, which makes meshes that use
quantization incompatible with shaders that expect non-quantized inputs.

Using normalized data fixes this. For texture coordinates, we should be
able to do that unconditionally. For positions, this can have a downside
in that it requires an application of an extra normalization factor
whenever you work with the data on the CPU side, which can break
frameworks like Three.JS that can read data directly out of Int16Array
otherwise. Additionally, this mode reduces precision for morph deltas by
one bit since we need to equalize the deltas between snorm and unorm.

While the morph target issue could be solved by using normalized signed
attributes for positions, they may decode with precision issues on Web and
as such we avoid them out of caution. We still have to use them for morph
targets though, so `-vpn` may have further unintended consequences for
Web platform when morph targets are used.

A small downside of this change is a small precision loss during
reconstruction - previously we did the reconstruction in one step, thus
losing ~0.5ulp of precision on that, and now reconstruction is two-step:
GPU divides the integer by 65535, and then we rescale back, which may
result in artifacts - however, in practice the extra 0.5ulp is always
insignificantly small to be observable, and even for positions it should never
result in gaps that weren't there previously.

Fixes #422.