### PR TITLE
Add glTF-Sample-Assets based gltfpack test

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,7 +87,28 @@ jobs:
         curl -sL $VALIDATOR | tar xJ
         find glTF-Sample-Models/2.0/ -name *.gltfpack.gltf | xargs -d '\n' -L 1 ./gltf_validator -r -a
       env:
-        VALIDATOR: https://github.com/KhronosGroup/glTF-Validator/releases/download/2.0.0-dev.3.3/gltf_validator-2.0.0-dev.3.3-linux64.tar.xz
+        VALIDATOR: https://github.com/KhronosGroup/glTF-Validator/releases/download/2.0.0-dev.3.8/gltf_validator-2.0.0-dev.3.8-linux64.tar.xz
+
+  gltfpack-assets:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
+      with:
+        repository: KhronosGroup/glTF-Sample-Assets
+        path: glTF-Sample-Assets
+    - name: make
+      run: make -j2 config=sanitize gltfpack
+    - name: test
+      run: find glTF-Sample-Assets -name *.gltf -or -name *.glb | xargs -d '\n' ./gltfpack -cc -test
+    - name: pack
+      run: find glTF-Sample-Assets -name *.gltf | grep -v 'glTF-Draco\|glTF-KTX-BasisU\|glTF-Meshopt' | xargs -d '\n' -I '{}' ./gltfpack -i '{}' -o '{}pack.gltf'
+    - name: validate
+      run: |
+        curl -sL $VALIDATOR | tar xJ
+        find glTF-Sample-Assets -name *.gltfpack.gltf | xargs -d '\n' -L 1 ./gltf_validator -r -a
+      env:
+        VALIDATOR: https://github.com/KhronosGroup/glTF-Validator/releases/download/2.0.0-dev.3.8/gltf_validator-2.0.0-dev.3.8-linux64.tar.xz
 
   gltfpack-js:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -102,7 +102,7 @@ jobs:
     - name: test
       run: find glTF-Sample-Assets -name *.gltf -or -name *.glb | xargs -d '\n' ./gltfpack -cc -test
     - name: pack
-      run: find glTF-Sample-Assets -name *.gltf | grep -v 'glTF-Draco\|glTF-KTX-BasisU\|glTF-Meshopt' | xargs -d '\n' -I '{}' ./gltfpack -i '{}' -o '{}pack.gltf'
+      run: find glTF-Sample-Assets -name *.gltf | grep -v 'glTF-Draco\|glTF-KTX2-BasisU\|glTF-Meshopt' | xargs -d '\n' -I '{}' ./gltfpack -i '{}' -o '{}pack.gltf'
     - name: validate
       run: |
         curl -sL $VALIDATOR | tar xJ

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,27 +74,6 @@ jobs:
     - uses: actions/checkout@v1
     - uses: actions/checkout@v3
       with:
-        repository: KhronosGroup/glTF-Sample-Models
-        path: glTF-Sample-Models
-    - name: make
-      run: make -j2 config=sanitize gltfpack
-    - name: test
-      run: find glTF-Sample-Models/2.0/ -name *.gltf -or -name *.glb | xargs -d '\n' ./gltfpack -cc -test
-    - name: pack
-      run: find glTF-Sample-Models/2.0/ -name *.gltf | grep -v 'glTF-Draco\|glTF-KTX\|glTF-Meshopt' | xargs -d '\n' -I '{}' ./gltfpack -i '{}' -o '{}pack.gltf'
-    - name: validate
-      run: |
-        curl -sL $VALIDATOR | tar xJ
-        find glTF-Sample-Models/2.0/ -name *.gltfpack.gltf | xargs -d '\n' -L 1 ./gltf_validator -r -a
-      env:
-        VALIDATOR: https://github.com/KhronosGroup/glTF-Validator/releases/download/2.0.0-dev.3.8/gltf_validator-2.0.0-dev.3.8-linux64.tar.xz
-
-  gltfpack-assets:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v1
-    - uses: actions/checkout@v3
-      with:
         repository: KhronosGroup/glTF-Sample-Assets
         path: glTF-Sample-Assets
     - name: make

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,7 +81,7 @@ jobs:
     - name: test
       run: find glTF-Sample-Models/2.0/ -name *.gltf -or -name *.glb | xargs -d '\n' ./gltfpack -cc -test
     - name: pack
-      run: find glTF-Sample-Models/2.0/ -name *.gltf | grep -v 'glTF-Draco\|glTF-KTX-BasisU\|glTF-Meshopt' | xargs -d '\n' -I '{}' ./gltfpack -i '{}' -o '{}pack.gltf'
+      run: find glTF-Sample-Models/2.0/ -name *.gltf | grep -v 'glTF-Draco\|glTF-KTX\|glTF-Meshopt' | xargs -d '\n' -I '{}' ./gltfpack -i '{}' -o '{}pack.gltf'
     - name: validate
       run: |
         curl -sL $VALIDATOR | tar xJ
@@ -102,7 +102,7 @@ jobs:
     - name: test
       run: find glTF-Sample-Assets -name *.gltf -or -name *.glb | xargs -d '\n' ./gltfpack -cc -test
     - name: pack
-      run: find glTF-Sample-Assets -name *.gltf | grep -v 'glTF-Draco\|glTF-KTX2-BasisU\|glTF-Meshopt' | xargs -d '\n' -I '{}' ./gltfpack -i '{}' -o '{}pack.gltf'
+      run: find glTF-Sample-Assets -name *.gltf | grep -v 'glTF-Draco\|glTF-KTX\|glTF-Meshopt' | xargs -d '\n' -I '{}' ./gltfpack -i '{}' -o '{}pack.gltf'
     - name: validate
       run: |
         curl -sL $VALIDATOR | tar xJ


### PR DESCRIPTION
If this is faster we could probably just switch from -Models to -Assets.

Also bump validator to release 2.0.0-dev.3.8