### PR TITLE
Update versions of setup-node and upload-artifact

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,7 +72,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         repository: KhronosGroup/glTF-Sample-Models
         path: glTF-Sample-Models
@@ -121,7 +121,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         repository: zeux/basis_universal
         ref: gltfpack

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,7 +56,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
-    - uses: actions/setup-node@v1
+    - uses: actions/setup-node@v3
       with:
         node-version: '16'
     - name: test decoder
@@ -93,7 +93,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
-    - uses: actions/setup-node@v1
+    - uses: actions/setup-node@v3
       with:
         node-version: '14.x'
     - name: install wasi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,12 +25,12 @@ jobs:
       run: cmake . -DMESHOPT_BUILD_GLTFPACK=ON -DMESHOPT_BASISU_PATH=basis_universal -DMESHOPT_WERROR=ON -DCMAKE_MSVC_RUNTIME_LIBRARY="MultiThreaded" -DCMAKE_BUILD_TYPE=Release
     - name: cmake build
       run: cmake --build . --target gltfpack --config Release -j 2
-    - uses: actions/upload-artifact@v1
+    - uses: actions/upload-artifact@v3
       with:
         name: gltfpack-windows
         path: Release/gltfpack.exe
       if: matrix.os == 'windows'
-    - uses: actions/upload-artifact@v1
+    - uses: actions/upload-artifact@v3
       with:
         name: gltfpack-${{matrix.os}}
         path: gltfpack
@@ -40,7 +40,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
-    - uses: actions/setup-node@v1
+    - uses: actions/setup-node@v3
       with:
         node-version: '14.x'
     - name: install wasi
@@ -61,11 +61,11 @@ jobs:
         cp LICENSE.md js/
         cd gltf && npm pack && cd ..
         cd js && npm pack && cd ..
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       with:
         name: gltfpack-npm
         path: gltf/gltfpack-*.tgz
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       with:
         name: meshoptimizer-npm
         path: js/meshoptimizer-*.tgz

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ${{matrix.os}}-latest
     steps:
     - uses: actions/checkout@v1
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         repository: zeux/basis_universal
         ref: gltfpack


### PR DESCRIPTION
This should fix build-time warnings on GHA about Node 12 deprecation.