### PR TITLE
gltfpack: Add -vpi option to match current default

### DIFF
--- a/gltf/gltfpack.cpp
+++ b/gltf/gltfpack.cpp
@@ -1197,8 +1197,14 @@ int main(int argc, char** argv)
 		{
 			settings.col_bits = clamp(atoi(argv[++i]), 1, 16);
 		}
+		else if (strcmp(arg, "-vpi") == 0)
+		{
+			settings.pos_float = false;
+			settings.pos_normalized = false;
+		}
 		else if (strcmp(arg, "-vpn") == 0)
 		{
+			settings.pos_float = false;
 			settings.pos_normalized = true;
 		}
 		else if (strcmp(arg, "-vpf") == 0)
@@ -1438,8 +1444,10 @@ int main(int argc, char** argv)
 			fprintf(stderr, "\t-vt N: use N-bit quantization for texture coordinates (default: 12; N should be between 1 and 16)\n");
 			fprintf(stderr, "\t-vn N: use N-bit quantization for normals and tangents (default: 8; N should be between 1 and 16)\n");
 			fprintf(stderr, "\t-vc N: use N-bit quantization for colors (default: 8; N should be between 1 and 16)\n");
-			fprintf(stderr, "\t-vpn: use normalized attributes for positions instead of using integers\n");
-			fprintf(stderr, "\t-vpf: use floating point attributes for positions instead of using integers\n");
+			fprintf(stderr, "\nVertex positions:\n");
+			fprintf(stderr, "\t-vpi: use integer attributes for positions (default)\n");
+			fprintf(stderr, "\t-vpn: use normalized attributes for positions\n");
+			fprintf(stderr, "\t-vpf: use floating point attributes for positions\n");
 			fprintf(stderr, "\nAnimations:\n");
 			fprintf(stderr, "\t-at N: use N-bit quantization for translations (default: 16; N should be between 1 and 24)\n");
 			fprintf(stderr, "\t-ar N: use N-bit quantization for rotations (default: 12; N should be between 4 and 16)\n");


### PR DESCRIPTION
Right now specifying -vpi does nothing compared to the default options,
but it might become useful if we decide to change the default to -vpf