### PR TITLE
js: Implement support for WebWorker-driven decoding

### DIFF
--- a/js/meshopt_decoder.module.d.ts
+++ b/js/meshopt_decoder.module.d.ts
@@ -9,4 +9,5 @@ export const MeshoptDecoder: {
     decodeIndexSequence: (target: Uint8Array, count: number, size: number, source: Uint8Array) => void;
 
     decodeGltfBuffer: (target: Uint8Array, count: number, size: number, source: Uint8Array, mode: string, filter?: string) => void;
+    decodeGltfBufferAsync: (count: number, size: number, source: Uint8Array, mode: string, filter?: string) => Promise<Uint8Array>;
 };

--- a/js/meshopt_decoder.module.d.ts
+++ b/js/meshopt_decoder.module.d.ts
@@ -9,5 +9,7 @@ export const MeshoptDecoder: {
     decodeIndexSequence: (target: Uint8Array, count: number, size: number, source: Uint8Array) => void;
 
     decodeGltfBuffer: (target: Uint8Array, count: number, size: number, source: Uint8Array, mode: string, filter?: string) => void;
+
+    useWorkers: (count: number) => void;
     decodeGltfBufferAsync: (count: number, size: number, source: Uint8Array, mode: string, filter?: string) => Promise<Uint8Array>;
 };


### PR DESCRIPTION
This change implements support for using WebWorkers during mesh
decoding; MeshoptDecoder module now has a function, useWorkers, that -
when called - switches behavior of the new function
decodeGltfBufferAsync to use web workers.

decodeGltfBufferAsync can also work without web workers, and it doesn't
require the use of ready promise, which simplifies support in GLTF
loaders.