### PR TITLE
Fixed vertexfilter.cpp compilation with Emscripten

### DIFF
--- a/src/vertexfilter.cpp
+++ b/src/vertexfilter.cpp
@@ -31,8 +31,6 @@
 #if defined(__wasm_simd128__)
 #define SIMD_WASM
 // Prevent compiling other variant when wasm simd compilation is active
-// This was previously missing here and caused this not to compile with Emscripten
-// Without this it mistakenly assumes it also has to compile the SSE functions
 #undef SIMD_NEON
 #undef SIMD_SSE
 #endif

--- a/src/vertexfilter.cpp
+++ b/src/vertexfilter.cpp
@@ -30,6 +30,11 @@
 // When targeting Wasm SIMD we can't use runtime cpuid checks so we unconditionally enable SIMD
 #if defined(__wasm_simd128__)
 #define SIMD_WASM
+// Prevent compiling other variant when wasm simd compilation is active
+// This was previously missing here and caused this not to compile with Emscripten
+// Without this it mistakenly assumes it also has to compile the SSE functions
+#undef SIMD_NEON
+#undef SIMD_SSE
 #endif
 
 #endif // !MESHOPTIMIZER_NO_SIMD


### PR DESCRIPTION
There was a missing undef of SIMD_SSE when we detect we're using __wasm_simd128__ in vertexfilter.cpp, funny enough vertexcodec.cpp does do this correctly.

Either way, this change fixes the WASM target compiling.