### PR TITLE
gltfpack: Fix row vs column indexing in decomposeTransform

### DIFF
--- a/gltf/node.cpp
+++ b/gltf/node.cpp
@@ -177,18 +177,18 @@ void decomposeTransform(float translation[3], float rotation[4], float scale[3],
 	float sign = (det < 0.f) ? -1.f : 1.f;
 
 	// recover scale from axis lengths
-	scale[0] = sqrtf(m[0][0] * m[0][0] + m[1][0] * m[1][0] + m[2][0] * m[2][0]) * sign;
-	scale[1] = sqrtf(m[0][1] * m[0][1] + m[1][1] * m[1][1] + m[2][1] * m[2][1]) * sign;
-	scale[2] = sqrtf(m[0][2] * m[0][2] + m[1][2] * m[1][2] + m[2][2] * m[2][2]) * sign;
+	scale[0] = sqrtf(m[0][0] * m[0][0] + m[0][1] * m[0][1] + m[0][2] * m[0][2]) * sign;
+	scale[1] = sqrtf(m[1][0] * m[1][0] + m[1][1] * m[1][1] + m[1][2] * m[1][2]) * sign;
+	scale[2] = sqrtf(m[2][0] * m[2][0] + m[2][1] * m[2][1] + m[2][2] * m[2][2]) * sign;
 
 	// normalize axes to get a pure rotation matrix
 	float rsx = (scale[0] == 0.f) ? 0.f : 1.f / scale[0];
 	float rsy = (scale[1] == 0.f) ? 0.f : 1.f / scale[1];
 	float rsz = (scale[2] == 0.f) ? 0.f : 1.f / scale[2];
 
-	float r00 = m[0][0] * rsx, r10 = m[1][0] * rsx, r20 = m[2][0] * rsx;
-	float r01 = m[0][1] * rsy, r11 = m[1][1] * rsy, r21 = m[2][1] * rsy;
-	float r02 = m[0][2] * rsz, r12 = m[1][2] * rsz, r22 = m[2][2] * rsz;
+	float r00 = m[0][0] * rsx, r10 = m[1][0] * rsy, r20 = m[2][0] * rsz;
+	float r01 = m[0][1] * rsx, r11 = m[1][1] * rsy, r21 = m[2][1] * rsz;
+	float r02 = m[0][2] * rsx, r12 = m[1][2] * rsy, r22 = m[2][2] * rsz;
 
 	// "branchless" version of Mike Day's matrix to quaternion conversion
 	int qc = r22 < 0 ? (r00 > r11 ? 0 : 1) : (r00 < -r11 ? 2 : 3);


### PR DESCRIPTION
We accidentally computed scale using columns instead of rows, which led to rotation affecting scale for non-uniform scale factors.

The adjusted implementation has been validated against cgltf node->matrix function and appears to round trip within floating point precision and modulo redundancy wrt scale sign that is inherent during reconstruction.

This fixes mesh instancing for scenes with non-uniform scale & rotation.