### PR TITLE
Clean up build infrastructure around Wasm

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -96,16 +96,13 @@ jobs:
       run: |
         curl -sL https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-$VERSION/wasi-sdk-$VERSION.0-linux.tar.gz | tar xz
         curl -sL https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-$VERSION/libclang_rt.builtins-wasm32-wasi-$VERSION.0.tar.gz | tar xz -C wasi-sdk-$VERSION.0
-        curl -sL https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-$VERSION/wasi-sysroot-$VERSION.0.tar.gz | tar xz
+        curl -sL https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-$VERSION/wasi-sysroot-$VERSION.0.tar.gz | tar xz -C wasi-sdk-$VERSION.0/share
         mv wasi-sdk-$VERSION.0 wasi-sdk
       env:
         VERSION: 16
     - name: build
       run: |
-        make -B WASMCC=wasi-sdk/bin/clang++ WASIROOT=./wasi-sysroot gltf/library.wasm
-        make -B WASMCC=wasi-sdk/bin/clang++ WASIROOT=./wasi-sysroot js/meshopt_decoder.js js/meshopt_decoder.module.js
-        make -B WASMCC=wasi-sdk/bin/clang++ WASIROOT=./wasi-sysroot js/meshopt_encoder.js js/meshopt_encoder.module.js
-        make -B WASMCC=wasi-sdk/bin/clang++ WASIROOT=./wasi-sysroot js/meshopt_simplifier.js js/meshopt_simplifier.module.js
+        make -B WASI_SDK=wasi-sdk gltf/library.wasm js
         git status
     - name: test
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -102,10 +102,10 @@ jobs:
         VERSION: 16
     - name: build
       run: |
-        make -B WASMCC=wasi-sdk/bin/clang++ WASI_SDK=./wasi-sysroot gltf/library.wasm
-        make -B WASMCC=wasi-sdk/bin/clang++ WASI_SDK=./wasi-sysroot js/meshopt_decoder.js js/meshopt_decoder.module.js
-        make -B WASMCC=wasi-sdk/bin/clang++ WASI_SDK=./wasi-sysroot js/meshopt_encoder.js js/meshopt_encoder.module.js
-        make -B WASMCC=wasi-sdk/bin/clang++ WASI_SDK=./wasi-sysroot js/meshopt_simplifier.js js/meshopt_simplifier.module.js
+        make -B WASMCC=wasi-sdk/bin/clang++ WASIROOT=./wasi-sysroot gltf/library.wasm
+        make -B WASMCC=wasi-sdk/bin/clang++ WASIROOT=./wasi-sysroot js/meshopt_decoder.js js/meshopt_decoder.module.js
+        make -B WASMCC=wasi-sdk/bin/clang++ WASIROOT=./wasi-sysroot js/meshopt_encoder.js js/meshopt_encoder.module.js
+        make -B WASMCC=wasi-sdk/bin/clang++ WASIROOT=./wasi-sysroot js/meshopt_simplifier.js js/meshopt_simplifier.module.js
         git status
     - name: test
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,10 +52,10 @@ jobs:
         VERSION: 16
     - name: build
       run: |
-        make -B WASMCC=wasi-sdk/bin/clang++ WASI_SDK=./wasi-sysroot gltf/library.wasm
-        make -B WASMCC=wasi-sdk/bin/clang++ WASI_SDK=./wasi-sysroot js/meshopt_decoder.js js/meshopt_decoder.module.js
-        make -B WASMCC=wasi-sdk/bin/clang++ WASI_SDK=./wasi-sysroot js/meshopt_encoder.js js/meshopt_encoder.module.js
-        make -B WASMCC=wasi-sdk/bin/clang++ WASI_SDK=./wasi-sysroot js/meshopt_simplifier.js js/meshopt_simplifier.module.js
+        make -B WASMCC=wasi-sdk/bin/clang++ WASIROOT=./wasi-sysroot gltf/library.wasm
+        make -B WASMCC=wasi-sdk/bin/clang++ WASIROOT=./wasi-sysroot js/meshopt_decoder.js js/meshopt_decoder.module.js
+        make -B WASMCC=wasi-sdk/bin/clang++ WASIROOT=./wasi-sysroot js/meshopt_encoder.js js/meshopt_encoder.module.js
+        make -B WASMCC=wasi-sdk/bin/clang++ WASIROOT=./wasi-sysroot js/meshopt_simplifier.js js/meshopt_simplifier.module.js
         git status
     - name: npm pack
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,16 +46,13 @@ jobs:
       run: |
         curl -sL https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-$VERSION/wasi-sdk-$VERSION.0-linux.tar.gz | tar xz
         curl -sL https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-$VERSION/libclang_rt.builtins-wasm32-wasi-$VERSION.0.tar.gz | tar xz -C wasi-sdk-$VERSION.0
-        curl -sL https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-$VERSION/wasi-sysroot-$VERSION.0.tar.gz | tar xz
+        curl -sL https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-$VERSION/wasi-sysroot-$VERSION.0.tar.gz | tar xz -C wasi-sdk-$VERSION.0/share
         mv wasi-sdk-$VERSION.0 wasi-sdk
       env:
         VERSION: 16
     - name: build
       run: |
