### PR TITLE
gltfpack: Remove normal streams from meshes with unlit materials

### DIFF
--- a/gltf/gltfpack.cpp
+++ b/gltf/gltfpack.cpp
@@ -354,6 +354,7 @@ static void process(cgltf_data* data, const char* input_path, const char* output
 
 			mi.needsTangents |= vi.needsTangents;
 			mi.textureSetMask |= vi.textureSetMask;
+			mi.unlit &= vi.unlit;
 		}
 
 		filterStreams(mesh, mi);

--- a/gltf/gltfpack.h
+++ b/gltf/gltfpack.h
@@ -219,6 +219,8 @@ struct MaterialInfo
 
 	bool usesTextureTransform;
 	bool needsTangents;
+	bool unlit;
+
 	unsigned int textureSetMask;
 
 	int remap;

--- a/gltf/material.cpp
+++ b/gltf/material.cpp
@@ -500,6 +500,9 @@ static void analyzeMaterial(const cgltf_material& material, MaterialInfo& mi, cg
 	analyzeMaterialTexture(material.normal_texture, TextureKind_Normal, mi, data, textures, images);
 	analyzeMaterialTexture(material.occlusion_texture, TextureKind_Attrib, mi, data, textures, images);
 	analyzeMaterialTexture(material.emissive_texture, TextureKind_Color, mi, data, textures, images);
+
+	if (material.unlit)
+		mi.unlit = true;
 }
 
 void analyzeMaterials(cgltf_data* data, std::vector<MaterialInfo>& materials, std::vector<TextureInfo>& textures, std::vector<ImageInfo>& images)

--- a/gltf/mesh.cpp
+++ b/gltf/mesh.cpp
@@ -424,6 +424,9 @@ void filterStreams(Mesh& mesh, const MaterialInfo& mi)
 		if (stream.type == cgltf_attribute_type_texcoord && stream.index > keep_texture_set)
 			continue;
 
+		if (stream.type == cgltf_attribute_type_normal && mi.unlit)
+			continue;
+
 		if (stream.type == cgltf_attribute_type_tangent && !mi.needsTangents)
 			continue;
 


### PR DESCRIPTION
Unlit materials do not require normals or tangents; we already automatically filter out tangents because of the lack of normal texture or other material extensions, but normals were not removed until now.

This can reduce the amount of geometry we need to output; this also mostly subsumes the redundant normal stream filtering for point clouds as point clouds often have an unlit material, but for now we'll keep that redundancy.

When material variants are used, we only do this when all material variants for a given mesh are unlit. The use of the default material also blocks this optimization as default material implies basic lighting.