### PR TITLE
gltfpack: Simplify extras handling

### DIFF
--- a/extern/cgltf.h
+++ b/extern/cgltf.h
@@ -837,6 +837,7 @@ cgltf_size cgltf_num_components(cgltf_type type);
 
 cgltf_size cgltf_accessor_unpack_floats(const cgltf_accessor* accessor, cgltf_float* out, cgltf_size float_count);
 
+/* this function is deprecated and will be removed in the future; use cgltf_extras::data instead */
 cgltf_result cgltf_copy_extras_json(const cgltf_data* data, const cgltf_extras* extras, char* dest, cgltf_size* dest_size);
 
 #ifdef __cplusplus
@@ -1718,8 +1719,7 @@ cgltf_result cgltf_validate(cgltf_data* data)
 
 cgltf_result cgltf_copy_extras_json(const cgltf_data* data, const cgltf_extras* extras, char* dest, cgltf_size* dest_size)
 {
-	(void)data;
-	cgltf_size json_size = extras->data ? strlen(extras->data) : 0;
+	cgltf_size json_size = extras->end_offset - extras->start_offset;
 
 	if (!dest)
 	{
@@ -1733,13 +1733,12 @@ cgltf_result cgltf_copy_extras_json(const cgltf_data* data, const cgltf_extras* 
 
 	if (*dest_size + 1 < json_size)
 	{
-		strncpy(dest, extras->data, *dest_size - 1);
+		strncpy(dest, data->json + extras->start_offset, *dest_size - 1);
 		dest[*dest_size - 1] = 0;
 	}
 	else
 	{
-		if (json_size)
-			strncpy(dest, extras->data, json_size);
+		strncpy(dest, data->json + extras->start_offset, json_size);
 		dest[json_size] = 0;
 	}
 

--- a/extern/cgltf.h
+++ b/extern/cgltf.h
@@ -920,12 +920,15 @@ static int jsmn_parse(jsmn_parser *parser, const char *js, size_t len, jsmntok_t
  */
 
 
+#ifndef CGLTF_CONSTS
 static const cgltf_size GlbHeaderSize = 12;
 static const cgltf_size GlbChunkHeaderSize = 8;
 static const uint32_t GlbVersion = 2;
 static const uint32_t GlbMagic = 0x46546C67;
 static const uint32_t GlbMagicJsonChunk = 0x4E4F534A;
 static const uint32_t GlbMagicBinChunk = 0x004E4942;
+#define CGLTF_CONSTS
+#endif
 
 #ifndef CGLTF_MALLOC
 #define CGLTF_MALLOC(size) malloc(size)
@@ -1716,7 +1719,7 @@ cgltf_result cgltf_validate(cgltf_data* data)
 cgltf_result cgltf_copy_extras_json(const cgltf_data* data, const cgltf_extras* extras, char* dest, cgltf_size* dest_size)
 {
 	(void)data;
-	cgltf_size json_size = strlen(extras->data);
+	cgltf_size json_size = extras->data ? strlen(extras->data) : 0;
 
 	if (!dest)
 	{
@@ -1735,7 +1738,8 @@ cgltf_result cgltf_copy_extras_json(const cgltf_data* data, const cgltf_extras* 
 	}
 	else
 	{
-		strncpy(dest, extras->data, json_size);
+		if (json_size)
+			strncpy(dest, extras->data, json_size);
 		dest[json_size] = 0;
 	}
 
@@ -2740,8 +2744,9 @@ static int cgltf_parse_json_extras(cgltf_options* options, jsmntok_t const* toke
 		return CGLTF_ERROR_JSON;
 	}
 
-
-
+	/* fill deprecated fields for now, this will be removed in the future */
+	out_extras->start_offset = tokens[i].start;
+	out_extras->end_offset = tokens[i].end;
 
 	size_t start = tokens[i].start;
 	size_t size = tokens[i].end - start;

--- a/gltf/gltfpack.cpp
+++ b/gltf/gltfpack.cpp
@@ -250,7 +250,7 @@ static bool canTransformMesh(const Mesh& mesh)
 	return true;
 }
 
-static void process(cgltf_data* data, const char* input_path, const char* output_path, const char* report_path, std::vector<Mesh>& meshes, std::vector<Animation>& animations, const std::string& extras, const Settings& settings, std::string& json, std::string& bin, std::string& fallback, size_t& fallback_size)
+static void process(cgltf_data* data, const char* input_path, const char* output_path, const char* report_path, std::vector<Mesh>& meshes, std::vector<Animation>& animations, const Settings& settings, std::string& json, std::string& bin, std::string& fallback, size_t& fallback_size)
 {
 	if (settings.verbose)
 	{
@@ -356,7 +356,7 @@ static void process(cgltf_data* data, const char* input_path, const char* output
 		filterStreams(mesh, mi);
 	}
 
-	mergeMeshMaterials(data, extras, meshes, settings);
+	mergeMeshMaterials(data, meshes, settings);
 	mergeMeshes(meshes, settings);
 	filterEmptyMeshes(meshes);
 
@@ -509,7 +509,7 @@ static void process(cgltf_data* data, const char* input_path, const char* output
 		append(json_materials, "{");
 		writeMaterial(json_materials, data, material, settings.quantize && !settings.pos_float ? &qp : NULL, settings.quantize ? &qt_materials[i] : NULL);
 		if (settings.keep_extras)
-			writeExtras(json_materials, extras, material.extras);
+			writeExtras(json_materials, material.extras);
 		append(json_materials, "}");
 
 		mi.remap = int(material_offset);
@@ -718,7 +718,7 @@ static void process(cgltf_data* data, const char* input_path, const char* output
 		append(json_nodes, "{");
 		writeNode(json_nodes, node, nodes, data);
 		if (settings.keep_extras)
-			writeExtras(json_nodes, extras, node.extras);
+			writeExtras(json_nodes, node.extras);
 		append(json_nodes, "}");
 	}
 
@@ -796,7 +796,7 @@ static void process(cgltf_data* data, const char* input_path, const char* output
 	append(json, "\"version\":\"2.0\",\"generator\":\"gltfpack ");
 	append(json, getVersion());
 	append(json, "\"");
-	writeExtras(json, extras, data->asset.extras);
+	writeExtras(json, data->asset.extras);
 	append(json, "}");
 
 	const ExtensionInfo extensions[] = {
@@ -948,7 +948,6 @@ int gltfpack(const char* input, const char* output, const char* report, Settings
 	cgltf_data* data = 0;
 	std::vector<Mesh> meshes;
 	std::vector<Animation> animations;
-	std::string extras;
 
 	std::string iext = getExtension(input);
 	std::string oext = output ? getExtension(output) : "";
@@ -956,7 +955,7 @@ int gltfpack(const char* input, const char* output, const char* report, Settings
 	if (iext == ".gltf" || iext == ".glb")
 	{
 		const char* error = 0;
-		data = parseGltf(input, meshes, animations, extras, &error);
+		data = parseGltf(input, meshes, animations, &error);
 
 		if (error)
 		{
@@ -999,7 +998,7 @@ int gltfpack(const char* input, const char* output, const char* report, Settings
 
 	std::string json, bin, fallback;
 	size_t fallback_size = 0;
-	process(data, input, output, report, meshes, animations, extras, settings, json, bin, fallback, fallback_size);
+	process(data, input, output, report, meshes, animations, settings, json, bin, fallback, fallback_size);
 
 	cgltf_free(data);
 

--- a/gltf/gltfpack.h
+++ b/gltf/gltfpack.h
@@ -285,7 +285,7 @@ bool readFile(const char* path, std::string& data);
 bool writeFile(const char* path, const std::string& data);
 
 cgltf_data* parseObj(const char* path, std::vector<Mesh>& meshes, const char** error);
-cgltf_data* parseGltf(const char* path, std::vector<Mesh>& meshes, std::vector<Animation>& animations, std::string& extras, const char** error);
+cgltf_data* parseGltf(const char* path, std::vector<Mesh>& meshes, std::vector<Animation>& animations, const char** error);
 
 void processAnimation(Animation& animation, const Settings& settings);
 void processMesh(Mesh& mesh, const Settings& settings);
@@ -302,7 +302,7 @@ void mergeMeshes(std::vector<Mesh>& meshes, const Settings& settings);
 void filterEmptyMeshes(std::vector<Mesh>& meshes);
 void filterStreams(Mesh& mesh, const MaterialInfo& mi);
 
-void mergeMeshMaterials(cgltf_data* data, const std::string& extras, std::vector<Mesh>& meshes, const Settings& settings);
+void mergeMeshMaterials(cgltf_data* data, std::vector<Mesh>& meshes, const Settings& settings);
 void markNeededMaterials(cgltf_data* data, std::vector<MaterialInfo>& materials, const std::vector<Mesh>& meshes, const Settings& settings);
 
 bool hasValidTransform(const cgltf_texture_view& view);
@@ -346,7 +346,7 @@ void append(std::string& s, size_t v);
 void append(std::string& s, float v);
 void append(std::string& s, const char* v);
 void append(std::string& s, const std::string& v);
-void appendJson(std::string& s, const char* begin, const char* end);
+void appendJson(std::string& s, const char* data);
 
 const char* attributeType(cgltf_attribute_type type);
 const char* animationPath(cgltf_animation_path_type type);
@@ -370,7 +370,7 @@ void writeCamera(std::string& json, const cgltf_camera& camera);
 void writeLight(std::string& json, const cgltf_light& light);
 void writeArray(std::string& json, const char* name, const std::string& contents);
 void writeExtensions(std::string& json, const ExtensionInfo* extensions, size_t count);
-void writeExtras(std::string& json, const std::string& data, const cgltf_extras& extras);
+void writeExtras(std::string& json, const cgltf_extras& extras);
 void writeScene(std::string& json, const cgltf_scene& scene, const std::string& roots);
 
 /**

--- a/gltf/json.cpp
+++ b/gltf/json.cpp
@@ -35,7 +35,7 @@ void append(std::string& s, const std::string& v)
 	s += v;
 }
 
-void appendJson(std::string& s, const char* begin, const char* end)
+void appendJson(std::string& s, const char* data)
 {
 	enum State
 	{
@@ -44,7 +44,7 @@ void appendJson(std::string& s, const char* begin, const char* end)
 		Quoted
 	} state = None;
 
-	for (const char* it = begin; it != end; ++it)
+	for (const char* it = data; *it; ++it)
 	{
 		char ch = *it;
 

--- a/gltf/material.cpp
+++ b/gltf/material.cpp
@@ -38,15 +38,12 @@ static bool areTextureViewsEqual(const cgltf_texture_view& lhs, const cgltf_text
 	return true;
 }
 
-static bool areExtrasEqual(const std::string& extras, const cgltf_extras& lhs, const cgltf_extras& rhs)
+static bool areExtrasEqual(const cgltf_extras& lhs, const cgltf_extras& rhs)
 {
-	if (lhs.end_offset - lhs.start_offset != rhs.end_offset - rhs.start_offset)
-		return false;
-
-	if (memcmp(extras.c_str() + lhs.start_offset, extras.c_str() + rhs.start_offset, lhs.end_offset - lhs.start_offset) != 0)
-		return false;
-
-	return true;
+	if (lhs.data && rhs.data)
+		return strcmp(lhs.data, rhs.data) == 0;
+	else
+		return lhs.data == rhs.data;
 }
 
 static bool areMaterialComponentsEqual(const cgltf_pbr_metallic_roughness& lhs, const cgltf_pbr_metallic_roughness& rhs)
@@ -210,7 +207,7 @@ static bool areMaterialComponentsEqual(const cgltf_iridescence& lhs, const cgltf
 	return true;
 }
 
-static bool areMaterialsEqual(const std::string& extras, const cgltf_material& lhs, const cgltf_material& rhs, const Settings& settings)
+static bool areMaterialsEqual(const cgltf_material& lhs, const cgltf_material& rhs, const Settings& settings)
 {
 	if (lhs.has_pbr_metallic_roughness != rhs.has_pbr_metallic_roughness)
 		return false;
@@ -296,13 +293,13 @@ static bool areMaterialsEqual(const std::string& extras, const cgltf_material& l
 	if (lhs.unlit != rhs.unlit)
 		return false;
 
-	if (settings.keep_extras && !areExtrasEqual(extras, lhs.extras, rhs.extras))
+	if (settings.keep_extras && !areExtrasEqual(lhs.extras, rhs.extras))
 		return false;
 
 	return true;
 }
 
-void mergeMeshMaterials(cgltf_data* data, const std::string& extras, std::vector<Mesh>& meshes, const Settings& settings)
+void mergeMeshMaterials(cgltf_data* data, std::vector<Mesh>& meshes, const Settings& settings)
 {
 	std::vector<cgltf_material*> material_remap(data->materials_count);
 
@@ -318,7 +315,7 @@ void mergeMeshMaterials(cgltf_data* data, const std::string& extras, std::vector
 			if (settings.keep_materials && data->materials[j].name && *data->materials[j].name)
 				continue;
 
-			if (areMaterialsEqual(extras, data->materials[i], data->materials[j], settings))
+			if (areMaterialsEqual(data->materials[i], data->materials[j], settings))
 			{
 				material_remap[i] = &data->materials[j];
 				break;

--- a/gltf/write.cpp
+++ b/gltf/write.cpp
@@ -1589,17 +1589,14 @@ void writeExtensions(std::string& json, const ExtensionInfo* extensions, size_t 
 	}
 }
 
-void writeExtras(std::string& json, const std::string& data, const cgltf_extras& extras)
+void writeExtras(std::string& json, const cgltf_extras& extras)
 {
-	if (extras.start_offset == extras.end_offset)
+	if (!extras.data)
 		return;
-
-	assert(extras.start_offset < data.size());
-	assert(extras.end_offset <= data.size());
 
 	comma(json);
 	append(json, "\"extras\":");
-	appendJson(json, data.c_str() + extras.start_offset, data.c_str() + extras.end_offset);
+	appendJson(json, extras.data);
 }
 
 void writeScene(std::string& json, const cgltf_scene& scene, const std::string& roots)


### PR DESCRIPTION
This change reworks cgltf parsing to handle extras by copying the data out of glTF file (upstream PR incoming), which removes the need for extras evacuation thereby simplifying the extras logic and making it easier to extend the pipeline to add extras handling for elements that currently don't preserve these.