### PR TITLE
Reorganize builds a little bit

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,11 @@ on:
   push:
     branches:
       - 'master'
+    paths-ignore:
+      - '*.md'
   pull_request:
+    paths-ignore:
+      - '*.md'
 
 jobs:
   unix:
@@ -85,7 +89,7 @@ jobs:
       env:
         VALIDATOR: https://github.com/KhronosGroup/glTF-Validator/releases/download/2.0.0-dev.3.3/gltf_validator-2.0.0-dev.3.3-linux64.tar.xz
 
-  gltfpackjs:
+  gltfpack-js:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
@@ -102,7 +106,7 @@ jobs:
         VERSION: 16
     - name: build
       run: |
-        make -B WASI_SDK=wasi-sdk gltf/library.wasm js
+        make -j2 -B WASI_SDK=wasi-sdk gltf/library.wasm js
         git status
     - name: test
       run: |
@@ -112,6 +116,18 @@ jobs:
         node js/meshopt_decoder.test.js
         node js/meshopt_encoder.test.js
         node js/meshopt_simplifier.test.js
+
+  gltfpack-basis:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
+      with:
+        repository: zeux/basis_universal
+        ref: gltfpack
+        path: basis_universal
+    - name: make gltfpack
+      run: make -j2 BASISU=basis_universal gltfpack
 
   arm64:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,8 @@ on:
   push:
     branches:
       - 'master'
-  pull_request:
+    paths-ignore:
+      - '*.md'
 
 jobs:
   gltfpack:
@@ -23,7 +24,7 @@ jobs:
     - name: cmake configure
       run: cmake . -DMESHOPT_BUILD_GLTFPACK=ON -DMESHOPT_BASISU_PATH=basis_universal -DCMAKE_MSVC_RUNTIME_LIBRARY="MultiThreaded" -DCMAKE_BUILD_TYPE=Release
     - name: cmake build
-      run: cmake --build . --target gltfpack --config Release
+      run: cmake --build . --target gltfpack --config Release -j 2
     - uses: actions/upload-artifact@v1
       with:
         name: gltfpack-windows
@@ -52,7 +53,7 @@ jobs:
         VERSION: 16
     - name: build
       run: |
-        make -B WASI_SDK=wasi-sdk gltf/library.wasm js
+        make -j2 -B WASI_SDK=wasi-sdk gltf/library.wasm js
         git status
     - name: npm pack
       run: |


### PR DESCRIPTION
With this change we no longer build anything for .md changes to make
sure we don't waste build capacity, and don't build release action on
PRs - instead we add a simple build to validate that gltfpack builds in
Basis mode to build.yml to prevent regressions.