### PR TITLE
gltfpack: Experimental support for floating point position quantization

### DIFF
--- a/gltf/gltfpack.cpp
+++ b/gltf/gltfpack.cpp
@@ -507,7 +507,7 @@ static void process(cgltf_data* data, const char* input_path, const char* output
 
 		comma(json_materials);
 		append(json_materials, "{");
-		writeMaterial(json_materials, data, material, settings.quantize ? &qp : NULL, settings.quantize ? &qt_materials[i] : NULL);
+		writeMaterial(json_materials, data, material, settings.quantize && !settings.pos_float ? &qp : NULL, settings.quantize ? &qt_materials[i] : NULL);
 		if (settings.keep_extras)
 			writeExtras(json_materials, extras, material.extras);
 		append(json_materials, "}");
@@ -657,7 +657,7 @@ static void process(cgltf_data* data, const char* input_path, const char* output
 				assert(ni.keep);
 				ni.meshes.push_back(node_offset);
 
-				writeMeshNode(json_nodes, mesh_offset, mesh.nodes[j], mesh.skin, data, settings.quantize ? &qp : NULL);
+				writeMeshNode(json_nodes, mesh_offset, mesh.nodes[j], mesh.skin, data, settings.quantize && !settings.pos_float ? &qp : NULL);
 
 				node_offset++;
 			}
@@ -681,7 +681,7 @@ static void process(cgltf_data* data, const char* input_path, const char* output
 			comma(json_roots[mesh.scene]);
 			append(json_roots[mesh.scene], node_offset);
 
-			writeMeshNode(json_nodes, mesh_offset, NULL, mesh.skin, data, settings.quantize ? &qp : NULL);
+			writeMeshNode(json_nodes, mesh_offset, NULL, mesh.skin, data, settings.quantize && !settings.pos_float ? &qp : NULL);
 
 			node_offset++;
 		}
@@ -1191,6 +1191,10 @@ int main(int argc, char** argv)
 		{
 			settings.pos_normalized = true;
 		}
+		else if (strcmp(arg, "-vpf") == 0)
+		{
+			settings.pos_float = true;
+		}
 		else if (strcmp(arg, "-at") == 0 && i + 1 < argc && isdigit(argv[i + 1][0]))
 		{
 			settings.trn_bits = clamp(atoi(argv[++i]), 1, 24);
@@ -1424,6 +1428,7 @@ int main(int argc, char** argv)
 			fprintf(stderr, "\t-vn N: use N-bit quantization for normals and tangents (default: 8; N should be between 1 and 16)\n");
 			fprintf(stderr, "\t-vc N: use N-bit quantization for colors (default: 8; N should be between 1 and 16)\n");
 			fprintf(stderr, "\t-vpn: use normalized attributes for positions instead of using integers\n");
+			fprintf(stderr, "\t-vpf: use floating point attributes for positions instead of using quantization\n");
 			fprintf(stderr, "\nAnimations:\n");
 			fprintf(stderr, "\t-at N: use N-bit quantization for translations (default: 16; N should be between 1 and 24)\n");
 			fprintf(stderr, "\t-ar N: use N-bit quantization for rotations (default: 12; N should be between 4 and 16)\n");

--- a/gltf/gltfpack.cpp
+++ b/gltf/gltfpack.cpp
@@ -1314,6 +1314,7 @@ int main(int argc, char** argv)
 		}
 		else if (strcmp(arg, "-noq") == 0)
 		{
+			// TODO: Warn if -noq is used and suggest -vpf instead; use -noqq to silence
 			settings.quantize = false;
 		}
 		else if (strcmp(arg, "-i") == 0 && i + 1 < argc && !input)
@@ -1428,7 +1429,7 @@ int main(int argc, char** argv)
 			fprintf(stderr, "\t-vn N: use N-bit quantization for normals and tangents (default: 8; N should be between 1 and 16)\n");
 			fprintf(stderr, "\t-vc N: use N-bit quantization for colors (default: 8; N should be between 1 and 16)\n");
 			fprintf(stderr, "\t-vpn: use normalized attributes for positions instead of using integers\n");
-			fprintf(stderr, "\t-vpf: use floating point attributes for positions instead of using quantization\n");
+			fprintf(stderr, "\t-vpf: use floating point attributes for positions instead of using integers\n");
 			fprintf(stderr, "\nAnimations:\n");
 			fprintf(stderr, "\t-at N: use N-bit quantization for translations (default: 16; N should be between 1 and 24)\n");
 			fprintf(stderr, "\t-ar N: use N-bit quantization for rotations (default: 12; N should be between 4 and 16)\n");

--- a/gltf/gltfpack.cpp
+++ b/gltf/gltfpack.cpp
@@ -1492,6 +1492,18 @@ int main(int argc, char** argv)
 		return 1;
 	}
 
+	if (settings.fallback && settings.compressmore)
+	{
+		fprintf(stderr, "Option -cf can not be used together with -cc\n");
+		return 1;
+	}
+
+	if (settings.fallback && settings.pos_float)
+	{
+		fprintf(stderr, "Option -cf can not be used together with -vpf\n");
+		return 1;
+	}
+
 	return gltfpack(input, output, report, settings);
 }
 

