### PR TITLE
gltfpack: Evaluate translation error relative to parent node scale

### DIFF
--- a/gltf/animation.cpp
+++ b/gltf/animation.cpp
@@ -312,9 +312,9 @@ void processAnimation(Animation& animation, const Settings& settings)
 		float tolerance = getDeltaTolerance(track.path);
 
 		// translation tracks use world space tolerance; in the future, we should compute all errors as linear using hierarchy
-		if (track.node && track.path == cgltf_animation_path_type_translation)
+		if (track.node && track.node->parent && track.path == cgltf_animation_path_type_translation)
 		{
-			float scale = getWorldScale(track.node);
+			float scale = getWorldScale(track.node->parent);
 			tolerance /= scale == 0.f ? 1.f : scale;
 		}
 


### PR DESCRIPTION
Before this change we evaluated translation using the node's scale, even though the node's own scale gets ignored when transforming the node's translation.

This could lead to issues where gltfpack would ignore the translation animation in nodes with very small scale even though the parent's scale was reasonable and the translation was noticeable as a consequence.

Fixes #615 