### PR TITLE
gltfpack: Improve texture file handling behavior

### DIFF
--- a/gltf/gltfpack.cpp
+++ b/gltf/gltfpack.cpp
@@ -1348,9 +1348,9 @@ int main(int argc, char** argv)
 		{
 			settings.texture_flipy = true;
 		}
-		else if (strcmp(arg, "-tcp") == 0)
+		else if (strcmp(arg, "-tr") == 0)
 		{
-			settings.texture_copy = true;
+			settings.texture_ref = true;
 		}
 		else if (strcmp(arg, "-tj") == 0 && i + 1 < argc && isdigit(argv[i + 1][0]))
 		{
@@ -1459,6 +1459,7 @@ int main(int argc, char** argv)
 			fprintf(stderr, "\t-tp: resize textures to nearest power of 2 to conform to WebGL1 restrictions\n");
 			fprintf(stderr, "\t-tfy: flip textures along Y axis during BasisU supercompression\n");
 			fprintf(stderr, "\t-tj N: use N threads when compressing textures\n");
+			fprintf(stderr, "\t-tr: keep referring to original texture paths instead of copying/embedding images\n");
 			fprintf(stderr, "\tTexture classes:\n");
 			fprintf(stderr, "\t-tc C: use ETC1S when encoding textures of class C\n");
 			fprintf(stderr, "\t-tu C: use UASTC when encoding textures of class C\n");
@@ -1540,6 +1541,12 @@ int main(int argc, char** argv)
 	if (settings.texture_flipy && !settings.texture_ktx2)
 	{
 		fprintf(stderr, "Option -tfy is only supported when -tc is set as well\n");
+		return 1;
+	}
+
+	if (settings.texture_ref && settings.texture_ktx2)
+	{
+		fprintf(stderr, "Option -tr currently can not be used together with -tc\n");
 		return 1;
 	}
 

--- a/gltf/gltfpack.cpp
+++ b/gltf/gltfpack.cpp
@@ -486,7 +486,7 @@ static void process(cgltf_data* data, const char* input_path, const char* output
 		}
 		else
 		{
-			writeImage(json_images, views, image, images[i], i, input_path, settings);
+			writeImage(json_images, views, image, images[i], i, input_path, output_path, settings);
 		}
 		append(json_images, "}");
 	}
