### PR TITLE
gltfpack: Add support for KHR_materials_dispersion

### DIFF
--- a/extern/cgltf.h
+++ b/extern/cgltf.h
@@ -505,6 +505,11 @@ typedef struct cgltf_anisotropy
 	cgltf_texture_view anisotropy_texture;
 } cgltf_anisotropy;
 
+typedef struct cgltf_dispersion
+{
+	cgltf_float dispersion;
+} cgltf_dispersion;
+
 typedef struct cgltf_material
 {
 	char* name;
@@ -519,6 +524,7 @@ typedef struct cgltf_material
 	cgltf_bool has_emissive_strength;
 	cgltf_bool has_iridescence;
 	cgltf_bool has_anisotropy;
+	cgltf_bool has_dispersion;
 	cgltf_pbr_metallic_roughness pbr_metallic_roughness;
 	cgltf_pbr_specular_glossiness pbr_specular_glossiness;
 	cgltf_clearcoat clearcoat;
@@ -530,6 +536,7 @@ typedef struct cgltf_material
 	cgltf_emissive_strength emissive_strength;
 	cgltf_iridescence iridescence;
 	cgltf_anisotropy anisotropy;
+	cgltf_dispersion dispersion;
 	cgltf_texture_view normal_texture;
 	cgltf_texture_view occlusion_texture;
 	cgltf_texture_view emissive_texture;
@@ -4297,6 +4304,37 @@ static int cgltf_parse_json_anisotropy(cgltf_options* options, jsmntok_t const* 
 	return i;
 }
 
+static int cgltf_parse_json_dispersion(jsmntok_t const* tokens, int i, const uint8_t* json_chunk, cgltf_dispersion* out_dispersion)
+{
+	CGLTF_CHECK_TOKTYPE(tokens[i], JSMN_OBJECT);
+	int size = tokens[i].size;
+	++i;
+
+
+	for (int j = 0; j < size; ++j)
+	{
+		CGLTF_CHECK_KEY(tokens[i]);
+
+		if (cgltf_json_strcmp(tokens + i, json_chunk, "dispersion") == 0)
+		{
+			++i;
+			out_dispersion->dispersion = cgltf_json_to_float(tokens + i, json_chunk);
+			++i;
+		}
+		else
+		{
+			i = cgltf_skip_json(tokens, i + 1);
+		}
+
+		if (i < 0)
+		{
+			return i;
+		}
+	}
+
+	return i;
+}
+
 static int cgltf_parse_json_image(cgltf_options* options, jsmntok_t const* tokens, int i, const uint8_t* json_chunk, cgltf_image* out_image)
 {
 	CGLTF_CHECK_TOKTYPE(tokens[i], JSMN_OBJECT);
@@ -4689,6 +4727,11 @@ static int cgltf_parse_json_material(cgltf_options* options, jsmntok_t const* to
 				{
 					out_material->has_anisotropy = 1;
 					i = cgltf_parse_json_anisotropy(options, tokens, i + 1, json_chunk, &out_material->anisotropy);
+				}
+				else if (cgltf_json_strcmp(tokens + i, json_chunk, "KHR_materials_dispersion") == 0)
+				{
+					out_material->has_dispersion = 1;
+					i = cgltf_parse_json_dispersion(tokens, i + 1, json_chunk, &out_material->dispersion);
 				}
 				else
 				{

--- a/gltf/README.md
+++ b/gltf/README.md
@@ -69,6 +69,7 @@ gltfpack supports most Khronos extensions and some multi-vendor extensions in th
 - KHR_lights_punctual
 - KHR_materials_anisotropy
 - KHR_materials_clearcoat
+- KHR_materials_dispersion
 - KHR_materials_emissive_strength
 - KHR_materials_ior
 - KHR_materials_iridescence

--- a/gltf/gltfpack.cpp
+++ b/gltf/gltfpack.cpp
@@ -439,6 +439,7 @@ static void process(cgltf_data* data, const char* input_path, const char* output
 	bool ext_emissive_strength = false;
 	bool ext_iridescence = false;
 	bool ext_anisotropy = false;
+	bool ext_dispersion = false;
 	bool ext_unlit = false;
 	bool ext_instancing = false;
 	bool ext_texture_transform = false;
@@ -537,6 +538,7 @@ static void process(cgltf_data* data, const char* input_path, const char* output
 		ext_emissive_strength = ext_emissive_strength || material.has_emissive_strength;
 		ext_iridescence = ext_iridescence || material.has_iridescence;
 		ext_anisotropy = ext_anisotropy || material.has_anisotropy;
+		ext_dispersion = ext_dispersion || material.has_dispersion;
 		ext_unlit = ext_unlit || material.unlit;
 		ext_texture_transform = ext_texture_transform || mi.usesTextureTransform;
 	}
@@ -826,6 +828,7 @@ static void process(cgltf_data* data, const char* input_path, const char* output
 	    {"KHR_materials_emissive_strength", ext_emissive_strength, false},
 	    {"KHR_materials_iridescence", ext_iridescence, false},
 	    {"KHR_materials_anisotropy", ext_anisotropy, false},
+	    {"KHR_materials_dispersion", ext_dispersion, false},
 	    {"KHR_materials_unlit", ext_unlit, false},
 	    {"KHR_materials_variants", data->variants_count > 0, false},
 	    {"KHR_lights_punctual", data->lights_count > 0, false},

--- a/gltf/material.cpp
+++ b/gltf/material.cpp
@@ -232,6 +232,14 @@ static bool areMaterialComponentsEqual(const cgltf_anisotropy& lhs, const cgltf_
 	return true;
 }
 
+static bool areMaterialComponentsEqual(const cgltf_dispersion& lhs, const cgltf_dispersion& rhs)
+{
+	if (lhs.dispersion != rhs.dispersion)
+		return false;
+
+	return true;
+}
+
 static bool areMaterialsEqual(const cgltf_material& lhs, const cgltf_material& rhs, const Settings& settings)
 {
 	if (lhs.has_pbr_metallic_roughness != rhs.has_pbr_metallic_roughness)
@@ -298,6 +306,12 @@ static bool areMaterialsEqual(const cgltf_material& lhs, const cgltf_material& r
 		return false;
 
 	if (lhs.has_anisotropy && !areMaterialComponentsEqual(lhs.anisotropy, rhs.anisotropy))
+		return false;
+
+	if (lhs.has_dispersion != rhs.has_dispersion)
+		return false;
+
+	if (lhs.has_dispersion && !areMaterialComponentsEqual(lhs.dispersion, rhs.dispersion))
 		return false;
 
 	if (!areTextureViewsEqual(lhs.normal_texture, rhs.normal_texture))

--- a/gltf/write.cpp
+++ b/gltf/write.cpp
@@ -580,6 +580,17 @@ static void writeMaterialComponent(std::string& json, const cgltf_data* data, co
 	append(json, "}");
 }
 
+static void writeMaterialComponent(std::string& json, const cgltf_data* data, const cgltf_dispersion& tm)
+{
+	(void)data;
+
+	comma(json);
+	append(json, "\"KHR_materials_dispersion\":{");
+	append(json, "\"dispersion\":");
+	append(json, tm.dispersion);
+	append(json, "}");
+}
+
 void writeMaterial(std::string& json, const cgltf_data* data, const cgltf_material& material, const QuantizationPosition* qp, const QuantizationTexture* qt, std::vector<TextureInfo>& textures)
 {
 	if (material.name && *material.name)
@@ -649,7 +660,7 @@ void writeMaterial(std::string& json, const cgltf_data* data, const cgltf_materi
 		append(json, "\"doubleSided\":true");
 	}
 
-	if (material.has_pbr_specular_glossiness || material.has_clearcoat || material.has_transmission || material.has_ior || material.has_specular || material.has_sheen || material.has_volume || material.has_emissive_strength || material.has_iridescence || material.has_anisotropy || material.unlit)
+	if (material.has_pbr_specular_glossiness || material.has_clearcoat || material.has_transmission || material.has_ior || material.has_specular || material.has_sheen || material.has_volume || material.has_emissive_strength || material.has_iridescence || material.has_anisotropy || material.has_dispersion || material.unlit)
 	{
 		comma(json);
 		append(json, "\"extensions\":{");
@@ -702,6 +713,11 @@ void writeMaterial(std::string& json, const cgltf_data* data, const cgltf_materi
 		if (material.has_anisotropy)
 		{
 			writeMaterialComponent(json, data, material.anisotropy, qt, textures);
+		}
+
+		if (material.has_dispersion)
+		{
+			writeMaterialComponent(json, data, material.dispersion);
 		}
 
 		if (material.unlit)


### PR DESCRIPTION
This change adds cgltf parsing support as well as material merging/writing; this extension is similar to KHR_materials_ior in that it's just one extra float.

Specification:
https://github.com/KhronosGroup/gltf/tree/main/extensions/2.0/Khronos/KHR_materials_dispersion