### PR TITLE
indexcodec: Bump default encoding version to 1

### DIFF
--- a/gltf/gltfpack.cpp
+++ b/gltf/gltfpack.cpp
@@ -1200,6 +1200,7 @@ int main(int argc, char** argv)
 	setlocale(LC_ALL, "C"); // disable locale specific convention for number parsing/printing
 #endif
 
+	meshopt_encodeVertexVersion(0);
 	meshopt_encodeIndexVersion(1);
 
 	Settings settings = defaults();

--- a/src/indexcodec.cpp
+++ b/src/indexcodec.cpp
@@ -13,7 +13,7 @@ namespace meshopt
 const unsigned char kIndexHeader = 0xe0;
 const unsigned char kSequenceHeader = 0xd0;
 
-static int gEncodeIndexVersion = 0;
+static int gEncodeIndexVersion = 1;
 
 typedef unsigned int VertexFifo[16];
 typedef unsigned int EdgeFifo[16][2];


### PR DESCRIPTION
indexcodec 0 is a legacy version that should not be preferred to 1 in any way; applications that worked with glTF contents as well as applications that required superior compression all had to set it to 1 manually.

We now bump the default encoding version to 1, which should be decodable by any application that uses meshoptimizer 0.14 (released 3 years ago) or later.

For applications that need compatibility of binary data here it should be trivial to revert back to 0.

For now we keep explicitly setting the versions for data encoding for gltfpack and JS mesh encoder; it's very unlikely that a newer version of index codec will be introduced, but a newer version of vertex codec is possible, so we'll keep pinning the version for glTF content for now.