### PR TITLE
gltfpack: Switch to basis_parallel_compress

### DIFF
--- a/gltf/basisenc.cpp
+++ b/gltf/basisenc.cpp
@@ -36,124 +36,100 @@ static const BasisSettings kBasisSettings[10] = {
     {1, 255, 2, 0.f},
 };
 
-static std::unique_ptr<basisu::job_pool> gJobPool;
-
-void encodeInit(int jobs)
+static const char* prepareEncode(basisu::basis_compressor_params& params, const cgltf_image& image, const char* input_path, const ImageInfo& info, const Settings& settings, TempFile& temp_input, TempFile& temp_output)
 {
-	using namespace basisu;
+	std::string img_data;
+	std::string mime_type;
+	std::string result;
 
-	basisu_encoder_init();
+	if (!readImage(image, input_path, img_data, mime_type))
+		return "error reading source file";
 
-	uint32_t num_threads = jobs == 0 ? std::thread::hardware_concurrency() : jobs;
+	int width = 0, height = 0;
+	if (!getDimensions(img_data, mime_type.c_str(), width, height))
+		return "error parsing image header";
 
-	gJobPool.reset(new job_pool(num_threads));
+	adjustDimensions(width, height, settings);
 
-	interval_timer::init(); // make sure interval_timer globals are initialized from main thread
-}
+	temp_input.create(mimeExtension(mime_type.c_str()));
+	temp_output.create(".ktx2");
 
