### PR TITLE
Improve quantization utilities

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,7 @@ set(SOURCES
     src/indexgenerator.cpp
     src/overdrawanalyzer.cpp
     src/overdrawoptimizer.cpp
+    src/quantization.cpp
     src/simplifier.cpp
     src/spatialorder.cpp
     src/stripifier.cpp

--- a/README.md
+++ b/README.md
@@ -134,6 +134,8 @@ unsigned short py = meshopt_quantizeHalf(v.y);
 unsigned short pz = meshopt_quantizeHalf(v.z);
 ```
 
+Since quantized vertex attributes often need to remain in their compact representations for efficient transfer and storage, they are usually dequantized during vertex processing by configuring the GPU vertex input correctly to expect normalized integers or half precision floats, which often needs no or minimal changes to the shader code. When CPU dequantization is required instead, `meshopt_dequantizeHalf` can be used to convert half precision values back to single precision; for normalized integer formats, the dequantization just requires dividing by 2^N-1 for unorm and 2^(N-1)-1 for snorm variants, for example manually reversing `meshopt_quantizeUnorm(v, 10)` can be done by dividing by 1023.
+
 ## Vertex/index buffer compression
 
 In case storage size or transmission bandwidth is of importance, you might want to additionally compress vertex and index data. While several mesh compression libraries, like Google Draco, are available, they typically are designed to maximize the compression ratio at the cost of disturbing the vertex/index order (which makes the meshes inefficient to render on GPU) or decompression performance. They also frequently don't support custom game-ready quantized vertex formats and thus require to re-quantize the data after loading it, introducing extra quantization errors and making decoding slower.

--- a/demo/tests.cpp
+++ b/demo/tests.cpp
@@ -1224,6 +1224,8 @@ static void tessellation()
 
 static void quantizeFloat()
 {
+	volatile float zero = 0.f; // avoids div-by-zero warnings
+
 	assert(meshopt_quantizeFloat(1.2345f, 23) == 1.2345f);
 
 	assert(meshopt_quantizeFloat(1.2345f, 16) == 1.2344971f);
@@ -1233,15 +1235,17 @@ static void quantizeFloat()
 
 	assert(meshopt_quantizeFloat(1.f, 0) == 1.0f);
 
-	assert(meshopt_quantizeFloat(1.f / 0.f, 0) == 1.f / 0.f);
-	assert(meshopt_quantizeFloat(-1.f / 0.f, 0) == -1.f / 0.f);
+	assert(meshopt_quantizeFloat(1.f / zero, 0) == 1.f / zero);
+	assert(meshopt_quantizeFloat(-1.f / zero, 0) == -1.f / zero);
 
-	float nanf = meshopt_quantizeFloat(0.f / 0.f, 8);
+	float nanf = meshopt_quantizeFloat(zero / zero, 8);
 	assert(nanf != nanf);
 }
 
 static void quantizeHalf()
 {
+	volatile float zero = 0.f; // avoids div-by-zero warnings
+
 	// normal
 	assert(meshopt_quantizeHalf(1.2345f) == 0x3cf0);
 
@@ -1274,16 +1278,18 @@ static void quantizeHalf()
 	assert(meshopt_quantizeHalf(-1e20f) == 0xfc00);
 
 	// inf
-	assert(meshopt_quantizeHalf(1.f / 0.f) == 0x7c00);
-	assert(meshopt_quantizeHalf(-1.f / 0.f) == 0xfc00);
+	assert(meshopt_quantizeHalf(1.f / zero) == 0x7c00);
+	assert(meshopt_quantizeHalf(-1.f / zero) == 0xfc00);
 
 	// nan
-	unsigned short nanh = meshopt_quantizeHalf(0.f / 0.f);
+	unsigned short nanh = meshopt_quantizeHalf(zero / zero);
 	assert(nanh == 0x7e00 || nanh == 0xfe00);
 }
 
 static void dequantizeHalf()
 {
+	volatile float zero = 0.f; // avoids div-by-zero warnings
+
 	// normal
 	assert(meshopt_dequantizeHalf(0x3cf0) == 1.234375f);
 
@@ -1302,11 +1308,11 @@ static void dequantizeHalf()
 	// denormal
 	assert(meshopt_dequantizeHalf(0x00ff) == 0.f);
 	assert(meshopt_dequantizeHalf(0x80ff) == 0.f); // actually this is -0.f
-	assert(1.f / meshopt_dequantizeHalf(0x80ff) == -1.f / 0.f);
+	assert(1.f / meshopt_dequantizeHalf(0x80ff) == -1.f / zero);
 
 	// inf
-	assert(meshopt_dequantizeHalf(0x7c00) == 1.f / 0.f);
-	assert(meshopt_dequantizeHalf(0xfc00) == -1.f / 0.f);
+	assert(meshopt_dequantizeHalf(0x7c00) == 1.f / zero);
+	assert(meshopt_dequantizeHalf(0xfc00) == -1.f / zero);
 
 	// nan
 	float nanf = meshopt_dequantizeHalf(0x7e00);

--- a/demo/tests.cpp
+++ b/demo/tests.cpp
@@ -1282,6 +1282,37 @@ static void quantizeHalf()
 	assert(nanh == 0x7e00 || nanh == 0xfe00);
 }
 
+static void dequantizeHalf()
+{
+	// normal
+	assert(meshopt_dequantizeHalf(0x3cf0) == 1.234375f);
+
+	// large
+	assert(meshopt_dequantizeHalf(0x7bef) == 64992.f);
+	assert(meshopt_dequantizeHalf(0xfbef) == -64992.f);
+
+	// small
+	assert(meshopt_dequantizeHalf(0x3000) == 0.125f);
+	assert(meshopt_dequantizeHalf(0xb000) == -0.125f);
+
+	// very small
+	assert(meshopt_dequantizeHalf(0x068e) == 1.00016594e-4f);
+	assert(meshopt_dequantizeHalf(0x868e) == -1.00016594e-4f);
+
+	// denormal
+	assert(meshopt_dequantizeHalf(0x00ff) == 0.f);
+	assert(meshopt_dequantizeHalf(0x80ff) == 0.f); // actually this is -0.f
+	assert(1.f / meshopt_dequantizeHalf(0x80ff) == -1.f / 0.f);
+
+	// inf
+	assert(meshopt_dequantizeHalf(0x7c00) == 1.f / 0.f);
+	assert(meshopt_dequantizeHalf(0xfc00) == -1.f / 0.f);
+
+	// nan
+	float nanf = meshopt_dequantizeHalf(0x7e00);
+	assert(nanf != nanf);
+}
+
 void runTests()
 {
 	decodeIndexV0();
@@ -1347,4 +1378,5 @@ void runTests()
 
 	quantizeFloat();
 	quantizeHalf();
+	dequantizeHalf();
 }

--- a/demo/tests.cpp
+++ b/demo/tests.cpp
@@ -1231,7 +1231,13 @@ static void quantizeFloat()
 	assert(meshopt_quantizeFloat(1.2345f, 4) == 1.25f);
 	assert(meshopt_quantizeFloat(1.2345f, 1) == 1.0);
 
-	assert(meshopt_quantizeFloat(1.0f, 0) == 1.0f);
+	assert(meshopt_quantizeFloat(1.f, 0) == 1.0f);
+
+	assert(meshopt_quantizeFloat(1.f / 0.f, 0) == 1.f / 0.f);
+	assert(meshopt_quantizeFloat(-1.f / 0.f, 0) == -1.f / 0.f);
+
+	float nanf = meshopt_quantizeFloat(0.f / 0.f, 8);
+	assert(nanf != nanf);
 }
 
 static void quantizeHalf()
@@ -1266,6 +1272,14 @@ static void quantizeHalf()
 	// exponent overflow
 	assert(meshopt_quantizeHalf(1e20f) == 0x7c00);
 	assert(meshopt_quantizeHalf(-1e20f) == 0xfc00);
+
+	// inf
+	assert(meshopt_quantizeHalf(1.f / 0.f) == 0x7c00);
+	assert(meshopt_quantizeHalf(-1.f / 0.f) == 0xfc00);
+
+	// nan
+	unsigned short nanh = meshopt_quantizeHalf(0.f / 0.f);
+	assert(nanh == 0x7e00 || nanh == 0xfe00);
 }
 
 void runTests()

--- a/demo/tests.cpp
+++ b/demo/tests.cpp
@@ -1222,6 +1222,52 @@ static void tessellation()
 	assert(memcmp(tessib, expected, sizeof(expected)) == 0);
 }
 
+static void quantizeFloat()
+{
+	assert(meshopt_quantizeFloat(1.2345f, 23) == 1.2345f);
+
+	assert(meshopt_quantizeFloat(1.2345f, 16) == 1.2344971f);
+	assert(meshopt_quantizeFloat(1.2345f, 8) == 1.2343750f);
+	assert(meshopt_quantizeFloat(1.2345f, 4) == 1.25f);
+	assert(meshopt_quantizeFloat(1.2345f, 1) == 1.0);
+
+	assert(meshopt_quantizeFloat(1.0f, 0) == 1.0f);
+}
+
+static void quantizeHalf()
+{
+	// normal
+	assert(meshopt_quantizeHalf(1.2345f) == 0x3cf0);
+
+	// overflow
+	assert(meshopt_quantizeHalf(65535.f) == 0x7c00);
+	assert(meshopt_quantizeHalf(-65535.f) == 0xfc00);
+
+	// large
+	assert(meshopt_quantizeHalf(65000.f) == 0x7bef);
+	assert(meshopt_quantizeHalf(-65000.f) == 0xfbef);
+
+	// small
+	assert(meshopt_quantizeHalf(0.125f) == 0x3000);
+	assert(meshopt_quantizeHalf(-0.125f) == 0xb000);
+
+	// very small
+	assert(meshopt_quantizeHalf(1e-4f) == 0x068e);
+	assert(meshopt_quantizeHalf(-1e-4f) == 0x868e);
+
+	// underflow
+	assert(meshopt_quantizeHalf(1e-5f) == 0x0000);
+	assert(meshopt_quantizeHalf(-1e-5f) == 0x8000);
+
+	// exponent underflow
+	assert(meshopt_quantizeHalf(1e-20f) == 0x0000);
+	assert(meshopt_quantizeHalf(-1e-20f) == 0x8000);
+
+	// exponent overflow
+	assert(meshopt_quantizeHalf(1e20f) == 0x7c00);
+	assert(meshopt_quantizeHalf(-1e20f) == 0xfc00);
+}
+
 void runTests()
 {
 	decodeIndexV0();
@@ -1284,4 +1330,7 @@ void runTests()
 
 	adjacency();
 	tessellation();
+
+	quantizeFloat();
+	quantizeHalf();
 }

--- a/src/meshoptimizer.h
+++ b/src/meshoptimizer.h
@@ -582,14 +582,14 @@ inline int meshopt_quantizeSnorm(float v, int N);
  * Representable magnitude range: [6e-5; 65504]
  * Maximum relative reconstruction error: 5e-4
  */
-inline unsigned short meshopt_quantizeHalf(float v);
+MESHOPTIMIZER_API unsigned short meshopt_quantizeHalf(float v);
 
 /**
  * Quantize a float into a floating point value with a limited number of significant mantissa bits
  * Generates +-inf for overflow, preserves NaN, flushes denormals to zero, rounds to nearest
  * Assumes N is in a valid mantissa precision range, which is 1..23
  */
-inline float meshopt_quantizeFloat(float v, int N);
+MESHOPTIMIZER_API float meshopt_quantizeFloat(float v, int N);
 #endif
 
 /**
@@ -683,50 +683,6 @@ inline int meshopt_quantizeSnorm(float v, int N)
 	v = (v <= +1) ? v : +1;
 
 	return int(v * scale + round);
-}
-
-inline unsigned short meshopt_quantizeHalf(float v)
-{
-	union { float f; unsigned int ui; } u = {v};
-	unsigned int ui = u.ui;
-
-	int s = (ui >> 16) & 0x8000;
-	int em = ui & 0x7fffffff;
-
-	/* bias exponent and round to nearest; 112 is relative exponent bias (127-15) */
-	int h = (em - (112 << 23) + (1 << 12)) >> 13;
-
-	/* underflow: flush to zero; 113 encodes exponent -14 */
-	h = (em < (113 << 23)) ? 0 : h;
-
-	/* overflow: infinity; 143 encodes exponent 16 */
-	h = (em >= (143 << 23)) ? 0x7c00 : h;
-
-	/* NaN; note that we convert all types of NaN to qNaN */
-	h = (em > (255 << 23)) ? 0x7e00 : h;
-
-	return (unsigned short)(s | h);
-}
-
-inline float meshopt_quantizeFloat(float v, int N)
-{
-	union { float f; unsigned int ui; } u = {v};
-	unsigned int ui = u.ui;
-
-	const int mask = (1 << (23 - N)) - 1;
-	const int round = (1 << (23 - N)) >> 1;
-
-	int e = ui & 0x7f800000;
-	unsigned int rui = (ui + round) & ~mask;
-
-	/* round all numbers except inf/nan; this is important to make sure nan doesn't overflow into -0 */
-	ui = e == 0x7f800000 ? ui : rui;
-
-	/* flush denormals to zero */
-	ui = e == 0 ? 0 : ui;
-
-	u.ui = ui;
-	return u.f;
 }
 #endif
 

--- a/src/meshoptimizer.h
+++ b/src/meshoptimizer.h
@@ -585,7 +585,7 @@ inline int meshopt_quantizeSnorm(float v, int N);
 MESHOPTIMIZER_API unsigned short meshopt_quantizeHalf(float v);
 
 /**
- * Quantize a float into a floating point value with a limited number of significant mantissa bits
+ * Quantize a float into a floating point value with a limited number of significant mantissa bits, preserving the IEEE-754 fp32 binary representation
  * Generates +-inf for overflow, preserves NaN, flushes denormals to zero, rounds to nearest
  * Assumes N is in a valid mantissa precision range, which is 1..23
  */

--- a/src/meshoptimizer.h
+++ b/src/meshoptimizer.h
@@ -577,7 +577,7 @@ inline int meshopt_quantizeUnorm(float v, int N);
 inline int meshopt_quantizeSnorm(float v, int N);
 
 /**
- * Quantize a float into half-precision floating point value
+ * Quantize a float into half-precision (as defined by IEEE-754 fp16) floating point value
  * Generates +-inf for overflow, preserves NaN, flushes denormals to zero, rounds to nearest
  * Representable magnitude range: [6e-5; 65504]
  * Maximum relative reconstruction error: 5e-4
@@ -590,6 +590,12 @@ MESHOPTIMIZER_API unsigned short meshopt_quantizeHalf(float v);
  * Assumes N is in a valid mantissa precision range, which is 1..23
  */
 MESHOPTIMIZER_API float meshopt_quantizeFloat(float v, int N);
+
+/**
+ * Reverse quantization of a half-precision (as defined by IEEE-754 fp16) floating point value
+ * Preserves Inf/NaN, flushes denormals to zero
+ */
+MESHOPTIMIZER_API float meshopt_dequantizeHalf(unsigned short h);
 #endif
 
 /**

--- a/src/quantization.cpp
+++ b/src/quantization.cpp
@@ -1,0 +1,46 @@
+// This file is part of meshoptimizer library; see meshoptimizer.h for version/license details
+#include "meshoptimizer.h"
+
+unsigned short meshopt_quantizeHalf(float v)
+{
+	union { float f; unsigned int ui; } u = {v};
+	unsigned int ui = u.ui;
+
+	int s = (ui >> 16) & 0x8000;
+	int em = ui & 0x7fffffff;
+
+	/* bias exponent and round to nearest; 112 is relative exponent bias (127-15) */
+	int h = (em - (112 << 23) + (1 << 12)) >> 13;
+
+	/* underflow: flush to zero; 113 encodes exponent -14 */
+	h = (em < (113 << 23)) ? 0 : h;
+
+	/* overflow: infinity; 143 encodes exponent 16 */
+	h = (em >= (143 << 23)) ? 0x7c00 : h;
+
+	/* NaN; note that we convert all types of NaN to qNaN */
+	h = (em > (255 << 23)) ? 0x7e00 : h;
+
+	return (unsigned short)(s | h);
+}
+
+float meshopt_quantizeFloat(float v, int N)
+{
+	union { float f; unsigned int ui; } u = {v};
+	unsigned int ui = u.ui;
+
+	const int mask = (1 << (23 - N)) - 1;
+	const int round = (1 << (23 - N)) >> 1;
+
+	int e = ui & 0x7f800000;
+	unsigned int rui = (ui + round) & ~mask;
+
+	/* round all numbers except inf/nan; this is important to make sure nan doesn't overflow into -0 */
+	ui = e == 0x7f800000 ? ui : rui;
+
+	/* flush denormals to zero */
+	ui = e == 0 ? 0 : ui;
+
+	u.ui = ui;
+	return u.f;
+}


### PR DESCRIPTION
- Move larger quantization functions to a .cpp file to make sure we can add more advanced quantizers in the future without inflating the header size
- Add `meshopt_dequantizeHalf` which can be used to reverse float->half quantization in cases when the result is needed on the CPU
- Document manual dequantization process a little better

Fixes #597.