@@ -1347,6 +1347,10 @@ int main(int argc, char** argv)
 		else if (strcmp(arg, "-tfy") == 0)
 		{
 			settings.texture_flipy = true;
+		}
+		else if (strcmp(arg, "-tcp") == 0)
+		{
+			settings.texture_copy = true;
 		}
 		else if (strcmp(arg, "-tj") == 0 && i + 1 < argc && isdigit(argv[i + 1][0]))
 		{

--- a/gltf/gltfpack.cpp
+++ b/gltf/gltfpack.cpp
@@ -1009,6 +1009,29 @@ int gltfpack(const char* input, const char* output, const char* report, Settings
 		settings.texture_embed = true;
 	}
 
+	if (data->images_count && !settings.texture_ref && !settings.texture_embed)
+	{
+		for (size_t i = 0; i < data->images_count; ++i)
+		{
+			const char* uri = data->images[i].uri;
+			if (!uri || strncmp(uri, "data:", 5) == 0)
+				continue;
+
+			for (size_t j = 0; j < i; ++j)
+			{
+				const char* urj = data->images[j].uri;
+				if (!urj || strncmp(urj, "data:", 5) == 0)
+					continue;
+
+				if (strcmp(uri, urj) != 0 && strcmp(getBaseName(uri), getBaseName(urj)) == 0)
+				{
+					fprintf(stderr, "Warning: images %s and %s share the same base name and will overwrite each other\n", uri, urj);
+					break;
+				}
+			}
+		}
+	}
+
 	std::string json, bin, fallback;
 	size_t fallback_size = 0;
 	process(data, input, output, report, meshes, animations, settings, json, bin, fallback, fallback_size);

--- a/gltf/gltfpack.h
+++ b/gltf/gltfpack.h
@@ -141,7 +141,7 @@ struct Settings
 
 	bool texture_ktx2;
 	bool texture_embed;
-	bool texture_copy;
+	bool texture_ref;
 
 	bool texture_pow2;
 	bool texture_flipy;

--- a/gltf/gltfpack.h
+++ b/gltf/gltfpack.h
@@ -141,6 +141,7 @@ struct Settings
 
 	bool texture_ktx2;
 	bool texture_embed;
+	bool texture_copy;
 
 	bool texture_pow2;
 	bool texture_flipy;
@@ -362,7 +363,7 @@ const char* animationPath(cgltf_animation_path_type type);
 void writeMaterial(std::string& json, const cgltf_data* data, const cgltf_material& material, const QuantizationPosition* qp, const QuantizationTexture* qt, std::vector<TextureInfo>& textures);
 void writeBufferView(std::string& json, BufferView::Kind kind, StreamFormat::Filter filter, size_t count, size_t stride, size_t bin_offset, size_t bin_size, BufferView::Compression compression, size_t compressed_offset, size_t compressed_size);
 void writeSampler(std::string& json, const cgltf_sampler& sampler);
-void writeImage(std::string& json, std::vector<BufferView>& views, const cgltf_image& image, const ImageInfo& info, size_t index, const char* input_path, const Settings& settings);
+void writeImage(std::string& json, std::vector<BufferView>& views, const cgltf_image& image, const ImageInfo& info, size_t index, const char* input_path, const char* output_path, const Settings& settings);
 void writeEncodedImage(std::string& json, std::vector<BufferView>& views, const cgltf_image& image, const std::string& encoded, const ImageInfo& info, const char* output_path, const Settings& settings);
 void writeTexture(std::string& json, const cgltf_texture& texture, const ImageInfo* info, cgltf_data* data, const Settings& settings);
 void writeMeshAttributes(std::string& json, std::vector<BufferView>& views, std::string& json_accessors, size_t& accr_offset, const Mesh& mesh, int target, const QuantizationPosition& qp, const QuantizationTexture& qt, const Settings& settings);

--- a/gltf/image.cpp
+++ b/gltf/image.cpp
@@ -7,6 +7,7 @@ static const char* kMimeTypes[][2] = {
     {"image/jpeg", ".jpg"},
     {"image/jpeg", ".jpeg"},
     {"image/png", ".png"},
+    {"image/ktx2", ".ktx2"},
 };
 
 static const char* inferMimeType(const char* path)

--- a/gltf/write.cpp
+++ b/gltf/write.cpp
@@ -910,7 +910,7 @@ void writeImage(std::string& json, std::vector<BufferView>& views, const cgltf_i
 {
 	bool dataUri = image.uri && strncmp(image.uri, "data:", 5) == 0;
 
-	if (image.uri && !dataUri && !settings.texture_embed && !settings.texture_copy)
+	if (image.uri && !dataUri && settings.texture_ref)
 	{
 		// fast-path: we don't need to read the image to memory
 		append(json, "\"uri\":\"");


### PR DESCRIPTION
Previously, when targeting .gltf files without texture compression, gltfpack left texture URIs untouched in the file. This meant that the users were required to copy the texture files by hand to the output folder so that the textures could be discovered (or somehow reference the original folder in the loader).

When using texture compression, gltfpack would instead save the files into the output folder. This meant that the output glTF file was complete, however when some textures were compressed and some weren't using selective (slot-specific) compression, this still meant that some files needed to be copied by hand.

When targeting .glb files, all textures we embedded in the output, compression or not. So the only way to guarantee complete glTF output was to use .glb destination... however, this meant that for .glb outputs textures could not be kept external, which could be a problem if the textures are shared between separate .glb files.

This change reworks the flow so that by default we guarantee that the output asset is complete, by copying files to the output folder (when target asset type is .gltf) or embedding them (when target asset type is .glb). Compression will just result in a different output file extension for textures that are compressed.

A new option, `-tr`, allows to keep the original paths without copying/embedding. When target asset type is `.gltf`, specifying `-tr` allows to revert to the old behavior. When target asset type is `.glb`, specifying `-tr` effectively keeps the textures unembedded (relying on the user to copy them). So the default behavior is now more correct, and `-tr` exists to satisfy special cases.

When texture compression is enabled, the meaning of `-tr` is unclear. While we could support it by, for example, compressing the files next to the original files, for now we explicitly forbid the combination - if this gets requested, it should be easy to add.

Notably, we currently use the same logic for determining target image paths as we do for compressed textures. This means we inherit the (potentially problematic) behavior of not preserving the relative texture paths, for example `textures/Material_1.png` ends up as `Material_1.png`. This can be improved separately, but this change will detect and flag the problem.

Fixes #487 (gltfpack now does the right thing)
Fixes #605 (using `-tr` allows to output a `.glb` asset with external textures)
