### PR TITLE
gltfpack: Merge identical texture objects together

### DIFF
--- a/gltf/gltfpack.cpp
+++ b/gltf/gltfpack.cpp
@@ -181,7 +181,7 @@ static void printImageStats(const std::vector<BufferView>& views, TextureKind ki
 		printf("stats: image %s: %d bytes in %d images\n", name, int(bytes), int(count));
 }
 
-static bool printReport(const char* path, cgltf_data* data, const std::vector<BufferView>& views, const std::vector<Mesh>& meshes, size_t node_count, size_t mesh_count, size_t material_count, size_t animation_count, size_t json_size, size_t bin_size)
+static bool printReport(const char* path, const std::vector<BufferView>& views, const std::vector<Mesh>& meshes, size_t node_count, size_t mesh_count, size_t texture_count, size_t material_count, size_t animation_count, size_t json_size, size_t bin_size)
 {
 	size_t bytes[BufferView::Kind_Count] = {};
 
@@ -216,7 +216,7 @@ static bool printReport(const char* path, cgltf_data* data, const std::vector<Bu
 	fprintf(out, "\t\t\"nodeCount\": %d,\n", int(node_count));
 	fprintf(out, "\t\t\"meshCount\": %d,\n", int(mesh_count));
 	fprintf(out, "\t\t\"materialCount\": %d,\n", int(material_count));
-	fprintf(out, "\t\t\"textureCount\": %d,\n", int(data->textures_count));
+	fprintf(out, "\t\t\"textureCount\": %d,\n", int(texture_count));
 	fprintf(out, "\t\t\"animationCount\": %d\n", int(animation_count));
 	fprintf(out, "\t},\n");
 	fprintf(out, "\t\"render\": {\n");
@@ -894,7 +894,7 @@ static void process(cgltf_data* data, const char* input_path, const char* output
 
 	if (report_path)
 	{
-		if (!printReport(report_path, data, views, meshes, node_offset, mesh_offset, material_offset, animations.size(), json.size(), bin.size()))
+		if (!printReport(report_path, views, meshes, node_offset, mesh_offset, texture_offset, material_offset, animations.size(), json.size(), bin.size()))
 		{
 			fprintf(stderr, "Warning: cannot save report to %s\n", report_path);
 		}

--- a/gltf/gltfpack.h
+++ b/gltf/gltfpack.h
@@ -223,6 +223,13 @@ struct MaterialInfo
 	int remap;
 };
 
+struct TextureInfo
+{
+	bool keep;
+
+	int remap;
+};
+
 struct ImageInfo
 {
 	TextureKind kind;
@@ -304,9 +311,11 @@ void filterStreams(Mesh& mesh, const MaterialInfo& mi);
 void mergeMeshMaterials(cgltf_data* data, std::vector<Mesh>& meshes, const Settings& settings);
 void markNeededMaterials(cgltf_data* data, std::vector<MaterialInfo>& materials, const std::vector<Mesh>& meshes, const Settings& settings);
 
+void mergeTextures(cgltf_data* data, std::vector<TextureInfo>& textures);
+
 bool hasValidTransform(const cgltf_texture_view& view);
 
-void analyzeMaterials(cgltf_data* data, std::vector<MaterialInfo>& materials, std::vector<ImageInfo>& images);
+void analyzeMaterials(cgltf_data* data, std::vector<MaterialInfo>& materials, std::vector<TextureInfo>& textures, std::vector<ImageInfo>& images);
 void optimizeMaterials(cgltf_data* data, const char* input_path, std::vector<ImageInfo>& images);
 
 bool readImage(const cgltf_image& image, const char* input_path, std::string& data, std::string& mime_type);
@@ -350,7 +359,7 @@ void appendJson(std::string& s, const char* data);
 const char* attributeType(cgltf_attribute_type type);
 const char* animationPath(cgltf_animation_path_type type);
 
-void writeMaterial(std::string& json, const cgltf_data* data, const cgltf_material& material, const QuantizationPosition* qp, const QuantizationTexture* qt);
+void writeMaterial(std::string& json, const cgltf_data* data, const cgltf_material& material, const QuantizationPosition* qp, const QuantizationTexture* qt, std::vector<TextureInfo>& textures);
 void writeBufferView(std::string& json, BufferView::Kind kind, StreamFormat::Filter filter, size_t count, size_t stride, size_t bin_offset, size_t bin_size, BufferView::Compression compression, size_t compressed_offset, size_t compressed_size);
 void writeSampler(std::string& json, const cgltf_sampler& sampler);
 void writeImage(std::string& json, std::vector<BufferView>& views, const cgltf_image& image, const ImageInfo& info, size_t index, const char* input_path, const Settings& settings);

--- a/gltf/material.cpp
+++ b/gltf/material.cpp
@@ -559,22 +559,22 @@ void mergeTextures(cgltf_data* data, std::vector<TextureInfo>& textures)
 
 	for (size_t i = 0; i < textures.size(); ++i)
 	{
-		if (!textures[i].keep)
+		TextureInfo& info = textures[i];
+
+		if (!info.keep)
 			continue;
 
 		for (size_t j = 0; j < i; ++j)
-		{
 			if (textures[j].keep && areTexturesEqual(data->textures[i], data->textures[j]))
 			{
-				textures[i].keep = false;
-				textures[i].remap = textures[j].remap;
+				info.keep = false;
+				info.remap = textures[j].remap;
 				break;
 			}
-		}
 
-		if (textures[i].keep)
+		if (info.keep)
 		{
-			textures[i].remap = int(offset);
+			info.remap = int(offset);
 			offset++;
 		}
 	}


### PR DESCRIPTION
Blender glTF exporter (and possibly others) output duplicate texture objects in some exports. This blocks material merging which can result in more draw calls than necessary, and in some loaders (such as Three.JS) may result in extra texture decoding during loading and extra memory spent.

For simplicity we still assume that images and samplers in the source document are unique, but deduplicate and remove redundant texture objects now.

The process is a little different from how materials are deduplicated, as we need to maintain remap for unused textures to avoid traversing all texture views again as they are part of a complicated material structure.