### PR TITLE
gltfpack: Preserve custom ID attributes

### DIFF
--- a/gltf/gltfpack.h
+++ b/gltf/gltfpack.h
@@ -29,6 +29,8 @@ struct Stream
 	int index;
 	int target; // 0 = base mesh, 1+ = morph target
 
+	const char* custom_name; // only valid for cgltf_attribute_type_custom
+
 	std::vector<Attr> data;
 };
 

--- a/gltf/parsegltf.cpp
+++ b/gltf/parsegltf.cpp
@@ -136,6 +136,13 @@ static void fixupIndices(std::vector<unsigned int>& indices, cgltf_primitive_typ
 	}
 }
 
+static bool isIdAttribute(const char* name)
+{
+	const char* uid = strstr(name, "_ID");
+
+	return uid && (uid[3] == 0 || uid[3] == '_');
+}
+
 static void parseMeshesGltf(cgltf_data* data, std::vector<Mesh>& meshes, std::vector<std::pair<size_t, size_t> >& mesh_remap)
 {
 	size_t total_primitives = 0;
@@ -194,7 +201,7 @@ static void parseMeshesGltf(cgltf_data* data, std::vector<Mesh>& meshes, std::ve
 			{
 				const cgltf_attribute& attr = primitive.attributes[ai];
 
-				if (attr.type == cgltf_attribute_type_invalid || attr.type == cgltf_attribute_type_custom)
+				if (attr.type == cgltf_attribute_type_invalid || (attr.type == cgltf_attribute_type_custom && !isIdAttribute(attr.name)))
 				{
 					fprintf(stderr, "Warning: ignoring %s attribute %s in primitive %d of mesh %d\n", attr.type == cgltf_attribute_type_invalid ? "unknown" : "custom", attr.name, int(pi), int(mi));
 					continue;
@@ -205,6 +212,9 @@ static void parseMeshesGltf(cgltf_data* data, std::vector<Mesh>& meshes, std::ve
 
 				s.type = attr.type;
 				s.index = attr.index;
+
+				if (attr.type == cgltf_attribute_type_custom)
+					s.custom_name = attr.name;
 
 				readAccessor(s.data, attr.data);
 

--- a/gltf/parsegltf.cpp
+++ b/gltf/parsegltf.cpp
@@ -138,9 +138,10 @@ static void fixupIndices(std::vector<unsigned int>& indices, cgltf_primitive_typ
 
 static bool isIdAttribute(const char* name)
 {
-	const char* uid = strstr(name, "_ID");
-
-	return uid && (uid[3] == 0 || uid[3] == '_');
+	return
+		strcmp(name, "_ID") == 0 ||
+		strcmp(name, "_BATCHID") == 0 ||
+		strncmp(name, "_FEATURE_ID_", 12) == 0;
 }
 
 static void parseMeshesGltf(cgltf_data* data, std::vector<Mesh>& meshes, std::vector<std::pair<size_t, size_t> >& mesh_remap)

--- a/gltf/stream.cpp
+++ b/gltf/stream.cpp
@@ -758,6 +758,10 @@ StreamFormat writeVertexStream(std::string& bin, const Stream& stream, const Qua
 			return format;
 		}
 	}
+	else if (stream.type == cgltf_attribute_type_custom)
+	{
+		return writeVertexStreamRaw(bin, stream, cgltf_type_scalar, 1);
+	}
 	else
 	{
 		return writeVertexStreamRaw(bin, stream, cgltf_type_vec4, 4);

--- a/gltf/write.cpp
+++ b/gltf/write.cpp
@@ -993,9 +993,13 @@ void writeMeshAttributes(std::string& json, std::vector<BufferView>& views, std:
 
 		comma(json);
 		append(json, "\"");
-		append(json, attributeType(stream.type));
-		if (stream.type != cgltf_attribute_type_position && stream.type != cgltf_attribute_type_normal && stream.type != cgltf_attribute_type_tangent)
+		if (stream.type == cgltf_attribute_type_custom)
+			append(json, stream.custom_name);
+		else if (stream.type == cgltf_attribute_type_position || stream.type == cgltf_attribute_type_normal || stream.type == cgltf_attribute_type_tangent)
+			append(json, attributeType(stream.type));
+		else
 		{
+			append(json, attributeType(stream.type));
 			append(json, "_");
 			append(json, size_t(stream.index));
 		}

--- a/gltf/write.cpp
+++ b/gltf/write.cpp
@@ -993,15 +993,18 @@ void writeMeshAttributes(std::string& json, std::vector<BufferView>& views, std:
 
 		comma(json);
 		append(json, "\"");
-		if (stream.type == cgltf_attribute_type_custom)
+		if (stream.custom_name)
+		{
 			append(json, stream.custom_name);
-		else if (stream.type == cgltf_attribute_type_position || stream.type == cgltf_attribute_type_normal || stream.type == cgltf_attribute_type_tangent)
-			append(json, attributeType(stream.type));
+		}
 		else
 		{
 			append(json, attributeType(stream.type));
-			append(json, "_");
-			append(json, size_t(stream.index));
+			if (stream.type != cgltf_attribute_type_position && stream.type != cgltf_attribute_type_normal && stream.type != cgltf_attribute_type_tangent)
+			{
+				append(json, "_");
+				append(json, size_t(stream.index));
+			}
 		}
 		append(json, "\":");
 		append(json, vertex_accr);


### PR DESCRIPTION
This change keeps attributes `_ID`, `_BATCHID` and `_FEATURE_ID_*` in tact when processing the scene. We assume that these attributes are scalar and encode them as floating-point (to avoid possible range issues with uint16).

This change is similar to #530 (without the extraneous names) but it crucially limits the supported attributes by name otherwise we can not assume that the attribute is scalar or integer, whereas with this filtering the assumption is reasonably safe.

For increased compression efficiency, when `-cc` is applied we use exponential encoding unless the IDs exceed the maximum permissible range. On some test files that use feature and vertex ids, this reduces the compressed size of ID attribute streams by ~2x.

Relates to #165
Fixes #529
Closes #530