### PR TITLE
vertexcodec: Use a more efficient lowering for neonMoveMask

### DIFF
--- a/src/vertexcodec.cpp
+++ b/src/vertexcodec.cpp
@@ -607,7 +607,7 @@ static void neonMoveMask(uint8x16_t mask, unsigned char& mask0, unsigned char& m
 	// magic constant found using z3 SMT assuming mask has 8 groups of 0xff or 0x00
 	const uint64_t magic = 0x000103070f1f3f80ull;
 
-	uint64x2_t mask2 = vreinterpretq_u8_u64(mask);
+	uint64x2_t mask2 = vreinterpretq_u64_u8(mask);
 
 	mask0 = uint8_t((vgetq_lane_u64(mask2, 0) * magic) >> 56);
 	mask1 = uint8_t((vgetq_lane_u64(mask2, 1) * magic) >> 56);

--- a/src/vertexcodec.cpp
+++ b/src/vertexcodec.cpp
@@ -604,24 +604,13 @@ static uint8x16_t shuffleBytes(unsigned char mask0, unsigned char mask1, uint8x8
 
 static void neonMoveMask(uint8x16_t mask, unsigned char& mask0, unsigned char& mask1)
 {
-	static const unsigned char byte_mask_data[16] = {1, 2, 4, 8, 16, 32, 64, 128, 1, 2, 4, 8, 16, 32, 64, 128};
+	// magic constant found using z3 SMT assuming mask has 8 groups of 0xff or 0x00
+	const uint64_t magic = 0x000103070f1f3f80ull;
 
-	uint8x16_t byte_mask = vld1q_u8(byte_mask_data);
-	uint8x16_t masked = vandq_u8(mask, byte_mask);
+	uint64x2_t mask2 = vreinterpretq_u8_u64(mask);
 
-#ifdef __aarch64__
-	// aarch64 has horizontal sums; MSVC doesn't expose this via arm64_neon.h so this path is exclusive to clang/gcc
-	mask0 = vaddv_u8(vget_low_u8(masked));
-	mask1 = vaddv_u8(vget_high_u8(masked));
-#else
-	// we need horizontal sums of each half of masked, which can be done in 3 steps (yielding sums of sizes 2, 4, 8)
-	uint8x8_t sum1 = vpadd_u8(vget_low_u8(masked), vget_high_u8(masked));
-	uint8x8_t sum2 = vpadd_u8(sum1, sum1);
-	uint8x8_t sum3 = vpadd_u8(sum2, sum2);
-
-	mask0 = vget_lane_u8(sum3, 0);
-	mask1 = vget_lane_u8(sum3, 1);
-#endif
+	mask0 = uint8_t((vgetq_lane_u64(mask2, 0) * magic) >> 56);
+	mask1 = uint8_t((vgetq_lane_u64(mask2, 1) * magic) >> 56);
 }
 
 static const unsigned char* decodeBytesGroupSimd(const unsigned char* data, unsigned char* buffer, int bitslog2)
@@ -715,7 +704,6 @@ static void wasmMoveMask(v128_t mask, unsigned char& mask0, unsigned char& mask1
 	// magic constant found using z3 SMT assuming mask has 8 groups of 0xff or 0x00
 	const uint64_t magic = 0x000103070f1f3f80ull;
 
-	// TODO: This can use v8x16_bitmask in the future
 	mask0 = uint8_t((wasm_i64x2_extract_lane(mask, 0) * magic) >> 56);
 	mask1 = uint8_t((wasm_i64x2_extract_lane(mask, 1) * magic) >> 56);
 }

--- a/tools/movemask.smt2
+++ b/tools/movemask.smt2
@@ -1,0 +1,47 @@
+; $ z3 movemask.smt2
+; sat
+; (model
+;   (define-fun magic () (_ BitVec 64)
+;     #x000103070f1f3f80)
+; )
+
+(set-logic BV)
+
+(declare-const magic (_ BitVec 64))
+
+(define-fun same ((v (_ BitVec 8))) Bool
+ (or (= v #x00) (= v #xFF)))
+
+(assert
+  (forall ((x (_ BitVec 64)))
+    (let ((y (bvmul x magic)))
+      (or
+        (not
+          (and
+           (same ((_ extract 63 56) x))
+           (same ((_ extract 55 48) x))
+           (same ((_ extract 47 40) x))
+           (same ((_ extract 39 32) x))
+           (same ((_ extract 31 24) x))
+           (same ((_ extract 23 16) x))
+           (same ((_ extract 15 8) x))
+           (same ((_ extract 7 0) x))
+           )
+        )
+        (and
+          (= ((_ extract 63 63) x) ((_ extract 63 63) y))
+          (= ((_ extract 55 55) x) ((_ extract 62 62) y))
+          (= ((_ extract 47 47) x) ((_ extract 61 61) y))
+          (= ((_ extract 39 39) x) ((_ extract 60 60) y))
+          (= ((_ extract 31 31) x) ((_ extract 59 59) y))
+          (= ((_ extract 23 23) x) ((_ extract 58 58) y))
+          (= ((_ extract 15 15) x) ((_ extract 57 57) y))
+          (= ((_ extract  7  7) x) ((_ extract 56 56) y))
+        )
+      )
+    )
+  )
+)
+
+(check-sat)
+(get-model)


### PR DESCRIPTION
Instead of using horizontal adds or more expensive paired adds on 32-bit ARM,
we can use the same trick we use for Wasm which assumes that all input
components are 32-bit and uses a specially crafted constant to turn the result
into a bitmask.

This results in ~2% faster decoding on Apple M2; the performance will need to
be validated on other ARM CPUs.