### PR TITLE
js: Fix significant memory overallocation for simplify

### DIFF
--- a/js/meshopt_simplifier.js
+++ b/js/meshopt_simplifier.js
@@ -138,7 +138,7 @@ var MeshoptSimplifier = (function() {
 			}
 
 			var indices32 = indices.BYTES_PER_ELEMENT == 4 ? indices : new Uint32Array(indices);
-			var result = simplify(instance.exports.meshopt_simplify, indices32, indices.length, vertex_positions, vertex_positions.length, vertex_positions_stride * 4, target_index_count, target_error, options);
+			var result = simplify(instance.exports.meshopt_simplify, indices32, indices.length, vertex_positions, vertex_positions.length / vertex_positions_stride, vertex_positions_stride * 4, target_index_count, target_error, options);
 			result[0] = (indices instanceof Uint32Array) ? result[0] : new indices.constructor(result[0]);
 
 			return result;
@@ -148,7 +148,7 @@ var MeshoptSimplifier = (function() {
 			assert(vertex_positions instanceof Float32Array);
 			assert(vertex_positions.length % vertex_positions_stride == 0);
 
-			return simplifyScale(instance.exports.meshopt_simplifyScale, vertex_positions, vertex_positions.length, vertex_positions_stride * 4);
+			return simplifyScale(instance.exports.meshopt_simplifyScale, vertex_positions, vertex_positions.length / vertex_positions_stride, vertex_positions_stride * 4);
 		},
 	};
 })();

--- a/js/meshopt_simplifier.module.js
+++ b/js/meshopt_simplifier.module.js
@@ -138,7 +138,7 @@ var MeshoptSimplifier = (function() {
 			}
 
 			var indices32 = indices.BYTES_PER_ELEMENT == 4 ? indices : new Uint32Array(indices);
-			var result = simplify(instance.exports.meshopt_simplify, indices32, indices.length, vertex_positions, vertex_positions.length, vertex_positions_stride * 4, target_index_count, target_error, options);
+			var result = simplify(instance.exports.meshopt_simplify, indices32, indices.length, vertex_positions, vertex_positions.length / vertex_positions_stride, vertex_positions_stride * 4, target_index_count, target_error, options);
 			result[0] = (indices instanceof Uint32Array) ? result[0] : new indices.constructor(result[0]);
 
 			return result;
@@ -148,7 +148,7 @@ var MeshoptSimplifier = (function() {
 			assert(vertex_positions instanceof Float32Array);
 			assert(vertex_positions.length % vertex_positions_stride == 0);
 
-			return simplifyScale(instance.exports.meshopt_simplifyScale, vertex_positions, vertex_positions.length, vertex_positions_stride * 4);
+			return simplifyScale(instance.exports.meshopt_simplifyScale, vertex_positions, vertex_positions.length / vertex_positions_stride, vertex_positions_stride * 4);
 		},
 	};
 })();


### PR DESCRIPTION
When computing the number of vertices, we took the length of the Float32Array without accounting for the stride. This would typically result in 3-4x higher value that's being passed in, which would significantly increase the memory consumption during simplification, as the array of quadrics would be much larger than it needed to be.