### PR TITLE
By default, don't treat warnings as errors in CMake builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,7 +43,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: cmake configure
-      run: cmake . -DMESHOPT_BUILD_DEMO=ON -DMESHOPT_BUILD_GLTFPACK=ON -DCMAKE_MSVC_RUNTIME_LIBRARY="MultiThreaded$<$<CONFIG:Debug>:Debug>" -A ${{matrix.arch}}
+      run: cmake . -DMESHOPT_BUILD_DEMO=ON -DMESHOPT_BUILD_GLTFPACK=ON -DMESHOPT_WERROR=ON -DCMAKE_MSVC_RUNTIME_LIBRARY="MultiThreaded$<$<CONFIG:Debug>:Debug>" -A ${{matrix.arch}}
     - name: cmake test
       shell: bash # necessary for fail-fast
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
         ref: gltfpack
         path: basis_universal
     - name: cmake configure
-      run: cmake . -DMESHOPT_BUILD_GLTFPACK=ON -DMESHOPT_BASISU_PATH=basis_universal -DCMAKE_MSVC_RUNTIME_LIBRARY="MultiThreaded" -DCMAKE_BUILD_TYPE=Release
+      run: cmake . -DMESHOPT_BUILD_GLTFPACK=ON -DMESHOPT_BASISU_PATH=basis_universal -DMESHOPT_WERROR=ON -DCMAKE_MSVC_RUNTIME_LIBRARY="MultiThreaded" -DCMAKE_BUILD_TYPE=Release
     - name: cmake build
       run: cmake --build . --target gltfpack --config Release -j 2
     - uses: actions/upload-artifact@v1

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,7 @@ project(meshoptimizer VERSION 0.18 LANGUAGES CXX)
 option(MESHOPT_BUILD_DEMO "Build demo" OFF)
 option(MESHOPT_BUILD_GLTFPACK "Build gltfpack" OFF)
 option(MESHOPT_BUILD_SHARED_LIBS "Build shared libraries" OFF)
+option(MESHOPT_WERROR "Treat warnings as errors" OFF)
 set(MESHOPT_BASISU_PATH "" CACHE STRING "")
 
 set(SOURCES
@@ -55,9 +56,17 @@ set(GLTF_SOURCES
 )
 
 if(MSVC)
-    add_compile_options(/W4 /WX)
+    add_compile_options(/W4)
 else()
     add_compile_options(-Wall -Wextra -Wshadow -Wno-missing-field-initializers)
+endif()
+
+if(MESHOPT_WERROR)
+    if(MSVC)
+        add_compile_options(/WX)
+    else()
+        add_compile_options(-Werror)
+    endif()
 endif()
 
 if(MESHOPT_BUILD_SHARED_LIBS)


### PR DESCRIPTION
We now enable warnings as errors in CI CMake builds only using a new MESHOPT_WERROR option; this ensures that while configurations tested in CI are warning-free, meshoptimizer can be used on an untested compiler version without errors.

For simplicity, Makefile builds for now keep -Werror unconditionally since these would mostly be used during meshoptimizer development.

Foillowup for #486 