### PR TITLE
js: Mark simplifyWithAttributes and simplifyPoints as experimental

### DIFF
--- a/demo/simplify.html
+++ b/demo/simplify.html
@@ -193,6 +193,8 @@
 
 			function simplify()
 			{
+				MeshoptSimplifier.useExperimentalFeatures = true;
+
 				MeshoptSimplifier.ready.then(function() {
 					scene.traverse(function (object) {
 						if (object.isMesh) {

--- a/js/meshopt_simplifier.js
+++ b/js/meshopt_simplifier.js
@@ -158,6 +158,10 @@ var MeshoptSimplifier = (function() {
 		ready: ready,
 		supported: true,
 
+		// set this to true to be able to use simplifyPoints and simplifyWithAttributes
+		// note that these functions are experimental and may change interface/behavior in a way that will require revising calling code
+		useExperimentalFeatures: false,
+
 		compactMesh: function(indices) {
 			assert(indices instanceof Uint32Array || indices instanceof Int32Array || indices instanceof Uint16Array || indices instanceof Int16Array);
 			assert(indices.length % 3 == 0);
@@ -189,6 +193,7 @@ var MeshoptSimplifier = (function() {
 		},
 
 		simplifyWithAttributes: function(indices, vertex_positions, vertex_positions_stride, vertex_attributes, vertex_attributes_stride, attribute_weights, target_index_count, target_error, flags) {
+			assert(this.useExperimentalFeatures); // set useExperimentalFeatures to use this; note that this function is experimental and may change interface in a way that will require revising calling code
 			assert(indices instanceof Uint32Array || indices instanceof Int32Array || indices instanceof Uint16Array || indices instanceof Int16Array);
 			assert(indices.length % 3 == 0);
 			assert(vertex_positions instanceof Float32Array);
@@ -223,6 +228,7 @@ var MeshoptSimplifier = (function() {
 		},
 
 		simplifyPoints: function(vertex_positions, vertex_positions_stride, target_vertex_count, vertex_colors, vertex_colors_stride, color_weight) {
+			assert(this.useExperimentalFeatures); // set useExperimentalFeatures to use this; note that this function is experimental and may change interface in a way that will require revising calling code
 			assert(vertex_positions instanceof Float32Array);
 			assert(vertex_positions.length % vertex_positions_stride == 0);
 			assert(vertex_positions_stride >= 3);

--- a/js/meshopt_simplifier.module.d.ts
+++ b/js/meshopt_simplifier.module.d.ts
@@ -5,14 +5,18 @@ export type Flags = "LockBorder";
 export const MeshoptSimplifier: {
     supported: boolean;
     ready: Promise<void>;
+
+    useExperimentalFeatures: boolean;
     
     compactMesh: (indices: Uint32Array) => [Uint32Array, number];
     
     simplify: (indices: Uint32Array, vertex_positions: Float32Array, vertex_positions_stride: number, target_index_count: number, target_error: number, flags?: Flags[]) => [Uint32Array, number];
 
+    // Experimental; requires useExperimentalFeatures to be set to true
     simplifyWithAttributes: (indices: Uint32Array, vertex_positions: Float32Array, vertex_positions_stride: number, vertex_attributes: Float32Array, vertex_attributes_stride: number, attribute_weights: number[], target_index_count: number, target_error: number, flags?: Flags[]) => [Uint32Array, number];
 
     getScale: (vertex_positions: Float32Array, vertex_positions_stride: number) => number;
 
+    // Experimental; requires useExperimentalFeatures to be set to true
     simplifyPoints: (vertex_positions: Float32Array, vertex_positions_stride: number, target_vertex_count: number, vertex_colors?: Float32Array, vertex_colors_stride?: number, color_weight?: number) => Uint32Array;
 };

--- a/js/meshopt_simplifier.module.js
+++ b/js/meshopt_simplifier.module.js
@@ -158,6 +158,10 @@ var MeshoptSimplifier = (function() {
 		ready: ready,
 		supported: true,
 
+		// set this to true to be able to use simplifyPoints and simplifyWithAttributes
+		// note that these functions are experimental and may change interface/behavior in a way that will require revising calling code
+		useExperimentalFeatures: false,
+
 		compactMesh: function(indices) {
 			assert(indices instanceof Uint32Array || indices instanceof Int32Array || indices instanceof Uint16Array || indices instanceof Int16Array);
 			assert(indices.length % 3 == 0);
@@ -189,6 +193,7 @@ var MeshoptSimplifier = (function() {
 		},
 
 		simplifyWithAttributes: function(indices, vertex_positions, vertex_positions_stride, vertex_attributes, vertex_attributes_stride, attribute_weights, target_index_count, target_error, flags) {
+			assert(this.useExperimentalFeatures); // set useExperimentalFeatures to use this; note that this function is experimental and may change interface in a way that will require revising calling code
 			assert(indices instanceof Uint32Array || indices instanceof Int32Array || indices instanceof Uint16Array || indices instanceof Int16Array);
 			assert(indices.length % 3 == 0);
 			assert(vertex_positions instanceof Float32Array);
@@ -223,6 +228,7 @@ var MeshoptSimplifier = (function() {
 		},
 
 		simplifyPoints: function(vertex_positions, vertex_positions_stride, target_vertex_count, vertex_colors, vertex_colors_stride, color_weight) {
+			assert(this.useExperimentalFeatures); // set useExperimentalFeatures to use this; note that this function is experimental and may change interface in a way that will require revising calling code
 			assert(vertex_positions instanceof Float32Array);
 			assert(vertex_positions.length % vertex_positions_stride == 0);
 			assert(vertex_positions_stride >= 3);

--- a/js/meshopt_simplifier.test.js
+++ b/js/meshopt_simplifier.test.js
@@ -6,6 +6,8 @@ process.on('unhandledRejection', error => {
 	process.exit(1);
 });
 
+simplifier.useExperimentalFeatures = true;
+
 var tests = {
 	compactMesh: function() {
 		var indices = new Uint32Array([


### PR DESCRIPTION
Both functions are marked as experimental in C++ code; their interface and implementation is subject to change. In JS, if the interface of these functions changes, it may lead to subtle or not-so-subtle issues with these functions. For now we require the caller to opt into the use of these functions by setting a module-level experimental boolean.

I am not 100% sure this is a great idea :) but the sensible alternative seems to be just marking them as experimental in the documentation... I mainly would like to avoid the situation where the NPM update to a future version silently breaks the users who decided to rely on the specific behavior of these functions. simplifyPoints is not very likely to change but is relatively new, and simplifyWithAttributes is very likely to change in so far as the error metric is concerned, and maybe other aspects of the implementation.

That said, given that these aren't even documented atm maybe a comment in `.d.ts` and `.js` file would suffice?