### PR TITLE
gltfpack: Implement support for floating-point texture coordinate quantization

### DIFF
--- a/gltf/gltfpack.h
+++ b/gltf/gltfpack.h
@@ -112,6 +112,7 @@ struct Settings
 
 	bool pos_normalized;
 	bool pos_float;
+	bool tex_float;
 
 	int trn_bits;
 	int rot_bits;


### PR DESCRIPTION
Similarly to position quantization, we can use quantized floating point values to represent texture coordinates. This can be useful as it trades off a little bit of memory and compression efficiency for convenience and interoperability - without the use of texture transforms it becomes easy to swap textures, reuse materials, and avoid edge cases in quantization when UV bounds are very large.

While `-vtn` option is currently not very useful as it just enforces the default, in the future we could ostensibly automatically switch between normalized integers and floating point based on some heuristics around UV range.

Fixes #194
Fixes #574