### PR TITLE
vertexfilter: Fix build on Android NDK 19c

### DIFF
--- a/src/vertexfilter.cpp
+++ b/src/vertexfilter.cpp
@@ -189,7 +189,7 @@ inline uint64_t rotateleft64(uint64_t v, int x)
 {
 #if defined(_MSC_VER) && !defined(__clang__)
 	return _rotl64(v, x);
-#elif __has_builtin(__builtin_rotateleft64)
+#elif defined(__clang__) && __has_builtin(__builtin_rotateleft64)
 	return __builtin_rotateleft64(v, x);
 #else
 	return (v << (x & 63)) | (v >> ((64 - x) & 63));

--- a/src/vertexfilter.cpp
+++ b/src/vertexfilter.cpp
@@ -63,6 +63,10 @@
 #define wasmx_unziphi_v32x4(a, b) wasm_v32x4_shuffle(a, b, 1, 3, 5, 7)
 #endif
 
+#ifndef __has_builtin
+#define __has_builtin(x) 0
+#endif
+
 namespace meshopt
 {
 
@@ -185,9 +189,7 @@ inline uint64_t rotateleft64(uint64_t v, int x)
 {
 #if defined(_MSC_VER) && !defined(__clang__)
 	return _rotl64(v, x);
-// Apple's Clang 8 is actually vanilla Clang 3.9, there we need to look for
-// version 11 instead: https://en.wikipedia.org/wiki/Xcode#Toolchain_versions
-#elif defined(__clang__) && ((!defined(__apple_build_version__) && __clang_major__ >= 8) || __clang_major__ >= 11)
+#elif __has_builtin(__builtin_rotateleft64)
 	return __builtin_rotateleft64(v, x);
 #else
 	return (v << (x & 63)) | (v >> ((64 - x) & 63));


### PR DESCRIPTION
Instead of using specific clang version detection for the intrinsic, we use a more general __has_builtin check. Note that the presence of this construct can not be checked in the same preprocessor expression so we use a standard (if perhaps rude) trick of re-defining __has_builtin if absent.

Fixes #534.