### PR TITLE
gltfpack: Try to attach meshes directly to their nodes

### DIFF
--- a/gltf/gltfpack.h
+++ b/gltf/gltfpack.h
@@ -196,7 +196,12 @@ struct NodeInfo
 	unsigned int animated_paths;
 
 	int remap;
-	std::vector<size_t> meshes;
+
+	std::vector<size_t> mesh_nodes;
+
+	bool has_mesh;
+	size_t mesh_index;
+	cgltf_skin* mesh_skin;
 };
 
 struct MaterialInfo


### PR DESCRIPTION
When integer/normalized quantization is used, gltfpack must use an extra
node to specify the dequantization transform. Before this change,
gltfpack always attached meshes via separate nodes because of this -
while in some cases this transform can be embedded into parent node,
this breaks animations and application logic and complicates the flow.

However, when the dequantization transform is not necessary, we now try
to attach the mesh to the original node. There's some complexity
associated with the fact that glTF nodes can only contain a single mesh,
however this generally still works out since splitting & recombining the
meshes mostly preserves the 1-1 relationship.

This is especially powerful in combination with the recently added `-vpf`:
now adding `-vpf -cc -kn` produces a highly compressed file that still has
the same node structure (when named nodes are concerned), and likely
just works for most applications without the need to change the
application logic.

Fixes #424.