### PR TITLE
gltfpack: Implement support for extracting colors from .obj files

### DIFF
--- a/extern/fast_obj.h
+++ b/extern/fast_obj.h
@@ -123,6 +123,9 @@ typedef struct
     unsigned int                normal_count;
     float*                      normals;
 
+    unsigned int                color_count;
+    float*                      colors;
+
     /* Face data: one element for each face */
     unsigned int                face_count;
     unsigned int*               face_vertices;
@@ -653,6 +656,23 @@ const char* parse_vertex(fastObjData* data, const char* ptr)
     {
         ptr = parse_float(ptr, &v);
         array_push(data->mesh->positions, v);
+    }
+
+
+    ptr = skip_whitespace(ptr);
+    if (!is_newline(*ptr))
+    {
+        /* Fill the colors array until it matches the size of the positions array */
+        for (ii = array_size(data->mesh->colors); ii < array_size(data->mesh->positions) - 3; ++ii)
+        {
+            array_push(data->mesh->colors, 1.0f);
+        }
+
+        for (ii = 0; ii < 3; ++ii)
+        {
+            ptr = parse_float(ptr, &v);
+            array_push(data->mesh->colors, v);
+        }
     }
 
     return ptr;
@@ -1326,6 +1346,15 @@ void parse_buffer(fastObjData* data, const char* ptr, const char* end, const fas
 
         data->line++;
     }
+    if (array_size(data->mesh->colors) > 0)
+    {
+        /* Fill the remaining slots in the colors array */
+        unsigned int ii;
+        for (ii = array_size(data->mesh->colors); ii < array_size(data->mesh->positions); ++ii)
+        {
+            array_push(data->mesh->colors, 1.0f);
+        }
+    }
 }
 
 
@@ -1346,6 +1375,7 @@ void fast_obj_destroy(fastObjMesh* m)
     array_clean(m->positions);
     array_clean(m->texcoords);
     array_clean(m->normals);
+    array_clean(m->colors);
     array_clean(m->face_vertices);
     array_clean(m->face_materials);
     array_clean(m->indices);
@@ -1400,6 +1430,7 @@ fastObjMesh* fast_obj_read_with_callbacks(const char* path, const fastObjCallbac
     m->positions      = 0;
     m->texcoords      = 0;
     m->normals        = 0;
+    m->colors         = 0;
     m->face_vertices  = 0;
     m->face_materials = 0;
     m->indices        = 0;
@@ -1507,6 +1538,7 @@ fastObjMesh* fast_obj_read_with_callbacks(const char* path, const fastObjCallbac
     m->position_count = array_size(m->positions) / 3;
     m->texcoord_count = array_size(m->texcoords) / 2;
     m->normal_count   = array_size(m->normals) / 3;
+    m->color_count    = array_size(m->colors) / 3;
     m->face_count     = array_size(m->face_vertices);
     m->index_count    = array_size(m->indices);
     m->material_count = array_size(m->materials);

--- a/gltf/parseobj.cpp
+++ b/gltf/parseobj.cpp
@@ -99,8 +99,9 @@ static void parseMeshObj(fastObjMesh* obj, unsigned int face_offset, unsigned in
 	int pos_stream = 0;
 	int nrm_stream = obj->normal_count > 1 ? 1 : -1;
 	int tex_stream = obj->texcoord_count > 1 ? 1 + (nrm_stream >= 0) : -1;
+	int col_stream = obj->color_count > 1 ? 1 + (nrm_stream >= 0) + (tex_stream >= 0) : -1;
 
-	mesh.streams.resize(1 + (nrm_stream >= 0) + (tex_stream >= 0));
+	mesh.streams.resize(1 + (nrm_stream >= 0) + (tex_stream >= 0) + (col_stream >= 0));
 
 	mesh.streams[pos_stream].type = cgltf_attribute_type_position;
 	mesh.streams[pos_stream].data.resize(unique_vertices);
@@ -115,6 +116,12 @@ static void parseMeshObj(fastObjMesh* obj, unsigned int face_offset, unsigned in
 	{
 		mesh.streams[tex_stream].type = cgltf_attribute_type_texcoord;
 		mesh.streams[tex_stream].data.resize(unique_vertices);
+	}
+
+	if (col_stream >= 0)
+	{
+		mesh.streams[col_stream].type = cgltf_attribute_type_color;
+		mesh.streams[col_stream].data.resize(unique_vertices);
 	}
 
 	mesh.indices.resize(index_count);
@@ -139,6 +146,12 @@ static void parseMeshObj(fastObjMesh* obj, unsigned int face_offset, unsigned in
 		{
 			Attr t = {{obj->texcoords[ii.t * 2 + 0], 1.f - obj->texcoords[ii.t * 2 + 1]}};
 			mesh.streams[tex_stream].data[target] = t;
+		}
+
+		if (col_stream >= 0)
+		{
+			Attr c = {{obj->colors[ii.p * 3 + 0], obj->colors[ii.p * 3 + 1], obj->colors[ii.p * 3 + 2]}};
+			mesh.streams[col_stream].data[target] = c;
 		}
 	}
 


### PR DESCRIPTION
When the source .obj file carries color data, we now preserve it when processing glTF files.

Example (https://www.shapeways.com/forum/t/vertex-color-obj-format.42061/):
![image](https://github.com/zeux/meshoptimizer/assets/1106629/b5c84064-224b-49ad-91cd-1fc6629c28b6)

Note: some .obj files may have redundant .w component, which gets translated as red color:

```
# humanoid_quad.obj
# created by TEC_TO_OBJ.F90.
v 3.25000 -2.48000 14.0000 1.00000
```

Only one file in my test data set has this so for now we will assume these are broken.