### PR TITLE
Add coverage build for gltfpack

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -151,6 +151,7 @@ jobs:
         ./gltfpack -test glTF-Sample-Assets/Models/BoxTextured/glTF/BoxTextured.gltf -vpf -vtf -c
         ./gltfpack -test glTF-Sample-Assets/Models/BoxTextured/glTF/BoxTextured.gltf -vpf -vtf -cc
         ./gltfpack -test glTF-Sample-Assets/Models/BoxTextured/glTF/BoxTextured.gltf -tc
+        ./gltfpack -test glTF-Sample-Assets/Models/CesiumMan/glTF/CesiumMan.gltf -tu -ts 0.6 -tp
     - name: test output
       run: |
         ./gltfpack || true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -150,7 +150,7 @@ jobs:
         ./gltfpack || true
         ./gltfpack -h || true
         ./gltfpack -i glTF-Sample-Assets/Models/BoxTextured/glTF/BoxTextured.gltf -o box.glb -vv -r box.json
-        ./gltfpack -i glTF-Sample-Assets/Models/BoxTextured/glTF/BoxTextured.gltf -o box.gltf
+        ./gltfpack -i glTF-Sample-Assets/Models/BoxTextured/glTF/BoxTextured.gltf -o box.gltf -cf
     - name: upload coverage
       run: |
         find . -type f -name '*.gcno' -exec gcov -p {} +

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -133,10 +133,15 @@ jobs:
     - uses: actions/checkout@v1
     - uses: actions/checkout@v3
       with:
+        repository: zeux/basis_universal
+        ref: gltfpack
+        path: basis_universal
+    - uses: actions/checkout@v3
+      with:
         repository: KhronosGroup/glTF-Sample-Assets
         path: glTF-Sample-Assets
     - name: make
-      run: make -j2 config=coverage gltfpack
+      run: make -j2 config=coverage BASISU=basis_universal gltfpack
     - name: test
       run: |
         find glTF-Sample-Assets -name *.gltf -or -name *.glb | xargs -d '\n' ./gltfpack -cc -test
@@ -145,6 +150,7 @@ jobs:
         ./gltfpack -test glTF-Sample-Assets/Models/ABeautifulGame/glTF/ABeautifulGame.gltf -mi -c
         ./gltfpack -test glTF-Sample-Assets/Models/BoxTextured/glTF/BoxTextured.gltf -vpf -vtf -c
         ./gltfpack -test glTF-Sample-Assets/Models/BoxTextured/glTF/BoxTextured.gltf -vpf -vtf -cc
+        ./gltfpack -test glTF-Sample-Assets/Models/BoxTextured/glTF/BoxTextured.gltf -tc
     - name: test output
       run: |
         ./gltfpack || true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -139,8 +139,8 @@ jobs:
       run: make -j2 config=coverage gltfpack
     - name: test
       run: |
-        ./gltfpack
-        ./gltfpack -h
+        ./gltfpack || true
+        ./gltfpack -h || true
         ./gltfpack -i demo/pirate.obj -o pirate.glb -vv
         find glTF-Sample-Assets -name *.gltf -or -name *.glb | xargs -d '\n' ./gltfpack -cc -test
     - name: upload coverage

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -149,7 +149,7 @@ jobs:
       run: |
         ./gltfpack || true
         ./gltfpack -h || true
-        ./gltfpack -i glTF-Sample-Assets/Models/BoxTextured/glTF/BoxTextured.gltf -o box.glb -vv -r /dev/tty
+        ./gltfpack -i glTF-Sample-Assets/Models/BoxTextured/glTF/BoxTextured.gltf -o box.glb -vv -r box.json
         ./gltfpack -i glTF-Sample-Assets/Models/BoxTextured/glTF/BoxTextured.gltf -o box.gltf
     - name: upload coverage
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -141,8 +141,9 @@ jobs:
       run: |
         ./gltfpack || true
         ./gltfpack -h || true
-        ./gltfpack -i demo/pirate.obj -o pirate.glb -vv
+        ./gltfpack -i demo/pirate.obj -o pirate.glb -vv -r /dev/tty
         find glTF-Sample-Assets -name *.gltf -or -name *.glb | xargs -d '\n' ./gltfpack -cc -test
+        ./gltfpack -i glTF-Sample-Assets/Models/ABeautifulGame/glTF/ABeautifulGame.gltf -o game.glb -mi -c
     - name: upload coverage
       run: |
         find . -type f -name '*.gcno' -exec gcov -p {} +

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -139,15 +139,18 @@ jobs:
       run: make -j2 config=coverage gltfpack
     - name: test
       run: |
