### PR TITLE
GCC and -Werror=alloc-size-larger-than error

### DIFF
--- a/src/meshoptimizer.h
+++ b/src/meshoptimizer.h
@@ -10,6 +10,7 @@
 
 #include <assert.h>
 #include <stddef.h>
+#include <stdint.h>
 
 /* Version macro; major * 1000 + minor * 10 + patch */
 #define MESHOPTIMIZER_VERSION 180 /* 0.18 */
@@ -736,7 +737,7 @@ public:
 	template <typename T> T* allocate(size_t size)
 	{
 		assert(count < sizeof(blocks) / sizeof(blocks[0]));
-		T* result = static_cast<T*>(Storage::allocate(size > size_t(-1) / sizeof(T) ? size_t(-1) : size * sizeof(T)));
+		T* result = static_cast<T*>(Storage::allocate(size > PTRDIFF_MAX / sizeof(T) ? PTRDIFF_MAX : size * sizeof(T)));
 		blocks[count++] = result;
 		return result;
 	}


### PR DESCRIPTION
Building the latest (`c4cfc35`) with GCC 10.2.1-6 on Debian Bullseye fails with multiples of this error:
```
In member function ‘allocate’,
    inlined from ‘meshopt_optimizeOverdraw’ at /home/carl/Work/Native/Obj2Buf/src/overdrawoptimizer.cpp:294:67,
    inlined from ‘main’ at /home/carl/Work/Native/Obj2Buf/src/main.cpp:195:29:
/home/carl/Work/Native/Obj2Buf/inc/meshoptimizer.h:739:48: error: argument 1 value ‘18446744073709551615’ exceeds maximum object size 9223372036854775807 [-Werror=alloc-size-larger-than=]
  739 |   T* result = static_cast<T*>(Storage::allocate(size > size_t(-1) / sizeof(T) ? size_t(-1) : size * sizeof(T)));
```
This is on a Power9 CPU, and `size_t` is 64-bit as expected.

The fix was to use `PTRDIFF_MAX` as the upper limit (which matches the signed `9223372036854775807` maximum object size). Whilst it seems extreme to be limiting to half the size of `size_t`, even on a 32-bit system this is surely larger that any workable buffer size?

Thoughts? Besides no-one has a Power9 and real men have Power10 these days...