### PR TITLE
clusterizer: Implement experimental triangle mask generator

### DIFF
--- a/demo/main.cpp
+++ b/demo/main.cpp
@@ -951,7 +951,8 @@ void meshlets(const Mesh& mesh, bool scan)
 	    int(accepted_s8), double(accepted_s8) / double(meshlets.size()) * 100,
 	    (endc - startc) * 1000);
 
-	std::vector<unsigned int> triangle_masks(6 * ((max_triangles + 31) / 32));
+	size_t triangle_sides = 6;
+	std::vector<unsigned int> triangle_masks(triangle_sides * ((max_triangles + 31) / 32));
 	unsigned int rejected_mc = 0;
 	unsigned int rejected_mt = 0;
 
@@ -962,7 +963,7 @@ void meshlets(const Mesh& mesh, bool scan)
 	{
 		const meshopt_Meshlet& m = meshlets[i];
 
-		meshopt_computeMeshletTriangleMasks(&triangle_masks[0], &centers[i * 3], radii[i], &meshlet_vertices[m.vertex_offset], &meshlet_triangles[m.triangle_offset], m.triangle_count, &mesh.vertices[0].px, mesh.vertices.size(), sizeof(Vertex));
+		meshopt_computeMeshletTriangleMasks(&triangle_masks[0], triangle_sides, &centers[i * 3], radii[i], &meshlet_vertices[m.vertex_offset], &meshlet_triangles[m.triangle_offset], m.triangle_count, &mesh.vertices[0].px, mesh.vertices.size(), sizeof(Vertex));
 
 		bool visc = false;
 		int vist = 0;

--- a/demo/tests.cpp
+++ b/demo/tests.cpp
@@ -1155,7 +1155,7 @@ static void meshletMasks()
 
 	// the triangle is visible from +X, invisible from -X, and the other masks should be 1 because the triangle is visible from some points and invisible from others
 	for (int k = 0; k < 6; ++k)
-		assert(masks[k] == (k == 3 ? 0 : 1));
+		assert(masks[k] == unsigned(k == 3 ? 0 : 1));
 }
 
 void runTests()

--- a/demo/tests.cpp
+++ b/demo/tests.cpp
@@ -1151,7 +1151,7 @@ static void meshletMasks()
 	float mr = 1;
 
 	unsigned int masks[6];
-	meshopt_computeMeshletTriangleMasks(masks, mc, mr, mvb, mib, 1, vb, 3, 3 * sizeof(float));
+	meshopt_computeMeshletTriangleMasks(masks, 6, mc, mr, mvb, mib, 1, vb, 3, 3 * sizeof(float));
 
 	// the triangle is visible from +X, invisible from -X, and the other masks should be 1 because the triangle is visible from some points and invisible from others
 	for (int k = 0; k < 6; ++k)

--- a/demo/tests.cpp
+++ b/demo/tests.cpp
@@ -1141,6 +1141,23 @@ static void tessellation()
 	assert(memcmp(tessib, expected, sizeof(expected)) == 0);
 }
 
+static void meshletMasks()
+{
+	const float vb[] = { 1, 1, 0, 1, 0, 1, 1, 0, 0 };
+	const unsigned int mvb[] = { 0, 1, 2 };
+	const unsigned char mib[] = { 0, 1, 2 };
+
+	const float mc[] = { 0, 0, 0 };
+	float mr = 1;
+
+	unsigned int masks[6];
+	meshopt_computeMeshletTriangleMasks(masks, mc, mr, mvb, mib, 1, vb, 3, 3 * sizeof(float));
+
+	// the triangle is visible from +X, invisible from -X, and the other masks should be 1 because the triangle is visible from some points and invisible from others
+	for (int k = 0; k < 6; ++k)
+		assert(masks[k] == (k == 3 ? 0 : 1));
+}
+
 void runTests()
 {
 	decodeIndexV0();
@@ -1201,4 +1218,6 @@ void runTests()
 
 	adjacency();
 	tessellation();
+
+	meshletMasks();
 }

