### PR TITLE
vcacheoptimizer: Tweak condition to help MSVC generate branchless code

### DIFF
--- a/src/vcacheoptimizer.cpp
+++ b/src/vcacheoptimizer.cpp
@@ -260,7 +260,7 @@ void meshopt_optimizeVertexCacheTable(unsigned int* destination, const unsigned 
 			unsigned int index = cache[i];
 
 			cache_new[cache_write] = index;
-			cache_write += (index != a && index != b && index != c);
+			cache_write += (index != a) & (index != b) & (index != c);
 		}
 
 		unsigned int* cache_temp = cache;


### PR DESCRIPTION
gcc/clang lower the condition to cmov sequence but MSVC uses branches
here; it's important to use branchless lowering as these branches are
difficult to predict. This change makes optimizeVertexCache ~7% faster
on MSVC on large meshes.
