### PR TITLE
simplify: Add color support to simplifyPoints

### DIFF
--- a/demo/main.cpp
+++ b/demo/main.cpp
@@ -524,7 +524,7 @@ void simplifyPoints(const Mesh& mesh, float threshold = 0.2f)
 	size_t target_vertex_count = size_t(mesh.vertices.size() * threshold);
 
 	std::vector<unsigned int> indices(target_vertex_count);
-	indices.resize(meshopt_simplifyPoints(&indices[0], &mesh.vertices[0].px, mesh.vertices.size(), sizeof(Vertex), target_vertex_count));
+	indices.resize(meshopt_simplifyPoints(&indices[0], &mesh.vertices[0].px, mesh.vertices.size(), sizeof(Vertex), NULL, 0, 0, target_vertex_count));
 
 	double end = timestamp();
 

--- a/demo/tests.cpp
+++ b/demo/tests.cpp
@@ -1004,7 +1004,7 @@ static void simplifyPointsStuck()
 	const float vb[] = {0, 0, 0, 0, 0, 0, 0, 0, 0};
 
 	// simplifying down to 0 points results in 0 immediately
-	assert(meshopt_simplifyPoints(0, vb, 3, 12, 0) == 0);
+	assert(meshopt_simplifyPoints(0, vb, 3, 12, 0, 0, 0, 0) == 0);
 }
 
 static void simplifyFlip()

--- a/gltf/mesh.cpp
+++ b/gltf/mesh.cpp
@@ -696,6 +696,8 @@ static void simplifyPointMesh(Mesh& mesh, float threshold)
 	if (!positions)
 		return;
 
+	const Stream* colors = getStream(mesh, cgltf_attribute_type_color);
+
 	size_t vertex_count = mesh.streams[0].data.size();
 
 	size_t target_vertex_count = size_t(double(vertex_count) * threshold);
@@ -703,8 +705,10 @@ static void simplifyPointMesh(Mesh& mesh, float threshold)
 	if (target_vertex_count < 1)
 		return;
 
+	const float color_weight = 1e-2f;
+
 	std::vector<unsigned int> indices(target_vertex_count);
-	indices.resize(meshopt_simplifyPoints(&indices[0], positions->data[0].f, vertex_count, sizeof(Attr), target_vertex_count));
+	indices.resize(meshopt_simplifyPoints(&indices[0], positions->data[0].f, vertex_count, sizeof(Attr), colors ? colors->data[0].f : NULL, sizeof(Attr), color_weight, target_vertex_count));
 
 	std::vector<Attr> scratch(indices.size());
 