-static bool encodeInternal(const char* input, const char* output, bool yflip, bool normal_map, bool linear, bool uastc, int uastc_l, float uastc_q, int etc1s_l, int etc1s_q, int zstd_l, int width, int height)
-{
-	using namespace basisu;
+	if (!writeFile(temp_input.path.c_str(), img_data))
+		return "error writing temporary file";
 
-	basis_compressor_params params;
+	int quality = settings.texture_quality[info.kind];
+	bool uastc = settings.texture_mode[info.kind] == TextureMode_UASTC;
+	int zstd = uastc ? 9 : 0;
 
-	params.m_multithreading = gJobPool->get_total_threads() > 1;
-	params.m_pJob_pool = gJobPool.get();
+	const BasisSettings& bs = kBasisSettings[quality - 1];
 
 	if (uastc)
 	{
-		static const uint32_t s_level_flags[TOTAL_PACK_UASTC_LEVELS] = {cPackUASTCLevelFastest, cPackUASTCLevelFaster, cPackUASTCLevelDefault, cPackUASTCLevelSlower, cPackUASTCLevelVerySlow};
+		static const uint32_t s_level_flags[basisu::TOTAL_PACK_UASTC_LEVELS] = {basisu::cPackUASTCLevelFastest, basisu::cPackUASTCLevelFaster, basisu::cPackUASTCLevelDefault, basisu::cPackUASTCLevelSlower, basisu::cPackUASTCLevelVerySlow};
 
 		params.m_uastc = true;
 
-		params.m_pack_uastc_flags &= ~cPackUASTCLevelMask;
-		params.m_pack_uastc_flags |= s_level_flags[uastc_l];
+		params.m_pack_uastc_flags &= ~basisu::cPackUASTCLevelMask;
+		params.m_pack_uastc_flags |= s_level_flags[bs.uastc_l];
 
-		params.m_rdo_uastc = uastc_q > 0;
-		params.m_rdo_uastc_quality_scalar = uastc_q;
+		params.m_rdo_uastc = bs.uastc_q > 0;
+		params.m_rdo_uastc_quality_scalar = bs.uastc_q;
 		params.m_rdo_uastc_dict_size = 1024;
 	}
 	else
 	{
-		params.m_compression_level = etc1s_l;
-		params.m_quality_level = etc1s_q;
+		params.m_compression_level = bs.etc1s_l;
+		params.m_quality_level = bs.etc1s_q;
 		params.m_max_endpoint_clusters = 0;
 		params.m_max_selector_clusters = 0;
 
-		params.m_no_selector_rdo = normal_map;
-		params.m_no_endpoint_rdo = normal_map;
+		params.m_no_selector_rdo = info.normal_map;
+		params.m_no_endpoint_rdo = info.normal_map;
 	}
 
-	params.m_perceptual = !linear;
+	params.m_perceptual = info.srgb;
 
 	params.m_mip_gen = true;
-	params.m_mip_srgb = !linear;
+	params.m_mip_srgb = info.srgb;
 
 	params.m_resample_width = width;
 	params.m_resample_height = height;
 
-	params.m_y_flip = yflip;
+	params.m_y_flip = settings.texture_flipy;
 
 	params.m_create_ktx2_file = true;
-	params.m_ktx2_srgb_transfer_func = !linear;
+	params.m_ktx2_srgb_transfer_func = info.srgb;
 
-	if (zstd_l)
+	if (zstd)
 	{
 		params.m_ktx2_uastc_supercompression = basist::KTX2_SS_ZSTANDARD;
-		params.m_ktx2_zstd_supercompression_level = zstd_l;
+		params.m_ktx2_zstd_supercompression_level = zstd;
 	}
 
 	params.m_read_source_images = true;
 	params.m_write_output_basis_files = true;
 
 	params.m_source_filenames.resize(1);
-	params.m_source_filenames[0] = input;
+	params.m_source_filenames[0] = temp_input.path;
 
-	params.m_out_filename = output;
+	params.m_out_filename = temp_output.path;
 
 	params.m_status_output = false;
-
-	basis_compressor c;
-
-	if (!c.init(params))
-		return false;
-
-	return c.process() == basis_compressor::cECSuccess;
-}
-
-static const char* encodeImage(const std::string& data, const char* mime_type, std::string& result, const ImageInfo& info, const Settings& settings)
-{
-	TempFile temp_input(mimeExtension(mime_type));
-	TempFile temp_output(".ktx2");
-
-	if (!writeFile(temp_input.path.c_str(), data))
-		return "error writing temporary file";
-
-	int quality = settings.texture_quality[info.kind];
-	bool uastc = settings.texture_mode[info.kind] == TextureMode_UASTC;
-
-	const BasisSettings& bs = kBasisSettings[quality - 1];
-
-	int width = 0, height = 0;
-	if (!getDimensions(data, mime_type, width, height))
-		return "error parsing image header";
-
-	adjustDimensions(width, height, settings);
-
-	int zstd = uastc ? 9 : 0;
-
-	if (!encodeInternal(temp_input.path.c_str(), temp_output.path.c_str(), settings.texture_flipy, info.normal_map, !info.srgb, uastc, bs.uastc_l, bs.uastc_q, bs.etc1s_l, bs.etc1s_q, zstd, width, height))
-		return "error encoding image";
-
-	if (!readFile(temp_output.path.c_str(), result))
-		return "error reading temporary file";
 
 	return nullptr;
 }
 
 void encodeImages(std::string* encoded, const cgltf_data* data, const std::vector<ImageInfo>& images, const char* input_path, const Settings& settings)
 {
-	assert(gJobPool);
+	basisu::basisu_encoder_init();
+
+	basisu::interval_timer::init(); // make sure interval_timer globals are initialized from main thread
+
+	basisu::vector<basisu::basis_compressor_params> params(data->images_count);
+	basisu::vector<basisu::parallel_results> results(data->images_count);
+
+	std::vector<TempFile> temp_inputs(data->images_count);
+	std::vector<TempFile> temp_outputs(data->images_count);
 
 	for (size_t i = 0; i < data->images_count; ++i)
 	{
@@ -163,20 +139,26 @@ void encodeImages(std::string* encoded, const cgltf_data* data, const std::vecto
 		if (settings.texture_mode[info.kind] == TextureMode_Raw)
 			continue;
 
-		gJobPool->add_job([=]() {
-			std::string img_data;
-			std::string mime_type;
-			std::string result;
+		if (const char* error = prepareEncode(params[i], image, input_path, info, settings, temp_inputs[i], temp_outputs[i]))
+			encoded[i] = error;
 
-			if (!readImage(image, input_path, img_data, mime_type))
-				encoded[i] = "error reading source file";
-			else if (const char* error = encodeImage(img_data, mime_type.c_str(), result, info, settings))
-				encoded[i] = error;
-			else
-				encoded[i].swap(result);
-		}, nullptr); // explicitly pass token to make sure we're using thread-safe job_pool implementation
+		// image is ready to encode in parallel
 	}
 
-	gJobPool->wait_for_all();
+	uint32_t num_threads = settings.texture_jobs == 0 ? std::thread::hardware_concurrency() : settings.texture_jobs;
+
+	basisu::basis_parallel_compress(num_threads, params, results);
+
+	for (size_t i = 0; i < data->images_count; ++i)
+	{
+		if (params[i].m_source_filenames.empty())
+			; // encoding was skipped or preparation resulted in an error
+		else if (results[i].m_error_code == basisu::basis_compressor::cECFailedReadingSourceImages)
+			encoded[i] = "error decoding source image";
+		else if (results[i].m_error_code != basisu::basis_compressor::cECSuccess)
+			encoded[i] = "error encoding image";
+		else if (!readFile(temp_outputs[i].path.c_str(), encoded[i]))
+			encoded[i] = "error reading temporary file";
+	}
 }
 #endif

--- a/gltf/fileio.cpp
+++ b/gltf/fileio.cpp
@@ -11,9 +11,32 @@
 #include <unistd.h>
 #endif
 
+TempFile::TempFile()
+	: fd(-1)
+{
+}
+
 TempFile::TempFile(const char* suffix)
     : fd(-1)
 {
+	create(suffix);
+}
+
+TempFile::~TempFile()
+{
+	if (!path.empty())
+		remove(path.c_str());
+
+#ifndef _WIN32
+	if (fd >= 0)
+		close(fd);
+#endif
+}
+
+void TempFile::create(const char* suffix)
+{
+	assert(fd < 0 && path.empty());
+
 #if defined(_WIN32)
 	const char* temp_dir = getenv("TEMP");
 	path = temp_dir ? temp_dir : ".";
@@ -32,15 +55,6 @@ TempFile::TempFile(const char* suffix)
 	path = "/tmp/gltfpack-XXXXXX";
 	path += suffix;
 	fd = mkstemps(&path[0], strlen(suffix));
-#endif
-}
-
-TempFile::~TempFile()
-{
-	remove(path.c_str());
-
-#ifndef _WIN32
-	close(fd);
 #endif
 }
 

--- a/gltf/gltfpack.cpp
+++ b/gltf/gltfpack.cpp
@@ -1381,11 +1381,6 @@ int main(int argc, char** argv)
 		return 0;
 	}
 