-        make -B WASMCC=wasi-sdk/bin/clang++ WASIROOT=./wasi-sysroot gltf/library.wasm
-        make -B WASMCC=wasi-sdk/bin/clang++ WASIROOT=./wasi-sysroot js/meshopt_decoder.js js/meshopt_decoder.module.js
-        make -B WASMCC=wasi-sdk/bin/clang++ WASIROOT=./wasi-sysroot js/meshopt_encoder.js js/meshopt_encoder.module.js
-        make -B WASMCC=wasi-sdk/bin/clang++ WASIROOT=./wasi-sysroot js/meshopt_simplifier.js js/meshopt_simplifier.module.js
+        make -B WASI_SDK=wasi-sdk gltf/library.wasm js
         git status
     - name: npm pack
       run: |

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ ifdef BASISU
     endif
 endif
 
-WASMCC?=$(WASI_SDK)/bin/clang
+WASMCC?=$(WASI_SDK)/bin/clang++
 WASIROOT?=$(WASI_SDK)/share/wasi-sysroot
 
 WASM_FLAGS=--target=wasm32-wasi --sysroot=$(WASIROOT)

--- a/Makefile
+++ b/Makefile
@@ -35,10 +35,10 @@ ifdef BASISU
     endif
 endif
 
-WASMCC=clang++
-WASI_SDK=
+WASMCC?=$(WASI_SDK)/bin/clang
+WASIROOT?=$(WASI_SDK)/share/wasi-sysroot
 
-WASM_FLAGS=--target=wasm32-wasi --sysroot=$(WASI_SDK)
+WASM_FLAGS=--target=wasm32-wasi --sysroot=$(WASIROOT)
 WASM_FLAGS+=-O3 -DNDEBUG -nostartfiles -nostdlib -Wl,--no-entry -Wl,-s
 WASM_FLAGS+=-fno-slp-vectorize -fno-vectorize -fno-unroll-loops
 WASM_FLAGS+=-Wl,-z -Wl,stack-size=24576 -Wl,--initial-memory=65536
@@ -111,7 +111,7 @@ $(BUILD)/gltfpack: $(GLTFPACK_OBJECTS) $(LIBRARY)
 gltfpack.wasm: gltf/library.wasm
 
 gltf/library.wasm: ${LIBRARY_SOURCES} ${GLTFPACK_SOURCES} tools/meshloader.cpp
-	$(WASMCC) $^ -o $@ -Os -DNDEBUG --target=wasm32-wasi --sysroot=$(WASI_SDK) -nostartfiles -Wl,--no-entry -Wl,--export=pack -Wl,--export=malloc -Wl,--export=free -Wl,--export=__wasm_call_ctors -Wl,-s -Wl,--allow-undefined-file=gltf/wasistubs.txt
+	$(WASMCC) $^ -o $@ -Os -DNDEBUG --target=wasm32-wasi --sysroot=$(WASIROOT) -nostartfiles -Wl,--no-entry -Wl,--export=pack -Wl,--export=malloc -Wl,--export=free -Wl,--export=__wasm_call_ctors -Wl,-s -Wl,--allow-undefined-file=gltf/wasistubs.txt
 
 build/decoder_base.wasm: $(WASM_DECODER_SOURCES)
 	@mkdir -p build
@@ -162,10 +162,10 @@ codecbench-simd.js: tools/codecbench.cpp ${LIBRARY_SOURCES}
 	emcc $^ -O3 -g -DNDEBUG -s TOTAL_MEMORY=268435456 -s SINGLE_FILE=1 -msimd128 -o $@
 
 codecbench.wasm: tools/codecbench.cpp ${LIBRARY_SOURCES}
-	$(WASMCC) $^ -fno-exceptions --target=wasm32-wasi --sysroot=$(WASI_SDK) -lc++ -lc++abi -O3 -g -DNDEBUG -o $@
+	$(WASMCC) $^ -fno-exceptions --target=wasm32-wasi --sysroot=$(WASIROOT) -lc++ -lc++abi -O3 -g -DNDEBUG -o $@
 
 codecbench-simd.wasm: tools/codecbench.cpp ${LIBRARY_SOURCES}
-	$(WASMCC) $^ -fno-exceptions --target=wasm32-wasi --sysroot=$(WASI_SDK) -lc++ -lc++abi -O3 -g -DNDEBUG -msimd128 -o $@
+	$(WASMCC) $^ -fno-exceptions --target=wasm32-wasi --sysroot=$(WASIROOT) -lc++ -lc++abi -O3 -g -DNDEBUG -msimd128 -o $@
 
 codecfuzz: tools/codecfuzz.cpp src/vertexcodec.cpp src/indexcodec.cpp
 	$(CXX) $^ -fsanitize=fuzzer,address,undefined -O1 -g -o $@


### PR DESCRIPTION
Now we can point WASI_SDK to an actual SDK install (using Ubuntu packaging structure).