--- a/src/meshoptimizer.h
+++ b/src/meshoptimizer.h
@@ -382,8 +382,9 @@ MESHOPTIMIZER_EXPERIMENTAL size_t meshopt_simplifySloppy(unsigned int* destinati
  *
  * destination must contain enough space for the target index buffer (target_vertex_count elements)
  * vertex_positions should have float3 position in the first 12 bytes of each vertex
+ * vertex_colors should can be NULL; when it's not NULL, it should have float4 rgba in the first 16 bytes of each vertex
  */
-MESHOPTIMIZER_EXPERIMENTAL size_t meshopt_simplifyPoints(unsigned int* destination, const float* vertex_positions, size_t vertex_count, size_t vertex_positions_stride, size_t target_vertex_count);
+MESHOPTIMIZER_EXPERIMENTAL size_t meshopt_simplifyPoints(unsigned int* destination, const float* vertex_positions, size_t vertex_count, size_t vertex_positions_stride, const float* vertex_colors, size_t vertex_colors_stride, float color_weight, size_t target_vertex_count);
 
 /**
  * Returns the error scaling factor used by the simplifier to convert between absolute and relative extents

--- a/src/meshoptimizer.h
+++ b/src/meshoptimizer.h
@@ -382,7 +382,7 @@ MESHOPTIMIZER_EXPERIMENTAL size_t meshopt_simplifySloppy(unsigned int* destinati
  *
  * destination must contain enough space for the target index buffer (target_vertex_count elements)
  * vertex_positions should have float3 position in the first 12 bytes of each vertex
- * vertex_colors should can be NULL; when it's not NULL, it should have float4 rgba in the first 16 bytes of each vertex
+ * vertex_colors should can be NULL; when it's not NULL, it should have float3 color in the first 12 bytes of each vertex
  */
 MESHOPTIMIZER_EXPERIMENTAL size_t meshopt_simplifyPoints(unsigned int* destination, const float* vertex_positions, size_t vertex_count, size_t vertex_positions_stride, const float* vertex_colors, size_t vertex_colors_stride, float color_weight, size_t target_vertex_count);
 

--- a/src/simplifier.cpp
+++ b/src/simplifier.cpp
@@ -1325,7 +1325,7 @@ static void fillCellQuadrics(Quadric* cell_quadrics, const unsigned int* indices
 
 static void fillCellReservoirs(Reservoir* cell_reservoirs, size_t cell_count, const Vector3* vertex_positions, const float* vertex_colors, size_t vertex_colors_stride, size_t vertex_count, const unsigned int* vertex_cells)
 {
-	static const float dummy_color[] = { 0.f, 0.f, 0.f, 1.f };
+	static const float dummy_color[] = { 0.f, 0.f, 0.f };
 
 	size_t vertex_colors_stride_float = vertex_colors_stride / sizeof(float);
 
@@ -1337,15 +1337,13 @@ static void fillCellReservoirs(Reservoir* cell_reservoirs, size_t cell_count, co
 
 		const float* color = vertex_colors ? &vertex_colors[i * vertex_colors_stride_float] : dummy_color;
 
-		float w = color[3];
-
-		r.x += v.x * w;
-		r.y += v.y * w;
-		r.z += v.z * w;
-		r.r += color[0] * w;
-		r.g += color[1] * w;
-		r.b += color[2] * w;
-		r.w += w;
+		r.x += v.x;
+		r.y += v.y;
+		r.z += v.z;
+		r.r += color[0];
+		r.g += color[1];
+		r.b += color[2];
+		r.w += 1.f;
 	}
 
 	for (size_t i = 0; i < cell_count; ++i)
@@ -1382,7 +1380,7 @@ static void fillCellRemap(unsigned int* cell_remap, float* cell_errors, size_t c
 
 static void fillCellRemap(unsigned int* cell_remap, float* cell_errors, size_t cell_count, const unsigned int* vertex_cells, const Reservoir* cell_reservoirs, const Vector3* vertex_positions, const float* vertex_colors, size_t vertex_colors_stride, float color_weight, size_t vertex_count)
 {
-	static const float dummy_color[] = { 0.f, 0.f, 0.f, 1.f };
+	static const float dummy_color[] = { 0.f, 0.f, 0.f };
 
 	size_t vertex_colors_stride_float = vertex_colors_stride / sizeof(float);
 
@@ -1782,7 +1780,7 @@ size_t meshopt_simplifyPoints(unsigned int* destination, const float* vertex_pos
 
 	assert(vertex_positions_stride >= 12 && vertex_positions_stride <= 256);
 	assert(vertex_positions_stride % sizeof(float) == 0);
-	assert(vertex_colors_stride == 0 || (vertex_colors_stride >= 16 && vertex_colors_stride <= 256));
+	assert(vertex_colors_stride == 0 || (vertex_colors_stride >= 12 && vertex_colors_stride <= 256));
 	assert(vertex_colors_stride % sizeof(float) == 0);
 	assert(vertex_colors == NULL || vertex_colors_stride != 0);
 	assert(target_vertex_count <= vertex_count);


### PR DESCRIPTION
Following the new reservoir code, we can now easily accumulate colors into the reservoirs, and add the color error to the position error with a user-supplied weight. The color error is squared distance; as such, we scale it by the squared weight.

In addition, we now use color alpha as a point weight; the weighted sum will thus bias towards more opaque points.

Note that the alpha is not accounted for during point selection.