### PR TITLE
gltfpack: Optimize .obj parsing for memory consumption

### DIFF
--- a/src/indexgenerator.cpp
+++ b/src/indexgenerator.cpp
@@ -187,7 +187,7 @@ size_t meshopt_generateVertexRemap(unsigned int* destination, const unsigned int
 	using namespace meshopt;
 
 	assert(indices || index_count == vertex_count);
-	assert(index_count % 3 == 0);
+	// assert(index_count % 3 == 0);
 	assert(vertex_size > 0 && vertex_size <= 256);
 
 	meshopt_Allocator allocator;

--- a/src/indexgenerator.cpp
+++ b/src/indexgenerator.cpp
@@ -187,7 +187,7 @@ size_t meshopt_generateVertexRemap(unsigned int* destination, const unsigned int
 	using namespace meshopt;
 
 	assert(indices || index_count == vertex_count);
-	// assert(index_count % 3 == 0);
+	assert(!indices || index_count % 3 == 0);
 	assert(vertex_size > 0 && vertex_size <= 256);
 
 	meshopt_Allocator allocator;


### PR DESCRIPTION
With this change we now deduplicate face vertices before creating the
vertex data, and don't create streams that we know don't exist.

This results in memory savings for loading large .obj files, although
this also regresses some:

Before:
./gltfpack -i /home/zeux/Downloads/rungholt.obj -o rh.glb 3.84 sec 924576 KB
./gltfpack -i /home/zeux/Downloads/hairball.obj -o hb.glb 1.36 sec 600440 KB
./gltfpack -i /home/zeux/Downloads/splash.obj -o sp.glb 15.12 sec 4249600 KB

After:
./gltfpack -i /home/zeux/Downloads/rungholt.obj -o rh.glb 3.91 sec 1100132 KB
./gltfpack -i /home/zeux/Downloads/hairball.obj -o hb.glb 1.26 sec 275084 KB
./gltfpack -i /home/zeux/Downloads/splash.obj -o sp.glb 12.06 sec 2766064 KB

It's not clear where the regression on rungholt comes from, although the
peak memory consumption there seems to be driven by mesh merging
instead.