### PR TITLE
Adds exports and updates type definitions for MeshoptSimplifier

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -1,4 +1,5 @@
 const MeshoptEncoder = require('./meshopt_encoder.js');
 const MeshoptDecoder = require('./meshopt_decoder.js');
+const MeshoptSimplifier = require('./meshopt_simplifier.js');
 
-module.exports = {MeshoptEncoder, MeshoptDecoder};
+module.exports = {MeshoptEncoder, MeshoptDecoder, MeshoptSimplifier};

--- a/js/index.module.d.ts
+++ b/js/index.module.d.ts
@@ -1,2 +1,3 @@
 export * from './meshopt_encoder.module';
 export * from './meshopt_decoder.module';
+export * from './meshopt_simplifier.module';

--- a/js/index.module.js
+++ b/js/index.module.js
@@ -1,2 +1,3 @@
 export * from './meshopt_encoder.module.js';
 export * from './meshopt_decoder.module.js';
+export * from './meshopt_simplifier.module.js';

--- a/js/meshopt_simplifier.module.d.ts
+++ b/js/meshopt_simplifier.module.d.ts
@@ -8,7 +8,7 @@ export const MeshoptSimplifier: {
     
     compactMesh: (indices: Uint32Array) => [Uint32Array, number];
     
-    simplify(indices: Uint32Array, vertex_positions: Float32Array, vertex_positions_stride: number, target_index_count: number, target_error: number, flags?: [Flags]) => [Uint32Array, number];
+    simplify: (indices: Uint32Array, vertex_positions: Float32Array, vertex_positions_stride: number, target_index_count: number, target_error: number, flags?: Flags[]) => [Uint32Array, number];
 
     getScale: (vertex_positions: Float32Array, vertex_positions_stride: number) => number;
 };

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "meshoptimizer",
-	"version": "0.18.0",
+	"version": "0.18.1",
 	"description": "Mesh optimizaiton library that makes meshes smaller and faster to render",
 	"author": "Arseny Kapoulkine",
 	"license": "MIT",


### PR DESCRIPTION
Changes:

- Adds missing exports for MeshoptSimplifier
- Fixes typo in TypeScript type declarations
- Changes `[Flags]` to `Flags[]`, allowing empty array