### PR TITLE
gltfpack: Fix optimizeMaterials incorrectly optimizing on MR fallback

### DIFF
--- a/gltf/material.cpp
+++ b/gltf/material.cpp
@@ -471,28 +471,6 @@ void analyzeMaterials(cgltf_data* data, std::vector<MaterialInfo>& materials, st
 	}
 }
 
-static const cgltf_texture_view* getColorTexture(const cgltf_material& material)
-{
-	if (material.has_pbr_metallic_roughness)
-		return &material.pbr_metallic_roughness.base_color_texture;
-
-	if (material.has_pbr_specular_glossiness)
-		return &material.pbr_specular_glossiness.diffuse_texture;
-
-	return NULL;
-}
-
-static float getAlphaFactor(const cgltf_material& material)
-{
-	if (material.has_pbr_metallic_roughness)
-		return material.pbr_metallic_roughness.base_color_factor[3];
-
-	if (material.has_pbr_specular_glossiness)
-		return material.pbr_specular_glossiness.diffuse_factor[3];
-
-	return 1.f;
-}
-
 static int getChannels(const cgltf_image& image, ImageInfo& info, const char* input_path)
 {
 	if (info.channels)
@@ -508,20 +486,31 @@ static int getChannels(const cgltf_image& image, ImageInfo& info, const char* in
 	return info.channels;
 }
 
+static bool shouldKeepAlpha(const cgltf_texture_view* color, float alpha, cgltf_data* data, const char* input_path, std::vector<ImageInfo>& images)
+{
+	if (alpha == 1.f)
+		return true;
+
+	return (color && color->texture && color->texture->image && getChannels(*color->texture->image, images[color->texture->image - data->images], input_path) == 4);
+}
+
 void optimizeMaterials(cgltf_data* data, const char* input_path, std::vector<ImageInfo>& images)
 {
 	for (size_t i = 0; i < data->materials_count; ++i)
 	{
 		// remove BLEND/MASK from materials that don't have alpha information
-		if (data->materials[i].alpha_mode != cgltf_alpha_mode_opaque)
+		cgltf_material& material = data->materials[i];
+		if (material.alpha_mode != cgltf_alpha_mode_opaque)
 		{
-			const cgltf_texture_view* color = getColorTexture(data->materials[i]);
-			float alpha = getAlphaFactor(data->materials[i]);
+			// XXX must check both base texture and diffuse texture, since the
+			// material might have a fallback to the metallic-roughness model
+			if (material.has_pbr_metallic_roughness && shouldKeepAlpha(&material.pbr_metallic_roughness.base_color_texture, material.pbr_metallic_roughness.base_color_factor[3], data, input_path, images))
+				continue;
 
-			if (alpha == 1.f && !(color && color->texture && color->texture->image && getChannels(*color->texture->image, images[color->texture->image - data->images], input_path) == 4))
-			{
-				data->materials[i].alpha_mode = cgltf_alpha_mode_opaque;
-			}
+			if (material.has_pbr_specular_glossiness && shouldKeepAlpha(&material.pbr_specular_glossiness.diffuse_texture, material.pbr_specular_glossiness.diffuse_factor[3], data, input_path, images))
+				continue;
+
+			material.alpha_mode = cgltf_alpha_mode_opaque;
 		}
 	}
 }

--- a/gltf/material.cpp
+++ b/gltf/material.cpp
@@ -488,10 +488,10 @@ static int getChannels(const cgltf_image& image, ImageInfo& info, const char* in
 
 static bool shouldKeepAlpha(const cgltf_texture_view* color, float alpha, cgltf_data* data, const char* input_path, std::vector<ImageInfo>& images)
 {
-	if (alpha == 1.f)
+	if (alpha != 1.f)
 		return true;
 
-	return (color && color->texture && color->texture->image && getChannels(*color->texture->image, images[color->texture->image - data->images], input_path) == 4);
+	return color && color->texture && color->texture->image && getChannels(*color->texture->image, images[color->texture->image - data->images], input_path) == 4;
 }
 
 void optimizeMaterials(cgltf_data* data, const char* input_path, std::vector<ImageInfo>& images)


### PR DESCRIPTION
If a material has both a metallic-roughness model and a specular-glossiness model, optimizeMaterials only checks the metallic-roughness model, which makes it incorrectly set the alphaMode to OPAQUE. This PR fixes the bug by checking both shading models instead of the first available model.