### PR TITLE
gltfpack: Enable border locking during simplification if requested

### DIFF
--- a/gltf/gltfpack.cpp
+++ b/gltf/gltfpack.cpp
@@ -1258,6 +1258,10 @@ int main(int argc, char** argv)
 		{
 			settings.simplify_aggressive = true;
 		}
+		else if (strcmp(arg, "-slb") == 0)
+		{
+			settings.simplify_lock_borders = true;
+		}
 #ifndef NDEBUG
 		else if (strcmp(arg, "-sd") == 0 && i + 1 < argc && isdigit(argv[i + 1][0]))
 		{
@@ -1438,6 +1442,7 @@ int main(int argc, char** argv)
 			fprintf(stderr, "\nSimplification:\n");
 			fprintf(stderr, "\t-si R: simplify meshes targeting triangle count ratio R (default: 1; R should be between 0 and 1)\n");
 			fprintf(stderr, "\t-sa: aggressively simplify to the target ratio disregarding quality\n");
+			fprintf(stderr, "\t-slb: lock border vertices during simplification to avoid gaps on connected meshes\n");
 			fprintf(stderr, "\nVertices:\n");
 			fprintf(stderr, "\t-vp N: use N-bit quantization for positions (default: 14; N should be between 1 and 16)\n");
 			fprintf(stderr, "\t-vt N: use N-bit quantization for texture coordinates (default: 12; N should be between 1 and 16)\n");

--- a/gltf/gltfpack.h
+++ b/gltf/gltfpack.h
@@ -127,6 +127,7 @@ struct Settings
 
 	float simplify_threshold;
 	bool simplify_aggressive;
+	bool simplify_lock_borders;
 	float simplify_debug;
 
 	int meshlet_debug;


### PR DESCRIPTION
Locking border vertices may be useful to preserve geometric details in certain cases. This helps when the mesh is split into multiple chunks (especially if the splitting is based on material since gltfpack won't be able to merge the sub meshes before simplification), or on certain classes of 3D scanned meshes when triangles are covering gaps in geometry without being connected to anything.

This setting is opt-in as it regresses simplification quality in cases when the locking isn't required; for some applications it's a safer default though so they can choose to enable -slb always.

Fixes #518.