--- a/src/meshoptimizer.h
+++ b/src/meshoptimizer.h
@@ -529,8 +529,8 @@ MESHOPTIMIZER_API struct meshopt_Bounds meshopt_computeMeshletBounds(const unsig
  *
  * triangle_masks should have ceil(triangle_count / 32) * 6 elements; masks are written in frustum order, then frustum order. In each mask, first triangle corresponds to the least significant bit.
  */
-MESHOPTIMIZER_EXPERIMENTAL void meshopt_computeClusterTriangleMasks(unsigned int* triangle_masks, const float* center, float radius, const unsigned int* indices, size_t index_count, const float* vertex_positions, size_t vertex_count, size_t vertex_positions_stride);
-MESHOPTIMIZER_EXPERIMENTAL void meshopt_computeMeshletTriangleMasks(unsigned int* triangle_masks, const float* center, float radius, const unsigned int* meshlet_vertices, const unsigned char* meshlet_triangles, size_t triangle_count, const float* vertex_positions, size_t vertex_count, size_t vertex_positions_stride);
+MESHOPTIMIZER_EXPERIMENTAL void meshopt_computeClusterTriangleMasks(unsigned int* triangle_masks, size_t sides, const float* center, float radius, const unsigned int* indices, size_t index_count, const float* vertex_positions, size_t vertex_count, size_t vertex_positions_stride);
+MESHOPTIMIZER_EXPERIMENTAL void meshopt_computeMeshletTriangleMasks(unsigned int* triangle_masks, size_t sides, const float* center, float radius, const unsigned int* meshlet_vertices, const unsigned char* meshlet_triangles, size_t triangle_count, const float* vertex_positions, size_t vertex_count, size_t vertex_positions_stride);
 
 /**
  * Experimental: Spatial sorter
@@ -1057,11 +1057,11 @@ inline meshopt_Bounds meshopt_computeClusterBounds(const T* indices, size_t inde
 }
 
 template <typename T>
-inline void meshopt_computeClusterTriangleMasks(unsigned int* triangle_masks, const float* center, float radius, const T* indices, size_t index_count, const float* vertex_positions, size_t vertex_count, size_t vertex_positions_stride)
+inline void meshopt_computeClusterTriangleMasks(unsigned int* triangle_masks, size_t sides, const float* center, float radius, const T* indices, size_t index_count, const float* vertex_positions, size_t vertex_count, size_t vertex_positions_stride)
 {
 	meshopt_IndexAdapter<T> in(0, indices, index_count);
 
-	meshopt_computeClusterTriangleMasks(triangle_masks, center, radius, in.data, index_count, vertex_positions, vertex_count, vertex_positions_stride);
+	meshopt_computeClusterTriangleMasks(triangle_masks, sides, center, radius, in.data, index_count, vertex_positions, vertex_count, vertex_positions_stride);
 }
 
 template <typename T>

--- a/src/meshoptimizer.h
+++ b/src/meshoptimizer.h
@@ -520,6 +520,17 @@ MESHOPTIMIZER_API struct meshopt_Bounds meshopt_computeClusterBounds(const unsig
 MESHOPTIMIZER_API struct meshopt_Bounds meshopt_computeMeshletBounds(const unsigned int* meshlet_vertices, const unsigned char* meshlet_triangles, size_t triangle_count, const float* vertex_positions, size_t vertex_count, size_t vertex_positions_stride);
 
 /**
+ * Experimental: Triangle mask generator
+ * Computes triangle masks that can be used for backface culling.
+ *
+ * Each group of 32 triangles is assigned a 32-bit mask for each of 6 frustum slices; each bit in the mask corresponds to a triangle in the group.
+ * The bit is set if the triangle is visible from any camera position in the frustum slice; the slices are in +X, +Y, +Z, -X, -Y, -Z order (i.e. +X is a slice where X > 0, abs(X) >= abs(Y), abs(X) >= abs(Z)).
+ *
+ * triangle_masks should have ceil(triangle_count / 32) * 6 elements; masks are written in frustum order, then frustum order. In each mask, first triangle corresponds to the least significant bit.
+ */
+MESHOPTIMIZER_EXPERIMENTAL void meshopt_computeMeshletTriangleMasks(unsigned int* triangle_masks, const float* meshlet_center, float meshlet_radius, const unsigned int* meshlet_vertices, const unsigned char* meshlet_triangles, size_t triangle_count, const float* vertex_positions, size_t vertex_count, size_t vertex_positions_stride);
+
+/**
  * Experimental: Spatial sorter
  * Generates a remap table that can be used to reorder points for spatial locality.
  * Resulting remap table maps old vertices to new vertices and can be used in meshopt_remapVertexBuffer.

--- a/src/meshoptimizer.h
+++ b/src/meshoptimizer.h
@@ -1057,6 +1057,14 @@ inline meshopt_Bounds meshopt_computeClusterBounds(const T* indices, size_t inde
 }
 
 template <typename T>
+inline void meshopt_computeClusterTriangleMasks(unsigned int* triangle_masks, const float* center, float radius, const T* indices, size_t index_count, const float* vertex_positions, size_t vertex_count, size_t vertex_positions_stride)
+{
+	meshopt_IndexAdapter<T> in(0, indices, index_count);
+
+	meshopt_computeClusterTriangleMasks(triangle_masks, center, radius, in.data, index_count, vertex_positions, vertex_count, vertex_positions_stride);
+}
+
+template <typename T>
 inline void meshopt_spatialSortTriangles(T* destination, const T* indices, size_t index_count, const float* vertex_positions, size_t vertex_count, size_t vertex_positions_stride)
 {
 	meshopt_IndexAdapter<T> in(0, indices, index_count);

--- a/src/meshoptimizer.h
+++ b/src/meshoptimizer.h
@@ -525,10 +525,12 @@ MESHOPTIMIZER_API struct meshopt_Bounds meshopt_computeMeshletBounds(const unsig
  *
  * Each group of 32 triangles is assigned a 32-bit mask for each of 6 frustum slices; each bit in the mask corresponds to a triangle in the group.
  * The bit is set if the triangle is visible from any camera position in the frustum slice; the slices are in +X, +Y, +Z, -X, -Y, -Z order (i.e. +X is a slice where X > 0, abs(X) >= abs(Y), abs(X) >= abs(Z)).
+ * To increase culling efficiency, frustum slices are considered cut off at the given radius; if max(abs(X), abs(Y), abs(Z)) <= radius, all triangles should be considered visible.
  *
  * triangle_masks should have ceil(triangle_count / 32) * 6 elements; masks are written in frustum order, then frustum order. In each mask, first triangle corresponds to the least significant bit.
  */
-MESHOPTIMIZER_EXPERIMENTAL void meshopt_computeMeshletTriangleMasks(unsigned int* triangle_masks, const float* meshlet_center, float meshlet_radius, const unsigned int* meshlet_vertices, const unsigned char* meshlet_triangles, size_t triangle_count, const float* vertex_positions, size_t vertex_count, size_t vertex_positions_stride);
+MESHOPTIMIZER_EXPERIMENTAL void meshopt_computeClusterTriangleMasks(unsigned int* triangle_masks, const float* center, float radius, const unsigned int* indices, size_t index_count, const float* vertex_positions, size_t vertex_count, size_t vertex_positions_stride);
+MESHOPTIMIZER_EXPERIMENTAL void meshopt_computeMeshletTriangleMasks(unsigned int* triangle_masks, const float* center, float radius, const unsigned int* meshlet_vertices, const unsigned char* meshlet_triangles, size_t triangle_count, const float* vertex_positions, size_t vertex_count, size_t vertex_positions_stride);
 
 /**
  * Experimental: Spatial sorter


### PR DESCRIPTION
This change computes triangle masks for each frustum slice, following "GPU-Driven Rendering Pipelines" from SIGGRAPH 2015.

The resulting masks can be used to quickly cull individual triangles, which only requires classifying the camera position in cube frustum face in the object space and selecting the appropriate set of triangle bits.

The masks can also be used to reject the entire clusters, or entire triangle groups, by comparing all of them to 0 in task shader and/or comparing each 32-triangle group to 0 in mesh shader before emitting that triangle group.

Note: this change is not fully tested, so it's not ready (may contain errors in sign/winding/etc.; also needs demo code cleanup)