+        find glTF-Sample-Assets -name *.gltf -or -name *.glb | xargs -d '\n' ./gltfpack -cc -test
+        ./gltfpack -test demo/pirate.obj -si 0.5 -sd 0.5 -md 64
+        ./gltfpack -test demo/pirate.obj -sd 0.5 -md 64
+        ./gltfpack -test glTF-Sample-Assets/Models/ABeautifulGame/glTF/ABeautifulGame.gltf -mi -c
+        ./gltfpack -test glTF-Sample-Assets/Models/BoxTextured/glTF/BoxTextured.gltf -vpf -vtf -c
+        ./gltfpack -test glTF-Sample-Assets/Models/BoxTextured/glTF/BoxTextured.gltf -vpf -vtf -cc
+    - name: test output
+      run: |
         ./gltfpack || true
         ./gltfpack -h || true
         ./gltfpack -i demo/pirate.obj -o pirate.glb -v
         ./gltfpack -i demo/pirate.obj -o pirate.gltf -vv -r /dev/tty
-        find glTF-Sample-Assets -name *.gltf -or -name *.glb | xargs -d '\n' ./gltfpack -cc -test
-        ./gltfpack -test demo/pirate.obj -si 0.5 -sd 0.5 -md 64
-        ./gltfpack -test glTF-Sample-Assets/Models/ABeautifulGame/glTF/ABeautifulGame.gltf -mi -c
-        ./gltfpack -test glTF-Sample-Assets/Models/BoxTextured/glTF/BoxTextured.gltf -vpf -vtf -c
-        ./gltfpack -test glTF-Sample-Assets/Models/BoxTextured/glTF/BoxTextured.gltf -vpf -vtf -cc
     - name: upload coverage
       run: |
         find . -type f -name '*.gcno' -exec gcov -p {} +

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -86,15 +86,6 @@ jobs:
         find glTF-Sample-Assets -name *.gltfpack.gltf | xargs -d '\n' -L 1 ./gltf_validator -r -a
       env:
         VALIDATOR: https://github.com/KhronosGroup/glTF-Validator/releases/download/2.0.0-dev.3.8/gltf_validator-2.0.0-dev.3.8-linux64.tar.xz
