### PR TITLE
Fix build errors

### DIFF
--- a/gltf/basislib.cpp
+++ b/gltf/basislib.cpp
@@ -3,6 +3,7 @@
 #ifdef __clang__
 #pragma GCC diagnostic ignored "-Wunknown-warning-option"
 #pragma GCC diagnostic ignored "-Wuninitialized-const-reference"
+#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
 #endif
 
 #ifdef __GNUC__


### PR DESCRIPTION
This changes fix below build errors.
```
In file included from /Users/runner/work/meshoptimizer/meshoptimizer/gltf/basislib.cpp:46:
/Users/runner/work/meshoptimizer/meshoptimizer/basis_universal/encoder/basisu_bc7enc.cpp:1304:11: error: variable 'total_err' set but not used [-Werror,-Wunused-but-set-variable]
        uint64_t total_err = 0;
                 ^
In file included from /Users/runner/work/meshoptimizer/meshoptimizer/gltf/basislib.cpp:47:
/Users/runner/work/meshoptimizer/meshoptimizer/basis_universal/encoder/basisu_comp.cpp:1[30](https://github.com/zeux/meshoptimizer/actions/runs/3294589917/jobs/5432254248#step:5:31)8:35: error: variable 'total_texels' set but not used [-Werror,-Wunused-but-set-variable]
                uint32_t total_orig_pixels = 0, total_texels = 0, total_orig_texels = 0;
                                                ^
In file included from /Users/runner/work/meshoptimizer/meshoptimizer/gltf/basislib.cpp:50:
/Users/runner/work/meshoptimizer/meshoptimizer/basis_universal/encoder/basisu_frontend.cpp:2371:15: error: variable 'overall_best_err' set but not used [-Werror,-Wunused-but-set-variable]
                                        uint64_t overall_best_err = 0;
                                                 ^
In file included from /Users/runner/work/meshoptimizer/meshoptimizer/gltf/basislib.cpp:51:
/Users/runner/work/meshoptimizer/meshoptimizer/basis_universal/encoder/basisu_gpu_texture.cpp:1536:13: error: variable 'bytes_written' set but not used [-Werror,-Wunused-but-set-variable]
                        uint[32](https://github.com/zeux/meshoptimizer/actions/runs/3294589917/jobs/5432254248#step:5:33)_t bytes_written = 0;
                                 ^
[ 65%] Building CXX object CMakeFiles/gltfpack.dir/gltf/gltfpack.cpp.o
In file included from /Users/runner/work/meshoptimizer/meshoptimizer/gltf/basislib.cpp:58:
/Users/runner/work/meshoptimizer/meshoptimizer/basis_universal/encoder/basisu_uastc_enc.cpp:386:12: error: variable 'total_endpoint_bits' set but not used [-Werror,-Wunused-but-set-variable]
                uint32_t total_endpoint_bits = 0;
                         ^
/Users/runner/work/meshoptimizer/meshoptimizer/basis_universal/encoder/basisu_uastc_enc.cpp:430:12: error: variable 'total_weight_bits' set but not used [-Werror,-Wunused-but-set-variable]
                uint32_t total_weight_bits = 0;
                         ^
In file included from /Users/runner/work/meshoptimizer/meshoptimizer/gltf/basislib.cpp:60:
/Users/runner/work/meshoptimizer/meshoptimizer/basis_universal/encoder/pvpngreader.cpp:1630:12: error: variable 'total_lines' set but not used [-Werror,-Wunused-but-set-variable]
                uint32_t total_lines, lines_processed;
                         ^
In file included from /Users/runner/work/meshoptimizer/meshoptimizer/gltf/basislib.cpp:64:
/Users/runner/work/meshoptimizer/meshoptimizer/basis_universal/zstd/zstd.c:1[34](https://github.com/zeux/meshoptimizer/actions/runs/3294589917/jobs/5432254248#step:5:35)56:12: error: variable 'litLengthSum' set but not used [-Werror,-Wunused-but-set-variable]
    size_t litLengthSum = 0;
```