### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,17 +39,7 @@ The source files are organized in such a way that you don't need to change your 
 
 ## Installing from vcpkg
 
-The meshoptimizer port in vcpkg is kept up to date by Microsoft team members and community contributors. The url of vcpkg is: https://github.com/Microsoft/vcpkg . You can download and install meshoptimizer using the vcpkg dependency manager:
-
-```shell
-git clone https://github.com/Microsoft/vcpkg.git
-cd vcpkg
-./bootstrap-vcpkg.sh  # ./bootstrap-vcpkg.bat for Windows
-./vcpkg integrate install
-./vcpkg install meshoptimizer
-```
-
-If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
+The meshoptimizer port in [vcpkg](https://github.com/Microsoft/vcpkg) is kept up to date by Microsoft team members and community contributors. You can download and install meshoptimizer using the vcpkg dependency manager, [Getting Started](https://github.com/microsoft/vcpkg#getting-started).
 
 ## Pipeline
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,20 @@ meshoptimizer is distributed as a set of C++ source files. To include it into yo
 
 The source files are organized in such a way that you don't need to change your build-system settings, and you only need to add the files for the algorithms you use.
 
+## Installing from vcpkg
+
+The meshoptimizer port in vcpkg is kept up to date by Microsoft team members and community contributors. The url of vcpkg is: https://github.com/Microsoft/vcpkg . You can download and install meshoptimizer using the vcpkg dependency manager:
+
+```shell
+git clone https://github.com/Microsoft/vcpkg.git
+cd vcpkg
+./bootstrap-vcpkg.sh  # ./bootstrap-vcpkg.bat for Windows
+./vcpkg integrate install
+./vcpkg install meshoptimizer
+```
+
+If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
+
 ## Pipeline
 
 When optimizing a mesh, you should typically feed it through a set of optimizations (the order is important!):


### PR DESCRIPTION
Meshoptimizer is available as a port in [vcpkg](https://github.com/microsoft/vcpkg), a C++ library manager that simplifies installation for meshoptimizer and other project dependencies. Documenting the install process here will help users get started by providing a single set of commands to build meshoptimizer, ready to be included in their projects.

We also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64, UWP, ARM) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and [here](https://github.com/microsoft/vcpkg/blob/master/ports/meshoptimizer/portfile.cmake) is what the port script looks like. We try to keep the library maintained as close as possible to the original library.