### PR TITLE
gltfpack: Introduce optional floating-point normal quantization

### DIFF
--- a/gltf/gltfpack.cpp
+++ b/gltf/gltfpack.cpp
@@ -1256,6 +1256,10 @@ int main(int argc, char** argv)
 		{
 			settings.tex_float = true;
 		}
+		else if (strcmp(arg, "-vnf") == 0)
+		{
+			settings.nrm_float = true;
+		}
 		else if (strcmp(arg, "-at") == 0 && i + 1 < argc && isdigit(argv[i + 1][0]))
 		{
 			settings.trn_bits = clamp(atoi(argv[++i]), 1, 24);
@@ -1581,9 +1585,9 @@ int main(int argc, char** argv)
 		return 1;
 	}
 
-	if (settings.fallback && (settings.pos_float || settings.tex_float))
+	if (settings.fallback && (settings.pos_float || settings.tex_float || settings.nrm_float))
 	{
-		fprintf(stderr, "Option -cf can not be used together with -vpf or -tpf\n");
+		fprintf(stderr, "Option -cf can not be used together with -vpf, -vtf or -vnf\n");
 		return 1;
 	}
 

--- a/gltf/gltfpack.h
+++ b/gltf/gltfpack.h
@@ -117,6 +117,7 @@ struct Settings
 	bool pos_normalized;
 	bool pos_float;
 	bool tex_float;
+	bool nrm_float;
 
 	int trn_bits;
 	int rot_bits;

--- a/gltf/stream.cpp
+++ b/gltf/stream.cpp
@@ -544,6 +544,10 @@ StreamFormat writeVertexStream(std::string& bin, const Stream& stream, const Qua
 		if (!settings.quantize)
 			return writeVertexStreamRaw(bin, stream, cgltf_type_vec3, 3);
 
+		// expand the encoded range to ensure it covers [0..1) interval
+		if (settings.nrm_float)
+			return writeVertexStreamFloat(bin, stream, cgltf_type_vec3, 3, settings, settings.nrm_bits, /* min_exp= */ 0);
+
 		bool oct = settings.compressmore && stream.target == 0;
 		int bits = settings.nrm_bits;
 


### PR DESCRIPTION
Usually normalized integer storage is optimal for normals; however, morph target deltas require a [-2, 2] storage range. During quantization we clamp them to [-1, 1] which ends up usually working fine, however there are some use cases where this doesn't work well when the normal deformation is extreme.

This can be solved by scaling normals by 0.5, so we'll use [-0.5, 0.5] range for base normal and [-1, 1] range for normal deltas. This usually works fine with any glTF renderers as they normalize the normal (which is more or less required for handling non-uniform scale transforms).

However, the validator treats files like this as invalid. Validator doesn't process files with -c/cc so technically we could fix this when compression is enabled, but that would result in an odd mismatch where compression *improves* quality instead of degrading it...

For now we introduce an option to use floating point normals, quantized using reduced mantissa and stored, when compression is enabled, using exponential filter. Similarly to -vtf, this isn't normally the recommended mode but there might be cases where it's a desireable tradeoff.

Fixes #632.