### PR TITLE
gltfpack: Merge instanced meshes when instance transforms align

### DIFF
--- a/gltf/mesh.cpp
+++ b/gltf/mesh.cpp
@@ -163,6 +163,11 @@ bool compareMeshNodes(const Mesh& lhs, const Mesh& rhs)
 	return true;
 }
 
+static bool compareTransforms(const Transform& lhs, const Transform& rhs)
+{
+	return memcmp(&lhs, &rhs, sizeof(Transform)) == 0;
+}
+
 static bool canMergeMeshNodes(cgltf_node* lhs, cgltf_node* rhs, const Settings& settings)
 {
 	if (lhs == rhs)
@@ -203,8 +208,12 @@ static bool canMergeMeshes(const Mesh& lhs, const Mesh& rhs, const Settings& set
 		if (!canMergeMeshNodes(lhs.nodes[i], rhs.nodes[i], settings))
 			return false;
 
-	if (lhs.instances.size() || rhs.instances.size())
+	if (lhs.instances.size() != rhs.instances.size())
 		return false;
+
+	for (size_t i = 0; i < lhs.instances.size(); ++i)
+		if (!compareTransforms(lhs.instances[i], rhs.instances[i]))
+			return false;
 
 	if (lhs.material != rhs.material)
 		return false;


### PR DESCRIPTION
Before we were able to merge meshes when they were parented to the nodes with the same transform (or rather nodes without transform parented to the same node), but when instancing was enabled, we'd gather instances and then refuse to merge the resulting meshes.

Normally this isn't a problem as usually mesh merging works for single meshes, but this can impact instancing efficiency for structured scenes.

On one test scene, this results in a significant reduction of draw calls:

- Default: 753 draw calls
- Instanced, before this patch: 2645 draw calls
- Instanced, after this patch: 105 draw calls