### PR TITLE
gltfpack: Warn when some materials could not be loaded from the .obj/.mtl

### DIFF
--- a/extern/fast_obj.h
+++ b/extern/fast_obj.h
@@ -65,6 +65,9 @@ typedef struct
     float                       d;      /* Disolve (alpha) */
     int                         illum;  /* Illumination model */
 
+    /* Set for materials that don't come from the associated mtllib */
+    int                         fallback;
+
     /* Texture maps */
     fastObjTexture              map_Ka;
     fastObjTexture              map_Kd;
@@ -872,6 +875,8 @@ fastObjMaterial mtl_default(void)
     mtl.d     = 1.0;
     mtl.illum = 1;
 
+    mtl.fallback = 0;
+
     mtl.map_Ka   = map_default();
     mtl.map_Kd   = map_default();
     mtl.map_Ks   = map_default();
@@ -919,6 +924,7 @@ const char* parse_usemtl(fastObjData* data, const char* ptr)
     {
         fastObjMaterial new_mtl = mtl_default();
         new_mtl.name = string_copy(s, e);
+        new_mtl.fallback = 1;
         array_push(data->mesh->materials, new_mtl);
     }
 

--- a/gltf/parseobj.cpp
+++ b/gltf/parseobj.cpp
@@ -282,6 +282,13 @@ cgltf_data* parseObj(const char* path, std::vector<Mesh>& meshes, const char** e
 		return NULL;
 	}
 
+	int fallback_materials = 0;
+	for (unsigned int mi = 0; mi < obj->material_count; ++mi)
+		fallback_materials += obj->materials[mi].fallback;
+
+	if (fallback_materials)
+		fprintf(stderr, "Warning: %d/%d materials could not be loaded from mtllib\n", fallback_materials, obj->material_count);
+
 	cgltf_data* data = (cgltf_data*)calloc(1, sizeof(cgltf_data));
 	data->memory.free_func = defaultFree;
 


### PR DESCRIPTION
This can happen in multiple different ways:

- No mtllib reference in the .obj file
- mtllib reference in the .obj file that can not be loaded
- usemtl references to materials that don't exist in the mtllib

Fixes #640 