-    - name: coverage
-      run: |
-        make -j2 config=coverage gltfpack
-        find glTF-Sample-Assets -name *.gltf -or -name *.glb | xargs -d '\n' ./gltfpack -cc -test
-    - name: upload coverage
-      run: |
-        find . -type f -name '*.gcno' -exec gcov -p {} +
-        sed -i -e "s/#####\(.*\)\(\/\/ unreachable.*\)/    -\1\2/" *.gcov
-        bash <(curl -s https://codecov.io/bash) -f './gltf*.gcov' -X search -t ${{secrets.CODECOV_TOKEN}} -B ${{github.ref}}
 
   gltfpack-js:
     runs-on: ubuntu-latest
@@ -135,6 +126,28 @@ jobs:
         path: basis_universal
     - name: make gltfpack
       run: make -j2 BASISU=basis_universal gltfpack
+
+  gltfpack-coverage:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
+      with:
+        repository: KhronosGroup/glTF-Sample-Assets
+        path: glTF-Sample-Assets
+    - name: make
+      run: make -j2 config=coverage gltfpack
+    - name: test
+      run: |
+        ./gltfpack
+        ./gltfpack -h
+        ./gltfpack -i demo/pirate.obj -o pirate.glb -vv
+        find glTF-Sample-Assets -name *.gltf -or -name *.glb | xargs -d '\n' ./gltfpack -cc -test
+    - name: upload coverage
+      run: |
+        find . -type f -name '*.gcno' -exec gcov -p {} +
+        sed -i -e "s/#####\(.*\)\(\/\/ unreachable.*\)/    -\1\2/" *.gcov
+        bash <(curl -s https://codecov.io/bash) -f './gltf*.gcov' -X search -t ${{secrets.CODECOV_TOKEN}} -B ${{github.ref}}
 
   arm64:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -140,7 +140,7 @@ jobs:
     - name: test
       run: |
         find glTF-Sample-Assets -name *.gltf -or -name *.glb | xargs -d '\n' ./gltfpack -cc -test
-        ./gltfpack -test demo/pirate.obj -si 0.5 -sd 0.5 -md 64
+        ./gltfpack -test demo/pirate.obj -si 0.5
         ./gltfpack -test demo/pirate.obj -sd 0.5 -md 64
         ./gltfpack -test glTF-Sample-Assets/Models/ABeautifulGame/glTF/ABeautifulGame.gltf -mi -c
         ./gltfpack -test glTF-Sample-Assets/Models/BoxTextured/glTF/BoxTextured.gltf -vpf -vtf -c
@@ -149,8 +149,8 @@ jobs:
       run: |
         ./gltfpack || true
         ./gltfpack -h || true
-        ./gltfpack -i demo/pirate.obj -o pirate.glb -v
-        ./gltfpack -i demo/pirate.obj -o pirate.gltf -vv -r /dev/tty
+        ./gltfpack -i glTF-Sample-Assets/Models/BoxTextured/glTF/BoxTextured.gltf -o box.glb -vv -r /dev/tty
+        ./gltfpack -i glTF-Sample-Assets/Models/BoxTextured/glTF/BoxTextured.gltf -o box.gltf
     - name: upload coverage
       run: |
         find . -type f -name '*.gcno' -exec gcov -p {} +

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,9 +26,7 @@ jobs:
         make -j2 config=release test
         make -j2 config=coverage test
     - name: make gltfpack
-      run: |
-        make -j2 config=release gltfpack
-        strip gltfpack
+      run: make -j2 config=release gltfpack
     - name: upload coverage
       run: |
         find . -type f -name '*.gcno' -exec gcov -p {} +
@@ -88,6 +86,15 @@ jobs:
         find glTF-Sample-Assets -name *.gltfpack.gltf | xargs -d '\n' -L 1 ./gltf_validator -r -a
       env:
         VALIDATOR: https://github.com/KhronosGroup/glTF-Validator/releases/download/2.0.0-dev.3.8/gltf_validator-2.0.0-dev.3.8-linux64.tar.xz
+    - name: coverage
+      run: |
+        make -j2 config=coverage gltfpack
+        find glTF-Sample-Assets -name *.gltf -or -name *.glb | xargs -d '\n' ./gltfpack -cc -test
+    - name: upload coverage
+      run: |
+        find . -type f -name '*.gcno' -exec gcov -p {} +
+        sed -i -e "s/#####\(.*\)\(\/\/ unreachable.*\)/    -\1\2/" *.gcov
+        bash <(curl -s https://codecov.io/bash) -f './gltf*.gcov' -X search -t ${{secrets.CODECOV_TOKEN}} -B ${{github.ref}}
 
   gltfpack-js:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -141,8 +141,9 @@ jobs:
       run: |
         ./gltfpack || true
         ./gltfpack -h || true
+        ./gltfpack -i demo/pirate.obj -o pirate.glb -v
+        ./gltfpack -i demo/pirate.obj -o pirate.gltf -vv -r /dev/tty
         find glTF-Sample-Assets -name *.gltf -or -name *.glb | xargs -d '\n' ./gltfpack -cc -test
-        ./gltfpack -test demo/pirate.obj -vv -r /dev/tty
         ./gltfpack -test demo/pirate.obj -si 0.5 -sd 0.5 -md 64
         ./gltfpack -test glTF-Sample-Assets/Models/ABeautifulGame/glTF/ABeautifulGame.gltf -mi -c
         ./gltfpack -test glTF-Sample-Assets/Models/BoxTextured/glTF/BoxTextured.gltf -vpf -vtf -c

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -141,8 +141,9 @@ jobs:
       run: |
         ./gltfpack || true
         ./gltfpack -h || true
-        ./gltfpack -i demo/pirate.obj -o pirate.glb -vv -r /dev/tty
         find glTF-Sample-Assets -name *.gltf -or -name *.glb | xargs -d '\n' ./gltfpack -cc -test
+        ./gltfpack -i demo/pirate.obj -o pirate.glb -vv -r /dev/tty
+        ./gltfpack -i demo/pirate.obj -o pirate-debug.glb -si 0.5 -sd 0.5 -md 64
         ./gltfpack -i glTF-Sample-Assets/Models/ABeautifulGame/glTF/ABeautifulGame.gltf -o game.glb -mi -c
     - name: upload coverage
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -142,9 +142,11 @@ jobs:
         ./gltfpack || true
         ./gltfpack -h || true
         find glTF-Sample-Assets -name *.gltf -or -name *.glb | xargs -d '\n' ./gltfpack -cc -test
-        ./gltfpack -i demo/pirate.obj -o pirate.glb -vv -r /dev/tty
-        ./gltfpack -i demo/pirate.obj -o pirate-debug.glb -si 0.5 -sd 0.5 -md 64
-        ./gltfpack -i glTF-Sample-Assets/Models/ABeautifulGame/glTF/ABeautifulGame.gltf -o game.glb -mi -c
+        ./gltfpack -test demo/pirate.obj -vv -r /dev/tty
+        ./gltfpack -test demo/pirate.obj -si 0.5 -sd 0.5 -md 64
+        ./gltfpack -test glTF-Sample-Assets/Models/ABeautifulGame/glTF/ABeautifulGame.gltf -mi -c
+        ./gltfpack -test glTF-Sample-Assets/Models/BoxTextured/glTF/BoxTextured.gltf -vpf -vtf -c
+        ./gltfpack -test glTF-Sample-Assets/Models/BoxTextured/glTF/BoxTextured.gltf -vpf -vtf -cc
     - name: upload coverage
       run: |
         find . -type f -name '*.gcno' -exec gcov -p {} +


### PR DESCRIPTION
For now we only run with `-cc`; this means that some paths will not be adequately covered. Additionally, some extensions may not be covered if glTF-Sample-Assets has no examples with them in use.