### PR TITLE
Update README.md to remove mentions of -te option

### DIFF
--- a/gltf/README.md
+++ b/gltf/README.md
@@ -22,7 +22,9 @@ When using `-c` option, gltfpack outputs compressed `.glb`/`.gltf` files that us
 
 For better compression, you can use `-cc` option which applies additional compression; additionally make sure that your content delivery method is configured to use deflate (gzip) - meshoptimizer codecs are designed to produce output that can be compressed further with general purpose compressors.
 
-gltfpack can also compress textures using Basis Universal format stored in a KTX2 container (`-tc` flag, requires support for `KHR_texture_basisu`). Textures can also be embedded into `.bin`/`.glb` output using `-te` flag.
+gltfpack can also compress textures using Basis Universal format stored in a KTX2 container (`-tc` flag, requires support for `KHR_texture_basisu`). 
+
+Textures are automatically embedded into the `.bin`/`.glb` output.
 
 ## Decompression
 

--- a/gltf/README.md
+++ b/gltf/README.md
@@ -24,8 +24,6 @@ For better compression, you can use `-cc` option which applies additional compre
 
 gltfpack can also compress textures using Basis Universal format stored in a KTX2 container (`-tc` flag, requires support for `KHR_texture_basisu`). 
 
-Textures are automatically embedded into the `.bin`/`.glb` output.
-
 ## Decompression
 
 When using compressed files, [js/meshopt_decoder.js](https://github.com/zeux/meshoptimizer/blob/master/js/meshopt_decoder.js) or `js/meshopt_decoder.module.js` needs to be loaded to provide the WebAssembly decoder module like this:


### PR DESCRIPTION
The -te flag was removed a few versions back, but it was still mentionned in the readme.