### PR TITLE
Don't add -Werror on GCC, it can break compilation in certain cases

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,7 +57,7 @@ set(GLTF_SOURCES
 if(MSVC)
     add_compile_options(/W4 /WX)
 else()
-    add_compile_options(-Wall -Wextra -Wshadow -Wno-missing-field-initializers -Werror)
+    add_compile_options(-Wall -Wextra -Wshadow -Wno-missing-field-initializers)
 endif()
 
 if(MESHOPT_BUILD_SHARED_LIBS)


### PR DESCRIPTION
The `_mm_undefined_si128()` AVX-512 intrinsics on GCC produces an "uninitialized variable" warning (which is, well, what is it intended to actually do), and due to `-Werror` that makes the code not compile even though there's no actual error inside your code. I discovered this only because I use `-march=native` to build my system packages and recently upgraded to an AVX-512-equipped hardware.

For completeness, here's the full error message (compiling 0.18, but same happens in current `master`):

```
/usr/bin/c++ -DMESHOPTIMIZER_API="__attribute__((visibility(\"default\")))" -Dmeshoptimizer_EXPORTS  -march=native -O2 -pipe -fno-plt -fexceptions         -Wp,-D_FORTIFY_SOURCE=2 -Wformat -Werror=format-security         -fstack-clash-protection -fcf-protection -Wp,-D_GLIBCXX_ASSERTIONS -O3 -DNDEBUG -fPIC -fvisibility=hidden -fvisibility-inlines-hidden -Wall -Wextra -Wshadow -Wno-missing-field-initializers -Werror -MD -MT CMakeFiles/meshoptimizer.dir/src/vertexcodec.cpp.o -MF CMakeFiles/meshoptimizer.dir/src/vertexcodec.cpp.o.d -o CMakeFiles/meshoptimizer.dir/src/vertexcodec.cpp.o -c /home/mosra/ABS/meshoptimizer/src/meshoptimizer-0.18/src/vertexcodec.cpp
In file included from /usr/lib/gcc/x86_64-pc-linux-gnu/12.2.0/include/immintrin.h:73,
                 from /home/mosra/ABS/meshoptimizer/src/meshoptimizer-0.18/src/vertexcodec.cpp:68:
In function ‘__m128i _mm_multishift_epi64_epi8(__m128i, __m128i)’,
    inlined from ‘const unsigned char* meshopt::decodeBytesGroupSimd(const unsigned char*, unsigned char*, int)’ at /home/mosra/ABS/meshoptimizer/src/meshoptimizer-0.18/src/vertexcodec.cpp:567:30,
    inlined from ‘const unsigned char* meshopt::decodeBytesSimd(const unsigned char*, const unsigned char*, unsigned char*, size_t)’ at /home/mosra/ABS/meshoptimizer/src/meshoptimizer-0.18/src/vertexcodec.cpp:900:30,
    inlined from ‘const unsigned char* meshopt::decodeVertexBlockSimd(const unsigned char*, const unsigned char*, unsigned char*, size_t, size_t, unsigned char*)’ at /home/mosra/ABS/meshoptimizer/src/meshoptimizer-0.18/src/vertexcodec.cpp:936:26:
/usr/lib/gcc/x86_64-pc-linux-gnu/12.2.0/include/avx512vbmivlintrin.h:94:58: error: ‘__Y’ may be used uninitialized [-Werror=maybe-uninitialized]
   94 |   return (__m128i) __builtin_ia32_vpmultishiftqb128_mask ((__v16qi) __X,
      |                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~
   95 |                                                           (__v16qi) __Y,
      |                                                           ~~~~~~~~~~~~~~
   96 |                                                           (__v16qi)
      |                                                           ~~~~~~~~~
   97 |                                                           _mm_undefined_si128 (),
      |                                                           ~~~~~~~~~~~~~~~~~~~~~~~
   98 |                                                           (__mmask16) -1);
      |                                                           ~~~~~~~~~~~~~~~
In file included from /usr/lib/gcc/x86_64-pc-linux-gnu/12.2.0/include/xmmintrin.h:1316,
                 from /usr/lib/gcc/x86_64-pc-linux-gnu/12.2.0/include/immintrin.h:31:
/usr/lib/gcc/x86_64-pc-linux-gnu/12.2.0/include/emmintrin.h: In function ‘const unsigned char* meshopt::decodeVertexBlockSimd(const unsigned char*, const unsigned char*, unsigned char*, size_t, size_t, unsigned char*)’:
/usr/lib/gcc/x86_64-pc-linux-gnu/12.2.0/include/emmintrin.h:788:11: note: ‘__Y’ was declared here
  788 |   __m128i __Y = __Y;
      |           ^~~
```

And [here's the relevant portion of the GCC intrinsics header](https://github.com/gcc-mirror/gcc/blob/9ac9fde961f76879f0379ff3b2494a2f9ac915f7/gcc/config/i386/emmintrin.h#L784-L790). The use of is coming from [`_mm_multishift_epi64_epi8`](https://github.com/gcc-mirror/gcc/blob/9ac9fde961f76879f0379ff3b2494a2f9ac915f7/gcc/config/i386/avx512vbmivlintrin.h#L90-L99), which is used here: https://github.com/zeux/meshoptimizer/blob/c4cfc3581f37ae70fa274bef37584a588ae266ab/src/vertexcodec.cpp#L603 

I assume this is just a temporary compiler wart that will eventually get fixed (althrough it doesn't seem that any changes to suppress such warning were made in that header so far), so I didn't see a point in trying to silence that warning from within meshoptimizer. Alternatively, `-Werror` could be kept and `-Wno-maybe-uninitialized` added, but I personally find the uninitialized warnings useful, so disabling it altogether might hide some *actual* bugs, and `-Werror` could still cause unforeseen problems in future compiler versions.

Thank you!