### PR TITLE
Stabilize simplifyWithAttributes tests by adjusting pos.z

### DIFF
--- a/demo/tests.cpp
+++ b/demo/tests.cpp
@@ -1151,7 +1151,7 @@ static void simplifyAttr()
 		{
 			vb[y * 3 + x][0] = float(x);
 			vb[y * 3 + x][1] = float(y);
-			vb[y * 3 + x][2] = 0.f;
+			vb[y * 3 + x][2] = 0.03f * x;
 			vb[y * 3 + x][3] = r;
 			vb[y * 3 + x][4] = g;
 			vb[y * 3 + x][5] = b;
@@ -1175,12 +1175,11 @@ static void simplifyAttr()
 
 	float attr_weights[3] = {0.01f, 0.01f, 0.01f};
 
-	unsigned int expected[3][6] =
-	    {
-	        {0, 2, 9, 9, 2, 11},
-	        {9, 11, 12, 12, 11, 14},
-	        {12, 14, 21, 21, 14, 23},
-	    };
+	unsigned int expected[3][6] = {
+	    {0, 2, 9, 9, 2, 11},
+	    {9, 11, 12, 12, 11, 14},
+	    {12, 14, 21, 21, 14, 23},
+	};
 
 	assert(meshopt_simplifyWithAttributes(ib[0], ib[0], 7 * 2 * 6, vb[0], 8 * 3, 6 * sizeof(float), vb[0] + 3, 6 * sizeof(float), attr_weights, 3, 6 * 3, 1e-2f) == 18);
 	assert(memcmp(ib, expected, sizeof(expected)) == 0);

--- a/js/meshopt_simplifier.test.js
+++ b/js/meshopt_simplifier.test.js
@@ -138,7 +138,7 @@ var tests = {
 			{
 				vb_pos[(y * 3 + x) * 3 + 0] = x;
 				vb_pos[(y * 3 + x) * 3 + 1] = y;
-				vb_pos[(y * 3 + x) * 3 + 2] = 0;
+				vb_pos[(y * 3 + x) * 3 + 2] = 0.03 * x;
 				vb_att[(y * 3 + x) * 3 + 0] = r;
 				vb_att[(y * 3 + x) * 3 + 1] = g;
 				vb_att[(y * 3 + x) * 3 + 2] = b;


### PR DESCRIPTION
The collapse order in our test isn't very well specified, as such under different compilers and floating point configurations we may end up with a different quad triangulation.

For now let's attempt to fix this by perturbing pos.z which seems to fix the issue at least on Xcode/A64.