--- a/gltf/gltfpack.h
+++ b/gltf/gltfpack.h
@@ -109,6 +109,7 @@ struct Settings
 	int col_bits;
 
 	bool pos_normalized;
+	bool pos_float;
 
 	int trn_bits;
 	int rot_bits;

--- a/gltf/gltfpack.h
+++ b/gltf/gltfpack.h
@@ -323,7 +323,7 @@ void decomposeTransform(float translation[3], float rotation[4], float scale[3],
 
 QuantizationPosition prepareQuantizationPosition(const std::vector<Mesh>& meshes, const Settings& settings);
 void prepareQuantizationTexture(cgltf_data* data, std::vector<QuantizationTexture>& result, std::vector<size_t>& indices, const std::vector<Mesh>& meshes, const Settings& settings);
-void getPositionBounds(float min[3], float max[3], const Stream& stream, const QuantizationPosition* qp);
+void getPositionBounds(float min[3], float max[3], const Stream& stream, const QuantizationPosition& qp, const Settings& settings);
 
 StreamFormat writeVertexStream(std::string& bin, const Stream& stream, const QuantizationPosition& qp, const QuantizationTexture& qt, const Settings& settings);
 StreamFormat writeIndexStream(std::string& bin, const std::vector<unsigned int>& stream);

--- a/gltf/write.cpp
+++ b/gltf/write.cpp
@@ -948,7 +948,7 @@ void writeMeshAttributes(std::string& json, std::vector<BufferView>& views, std:
 		{
 			float min[3] = {};
 			float max[3] = {};
-			getPositionBounds(min, max, stream, settings.quantize && !settings.pos_float ? &qp : NULL);
+			getPositionBounds(min, max, stream, qp, settings);
 
 			writeAccessor(json_accessors, view, offset, format.type, format.component_type, format.normalized, stream.data.size(), min, max, 3);
 		}

--- a/gltf/write.cpp
+++ b/gltf/write.cpp
@@ -948,7 +948,7 @@ void writeMeshAttributes(std::string& json, std::vector<BufferView>& views, std:
 		{
 			float min[3] = {};
 			float max[3] = {};
-			getPositionBounds(min, max, stream, settings.quantize ? &qp : NULL);
+			getPositionBounds(min, max, stream, settings.quantize && !settings.pos_float ? &qp : NULL);
 
 			writeAccessor(json_accessors, view, offset, format.type, format.component_type, format.normalized, stream.data.size(), min, max, 3);
 		}
@@ -1026,7 +1026,7 @@ size_t writeJointBindMatrices(std::vector<BufferView>& views, std::string& json_
 			cgltf_accessor_read_float(skin.inverse_bind_matrices, j, transform, 16);
 		}
 
-		if (settings.quantize)
+		if (settings.quantize && !settings.pos_float)
 		{
 			float node_scale = qp.scale / float((1 << qp.bits) - 1) * (qp.normalized ? 65535.f : 1.f);
 
@@ -1083,7 +1083,7 @@ size_t writeInstances(std::vector<BufferView>& views, std::string& json_accessor
 	{
 		decomposeTransform(position[i].f, rotation[i].f, scale[i].f, transforms[i].data);
 
-		if (settings.quantize)
+		if (settings.quantize && !settings.pos_float)
 		{
 			const float* transform = transforms[i].data;
 

--- a/src/vertexfilter.cpp
+++ b/src/vertexfilter.cpp
@@ -931,7 +931,7 @@ void meshopt_encodeFilterExp(void* destination_, size_t count, size_t stride, in
 		const float* v = &data[i * stride_float];
 		unsigned int* d = &destination[i * stride_float];
 
-		// use maximum exponent to encode values; this guarantess that mantissa is [-1, 1]
+		// use maximum exponent to encode values; this guarantees that mantissa is [-1, 1]
 		int exp = -100;
 
 		for (size_t j = 0; j < stride_float; ++j)


### PR DESCRIPTION
Currently gltfpack provides all or nothing quantization: either all
attributes get quantized, or none do.

When quantization is used, we use the most size and memory efficient
formats, which is great, but it can lead to integration issues for
applications - since dequantization uses an extra transform, this
results in changes that are needed for some applications to take that
transform into account. Notably, these changes mostly revolve around
positions (and rarely around texture coordinates wrt texture
replacement, but positions are definitely the main source of issues).

Due to the flexibility of meshopt codecs however, there are other
options available that don't change the coordinate space of mesh
positions, but instead just change the positions a little bit to encode
more efficiently.

This change adds a new mode, -vpf, which uses floating point
quantization to encode position values:

- When using regular compression (-c), we quantize each coordinate
  individually
- When using extra compression (-cc), we use exponential filter when
  serializing the position stream

It is expected that either mode is less efficient than integer
quantization, but -cc can be closer to integer quantization and on
meshes with many attributes the extra size could be an acceptable
tradeoff for better compatibility. Of course this also results in geometry
taking a little bit more space after being loaded, since we use 12 bytes
per position instead of 8 bytes.

- [x] Fix min/max bounds (these need to be precise to validate correctly)
- [x] Gather size statistics for various models
- [x] Validate quantization bits behavior for models to ensure precision is reasonably close between different modes
- [x] Figure out how to select between float quantization vs separate vs shared exponent