### PR TITLE
gltfpack: Remove point normal streams when they are constant

### DIFF
--- a/gltf/mesh.cpp
+++ b/gltf/mesh.cpp
@@ -439,6 +439,9 @@ void filterStreams(Mesh& mesh, const MaterialInfo& mi)
 		if (stream.target && stream.type == cgltf_attribute_type_tangent && !morph_tangent)
 			continue;
 
+		if (mesh.type == cgltf_primitive_type_points && stream.type == cgltf_attribute_type_normal && !stream.data.empty() && isConstant(stream.data, stream.data[0]))
+			continue;
+
 		// the following code is roughly equivalent to streams[write] = std::move(stream)
 		std::vector<Attr> data;
 		data.swap(stream.data);


### PR DESCRIPTION
A fair amount of point cloud exports to glTF seem to have a redundant
normal stream (filled with the same value). This is relatively common
(about one in 6-7 files from Sketchfab has this issue), and it results
in incorrect rendering for renderers that respect normals *and* extra
data (4 out of 16 bytes in point clouds with normals & colors).

While it may sometimes be incorrect to remove this data, for now let's
err on the side of aggressive optimization and detect & remove it.