-#ifdef WITH_BASISU
-	if (settings.texture_ktx2)
-		encodeInit(settings.texture_jobs);
-#endif
-
 	if (test)
 	{
 		for (size_t i = 0; i < testinputs.size(); ++i)

--- a/gltf/gltfpack.h
+++ b/gltf/gltfpack.h
@@ -264,8 +264,11 @@ struct TempFile
 	std::string path;
 	int fd;
 
+	TempFile();
 	TempFile(const char* suffix);
 	~TempFile();
+
+	void create(const char* suffix);
 };
 
 std::string getFullPath(const char* path, const char* base_path);
@@ -308,8 +311,6 @@ void adjustDimensions(int& width, int& height, const Settings& settings);
 const char* mimeExtension(const char* mime_type);
 
 #ifdef WITH_BASISU
-void encodeInit(int jobs);
-bool encodeBasis(const std::string& data, const char* mime_type, std::string& result, const ImageInfo& info, const Settings& settings);
 void encodeImages(std::string* encoded, const cgltf_data* data, const std::vector<ImageInfo>& images, const char* input_path, const Settings& settings);
 #endif
 


### PR DESCRIPTION
When internal Basis encoding was implemented initially, Basis didn't
provide an API to compress multiple textures together in parallel, but
now it does.

Right now we rely on the gltfpack fork to provide a special performant
job pool implementation that allows us to scale parallel compression
much better. As a side effect, this means gltfpack *must* be built
against the forked version of basis_universal, which results in
confusion around builds.

The implementation of parallel_compress is inefficient in the main
version, but it's efficient in gltfpack fork. This change switches to
that API instead, with the eventual angle of integrating the efficiency
improvements into mainline so that we no longer need to maintain a fork.

Before this change we would read the images in parallel, but that didn't
really provide appreciable savings so the resulting change is neutral on
performance.

Building against the upstream version now works, and simply results in
less efficient texture compression.

This came up in #450 and #437.