### PR TITLE
gltfpack: Enhance .obj parsing by preserving more information

### DIFF
--- a/gltf/gltfpack.h
+++ b/gltf/gltfpack.h
@@ -11,6 +11,10 @@
 #define _CRT_SECURE_NO_WARNINGS
 #endif
 
+#ifndef _CRT_NONSTDC_NO_WARNINGS
+#define _CRT_NONSTDC_NO_WARNINGS
+#endif
+
 #include "../extern/cgltf.h"
 
 #include <assert.h>

--- a/gltf/parseobj.cpp
+++ b/gltf/parseobj.cpp
@@ -118,6 +118,8 @@ static void parseNodesObj(fastObjMesh* obj, cgltf_data* data)
 	data->scenes = (cgltf_scene*)calloc(1, sizeof(cgltf_scene));
 	data->scenes_count = 1;
 
+	data->scene = data->scenes;
+
 	data->scenes->nodes = (cgltf_node**)calloc(obj->object_count, sizeof(cgltf_node*));
 	data->scenes->nodes_count = obj->object_count;
 

--- a/gltf/parseobj.cpp
+++ b/gltf/parseobj.cpp
@@ -61,6 +61,9 @@ static cgltf_data* parseSceneObj(fastObjMesh* obj)
 		const fastObjMaterial& om = obj->materials[mi];
 		cgltf_material& gm = data->materials[mi];
 
+		if (om.name)
+			gm.name = strdup(om.name);
+
 		gm.has_pbr_metallic_roughness = true;
 
 		gm.pbr_metallic_roughness.base_color_factor[0] = om.Kd[0];

--- a/gltf/parseobj.cpp
+++ b/gltf/parseobj.cpp
@@ -58,14 +58,16 @@ static cgltf_data* parseSceneObj(fastObjMesh* obj)
 
 	for (unsigned int mi = 0; mi < obj->material_count; ++mi)
 	{
+		const fastObjMaterial& om = obj->materials[mi];
 		cgltf_material& gm = data->materials[mi];
-		fastObjMaterial& om = obj->materials[mi];
 
 		gm.has_pbr_metallic_roughness = true;
-		gm.pbr_metallic_roughness.base_color_factor[0] = 1.0f;
-		gm.pbr_metallic_roughness.base_color_factor[1] = 1.0f;
-		gm.pbr_metallic_roughness.base_color_factor[2] = 1.0f;
-		gm.pbr_metallic_roughness.base_color_factor[3] = 1.0f;
+
+		gm.pbr_metallic_roughness.base_color_factor[0] = om.Kd[0];
+		gm.pbr_metallic_roughness.base_color_factor[1] = om.Kd[1];
+		gm.pbr_metallic_roughness.base_color_factor[2] = om.Kd[2];
+		gm.pbr_metallic_roughness.base_color_factor[3] = om.d;
+
 		gm.pbr_metallic_roughness.metallic_factor = 0.0f;
 		gm.pbr_metallic_roughness.roughness_factor = 1.0f;
 
@@ -80,6 +82,14 @@ static cgltf_data* parseSceneObj(fastObjMesh* obj)
 		}
 
 		if (om.map_d.name)
+		{
+			if (om.map_Kd.name && strcmp(om.map_Kd.name, om.map_d.name) != 0)
+				fprintf(stderr, "Warning: material has different diffuse and alpha textures (Kd: %s, d: %s) and might not render correctly\n", om.map_Kd.name, om.map_d.name);
+
+			gm.alpha_mode = cgltf_alpha_mode_blend;
+		}
+
+		if (om.d < 1.0f)
 		{
 			gm.alpha_mode = cgltf_alpha_mode_blend;
 		}

--- a/gltf/parseobj.cpp
+++ b/gltf/parseobj.cpp
@@ -71,10 +71,10 @@ static void parseMaterialsObj(fastObjMesh* obj, cgltf_data* data)
 
 		gm.has_pbr_metallic_roughness = true;
 
-		gm.pbr_metallic_roughness.base_color_factor[0] = om.Kd[0];
-		gm.pbr_metallic_roughness.base_color_factor[1] = om.Kd[1];
-		gm.pbr_metallic_roughness.base_color_factor[2] = om.Kd[2];
-		gm.pbr_metallic_roughness.base_color_factor[3] = om.d;
+		gm.pbr_metallic_roughness.base_color_factor[0] = 1.0f;
+		gm.pbr_metallic_roughness.base_color_factor[1] = 1.0f;
+		gm.pbr_metallic_roughness.base_color_factor[2] = 1.0f;
+		gm.pbr_metallic_roughness.base_color_factor[3] = 1.0f;
 
 		gm.pbr_metallic_roughness.metallic_factor = 0.0f;
 		gm.pbr_metallic_roughness.roughness_factor = 1.0f;
@@ -88,6 +88,12 @@ static void parseMaterialsObj(fastObjMesh* obj, cgltf_data* data)
 
 			gm.alpha_mode = (om.illum == 4 || om.illum == 6 || om.illum == 7 || om.illum == 9) ? cgltf_alpha_mode_mask : cgltf_alpha_mode_opaque;
 		}
+		else
+		{
+			gm.pbr_metallic_roughness.base_color_factor[0] = om.Kd[0];
+			gm.pbr_metallic_roughness.base_color_factor[1] = om.Kd[1];
+			gm.pbr_metallic_roughness.base_color_factor[2] = om.Kd[2];
+		}
 
 		if (om.map_d.name)
 		{
@@ -96,9 +102,10 @@ static void parseMaterialsObj(fastObjMesh* obj, cgltf_data* data)
 
 			gm.alpha_mode = cgltf_alpha_mode_blend;
 		}
-
-		if (om.d < 1.0f)
+		else if (om.d < 1.0f)
 		{
+			gm.pbr_metallic_roughness.base_color_factor[3] = om.d;
+
 			gm.alpha_mode = cgltf_alpha_mode_blend;
 		}
 	}

--- a/gltf/parseobj.cpp
+++ b/gltf/parseobj.cpp
@@ -21,6 +21,14 @@ static int textureIndex(const std::vector<std::string>& textures, const char* na
 	return -1;
 }
 
+static void fixupUri(char* uri)
+{
+	// Some .obj paths come with back slashes, that are invalid as URI separators and won't open on macOS/Linux when embedding textures
+	for (char* s = uri; *s; ++s)
+		if (*s == '\\')
+			*s = '/';
+}
+
 static void parseMaterialsObj(fastObjMesh* obj, cgltf_data* data)
 {
 	std::vector<std::string> textures;
@@ -38,8 +46,8 @@ static void parseMaterialsObj(fastObjMesh* obj, cgltf_data* data)
 
 	for (size_t i = 0; i < textures.size(); ++i)
 	{
-		data->images[i].uri = (char*)malloc(textures[i].size() + 1);
-		strcpy(data->images[i].uri, textures[i].c_str());
+		data->images[i].uri = strdup(textures[i].c_str());
+		fixupUri(data->images[i].uri);
 	}
 
 	data->textures = (cgltf_texture*)calloc(textures.size(), sizeof(cgltf_texture));


### PR DESCRIPTION
When parsing .obj, gltfpack now:

- Preserves material names
- Preserves object names by parsing individual objects separately and assigning them to separate nodes
- Preserves Kd/d material parameters
- Fixes texture paths if they contain backslashes in the source .mtl
- Assigns the default scene in the output .glb file

Before merging:

- [x] Review and test more thoroughly
- [x] Measure memory/performance overhead of object split/merge on a few large scenes

Fixes #594 
Fixes #595