### PR TITLE
simplify: Rework point simplification to use reservoirs

### DIFF
--- a/src/simplifier.cpp
+++ b/src/simplifier.cpp
@@ -1835,7 +1835,13 @@ size_t meshopt_simplifyPoints(unsigned int* destination, const float* vertex_pos
 	memcpy(destination, cell_remap, sizeof(unsigned int) * cell_count);
 
 #if TRACE
-	printf("result: %d cells\n", int(cell_count));
+	// compute error
+	float result_error = 0.f;
+
+	for (size_t i = 0; i < cell_count; ++i)
+		result_error = result_error < cell_errors[i] ? cell_errors[i] : result_error;
+
+	printf("result: %d cells, %e error\n", int(cell_count), sqrtf(result_error));
 #endif
 
 	return cell_count;

--- a/src/simplifier.cpp
+++ b/src/simplifier.cpp
@@ -445,6 +445,7 @@ static const size_t kMaxAttributes = 16;
 
 struct Quadric
 {
+	// a00*x^2 + a11*y^2 + a22*z^2 + 2*(a10*xy + a20*xz + a21*yz) + b0*x + b1*y + b2*z + c
 	float a00, a11, a22;
 	float a10, a20, a21;
 	float b0, b1, b2, c;
@@ -453,6 +454,7 @@ struct Quadric
 
 struct QuadricGrad
 {
+	// gx*x + gy*y + gz*z + gw
 	float gx, gy, gz, gw;
 };
 
@@ -605,9 +607,9 @@ static void quadricFromPoint(Quadric& Q, float x, float y, float z, float w)
 	Q.a10 = 0.f;
 	Q.a20 = 0.f;
 	Q.a21 = 0.f;
-	Q.b0 = -2.f * x * w;
-	Q.b1 = -2.f * y * w;
-	Q.b2 = -2.f * z * w;
+	Q.b0 = -x * w;
+	Q.b1 = -y * w;
+	Q.b2 = -z * w;
 	Q.c = (x * x + y * y + z * z) * w;
 	Q.w = w;
 }


### PR DESCRIPTION
While quadrics are very important for triangle mesh simplification, they
are decidedly overkill for point cloud simplification. We encode a
simpler function into them compared to triangles, and even that function
is too complicated for what we need - minimizing the sum of square
distances to all points in the cell ends up yielding approximately the
same result as averaging all points in the cell and minimizing the
distance to that average.

The benefit of a simpler formulation is that there's less memory used
for encoding the function and less computation required to aggregate the
points / minimize the error.

This also sets us up for including color error into the calculation (by
computing a weighted average of the colors and minimizing the 6D
distance to XYZ+RGB). Even once we include RGB into the reservoirs,
we'll be at 7 floats per cell, vs 11 floats per cell that we spend right
now for weighted quadrics.

The RGB support is planned for a future PR; for now this improves the
error (due to a bug fix in quadric math, which is approximately equivalent
to reservoir based code) and makes space for extra data and calculation
for color support.