### PR TITLE
gltfpack: Implement texture copying when compression is not used

### DIFF
--- a/gltf/gltfpack.cpp
+++ b/gltf/gltfpack.cpp
@@ -486,7 +486,7 @@ static void process(cgltf_data* data, const char* input_path, const char* output
 		}
 		else
 		{
-			writeImage(json_images, views, image, images[i], i, input_path, settings);
+			writeImage(json_images, views, image, images[i], i, input_path, output_path, settings);
 		}
 		append(json_images, "}");
 	}
@@ -1347,6 +1347,10 @@ int main(int argc, char** argv)
 		else if (strcmp(arg, "-tfy") == 0)
 		{
 			settings.texture_flipy = true;
+		}
+		else if (strcmp(arg, "-tcp") == 0)
+		{
+			settings.texture_copy = true;
 		}
 		else if (strcmp(arg, "-tj") == 0 && i + 1 < argc && isdigit(argv[i + 1][0]))
 		{

--- a/gltf/gltfpack.h
+++ b/gltf/gltfpack.h
@@ -141,6 +141,7 @@ struct Settings
 
 	bool texture_ktx2;
 	bool texture_embed;
+	bool texture_copy;
 
 	bool texture_pow2;
 	bool texture_flipy;
@@ -362,7 +363,7 @@ const char* animationPath(cgltf_animation_path_type type);
 void writeMaterial(std::string& json, const cgltf_data* data, const cgltf_material& material, const QuantizationPosition* qp, const QuantizationTexture* qt, std::vector<TextureInfo>& textures);
 void writeBufferView(std::string& json, BufferView::Kind kind, StreamFormat::Filter filter, size_t count, size_t stride, size_t bin_offset, size_t bin_size, BufferView::Compression compression, size_t compressed_offset, size_t compressed_size);
 void writeSampler(std::string& json, const cgltf_sampler& sampler);
-void writeImage(std::string& json, std::vector<BufferView>& views, const cgltf_image& image, const ImageInfo& info, size_t index, const char* input_path, const Settings& settings);
+void writeImage(std::string& json, std::vector<BufferView>& views, const cgltf_image& image, const ImageInfo& info, size_t index, const char* input_path, const char* output_path, const Settings& settings);
 void writeEncodedImage(std::string& json, std::vector<BufferView>& views, const cgltf_image& image, const std::string& encoded, const ImageInfo& info, const char* output_path, const Settings& settings);
 void writeTexture(std::string& json, const cgltf_texture& texture, const ImageInfo* info, cgltf_data* data, const Settings& settings);
 void writeMeshAttributes(std::string& json, std::vector<BufferView>& views, std::string& json_accessors, size_t& accr_offset, const Mesh& mesh, int target, const QuantizationPosition& qp, const QuantizationTexture& qt, const Settings& settings);

--- a/gltf/image.cpp
+++ b/gltf/image.cpp
@@ -7,6 +7,7 @@ static const char* kMimeTypes[][2] = {
     {"image/jpeg", ".jpg"},
     {"image/jpeg", ".jpeg"},
     {"image/png", ".png"},
+    {"image/ktx2", ".ktx2"},
 };
 
 static const char* inferMimeType(const char* path)


### PR DESCRIPTION
When compression is not used and the output is a .gltf file, we currently simply preserve the image URIs and expect the caller to somehow copy the images. This is convenient for testing, but results in glTF files that are missing the image resources.

With this change, the newly added option -tcp uses the flow similar to the one we use for compression to write out copies of image assets when requested.

Fixes #487