### PR TITLE
gltfpack: Remove dummy -te option

### DIFF
--- a/gltf/gltfpack.cpp
+++ b/gltf/gltfpack.cpp
@@ -1304,10 +1304,6 @@ int main(int argc, char** argv)
 		{
 			settings.texture_flipy = true;
 		}
-		else if (strcmp(arg, "-te") == 0)
-		{
-			fprintf(stderr, "Warning: -te is deprecated and will be removed in the future; gltfpack now automatically embeds textures into GLB files\n");
-		}
 		else if (strcmp(arg, "-tj") == 0 && i + 1 < argc && isdigit(argv[i + 1][0]))
 		{
 			settings.texture_jobs = clamp(atoi(argv[++i]), 0, 128);


### PR DESCRIPTION
Specifying -te did nothing for 2 years now (since 0.15); it looks like
the mere presence of the option now generates some confusion (#459), so
this change simply removes it for the future release.