### PR TITLE
gltfpack: Calculate AABB of morph targets correctly

### DIFF
--- a/gltf/gltfpack.cpp
+++ b/gltf/gltfpack.cpp
@@ -538,7 +538,7 @@ static void process(cgltf_data* data, const char* input_path, const char* output
 		size_t pi = i;
 		for (; pi < meshes.size(); ++pi)
 		{
-			const Mesh& prim = meshes[pi];
+			Mesh& prim = meshes[pi];
 
 			if (prim.skin != mesh.skin || prim.targets != mesh.targets)
 				break;

--- a/gltf/gltfpack.h
+++ b/gltf/gltfpack.h
@@ -30,6 +30,9 @@ struct Stream
 	int target; // 0 = base mesh, 1+ = morph target
 
 	std::vector<Attr> data;
+
+	float min[3];
+	float max[3];
 };
 
 struct Transform
@@ -357,7 +360,7 @@ void writeSampler(std::string& json, const cgltf_sampler& sampler);
 void writeImage(std::string& json, std::vector<BufferView>& views, const cgltf_image& image, const ImageInfo& info, size_t index, const char* input_path, const Settings& settings);
 void writeEncodedImage(std::string& json, std::vector<BufferView>& views, const cgltf_image& image, const std::string& encoded, const ImageInfo& info, const char* output_path, const Settings& settings);
 void writeTexture(std::string& json, const cgltf_texture& texture, const ImageInfo* info, cgltf_data* data, const Settings& settings);
-void writeMeshAttributes(std::string& json, std::vector<BufferView>& views, std::string& json_accessors, size_t& accr_offset, const Mesh& mesh, int target, const QuantizationPosition& qp, const QuantizationTexture& qt, const Settings& settings);
+void writeMeshAttributes(std::string& json, std::vector<BufferView>& views, std::string& json_accessors, size_t& accr_offset, Mesh& mesh, int target, const QuantizationPosition& qp, const QuantizationTexture& qt, const Settings& settings);
 size_t writeMeshIndices(std::vector<BufferView>& views, std::string& json_accessors, size_t& accr_offset, const Mesh& mesh, const Settings& settings);
 size_t writeJointBindMatrices(std::vector<BufferView>& views, std::string& json_accessors, size_t& accr_offset, const cgltf_skin& skin, const QuantizationPosition& qp, const Settings& settings);
 size_t writeInstances(std::vector<BufferView>& views, std::string& json_accessors, size_t& accr_offset, const std::vector<Transform>& transforms, const QuantizationPosition& qp, const Settings& settings);


### PR DESCRIPTION
The morph target is displacement data (deltas). So the base primitive's AABB and the morph target's AABB should be added to calculate correctly.

Fix #503 