### PR TITLE
clusterizer: Implement experimental meshlet optimizer

### DIFF
--- a/src/clusterizer.cpp
+++ b/src/clusterizer.cpp
@@ -903,29 +903,27 @@ void meshopt_optimizeMeshlet(unsigned int* meshlet_vertices, unsigned char* mesh
 	for (size_t i = 0; i < triangle_count; ++i)
 	{
 		int next = -1;
+		int next_match = -1;
 
-		for (int pass = 2; pass >= 0; pass--)
+		for (size_t j = 0; j < triangle_count; ++j)
 		{
-			for (size_t j = 0; j < triangle_count; ++j)
+			if (visited[j])
+				continue;
+
+			unsigned char a = indices[j * 3 + 0], b = indices[j * 3 + 1], c = indices[j * 3 + 2];
+
+			int aok = (a == lasta || a == lastb || a == lastc);
+			int bok = (b == lasta || b == lastb || b == lastc);
+			int cok = (c == lasta || c == lastb || c == lastc);
+
+			if (aok + bok + cok > next_match)
 			{
-				if (visited[j])
-					continue;
+				next = (int)j;
+				next_match = aok + bok + cok;
 
-				unsigned char a = indices[j * 3 + 0], b = indices[j * 3 + 1], c = indices[j * 3 + 2];
-
-				int aok = (a == lasta || a == lastb || a == lastc);
-				int bok = (b == lasta || b == lastb || b == lastc);
-				int cok = (c == lasta || c == lastb || c == lastc);
-
-				if (aok + bok + cok >= pass)
-				{
-					next = (int)j;
+				if (next_match == 2)
 					break;
-				}
 			}
-
-			if (next >= 0)
-				break;
 		}
 
 		assert(next >= 0);

--- a/src/meshoptimizer.h
+++ b/src/meshoptimizer.h
@@ -493,6 +493,16 @@ MESHOPTIMIZER_API size_t meshopt_buildMeshlets(struct meshopt_Meshlet* meshlets,
 MESHOPTIMIZER_API size_t meshopt_buildMeshletsScan(struct meshopt_Meshlet* meshlets, unsigned int* meshlet_vertices, unsigned char* meshlet_triangles, const unsigned int* indices, size_t index_count, size_t vertex_count, size_t max_vertices, size_t max_triangles);
 MESHOPTIMIZER_API size_t meshopt_buildMeshletsBound(size_t index_count, size_t max_vertices, size_t max_triangles);
 
+/**
+ * Experimental: Meshlet optimizer
+ * Reorders meshlet vertices and triangles to maximize locality to improve rasterizer throughput
+ *
+ * meshlet_triangles and meshlet_vertices must refer to meshlet triangle and vertex index data; when buildMeshlets* is used, these
+ * need to be computed from meshlet's vertex_offset and triangle_offset
+ * triangle_count and vertex_count must not exceed implementation limits (vertex_count <= 255 - not 256!, triangle_count <= 512)
+ */
+MESHOPTIMIZER_EXPERIMENTAL void meshopt_optimizeMeshlet(unsigned int* meshlet_vertices, unsigned char* meshlet_triangles, size_t triangle_count, size_t vertex_count);
+
 struct meshopt_Bounds
 {
 	/* bounding sphere, useful for frustum and occlusion culling */


### PR DESCRIPTION
So far we were mostly concerned with meshlet clustering from the
perspective of treating meshlets as an unordered set of triangles; while
this matches the computational and documented model, this may not be
optimal for a given GPU.

Notably, NVidia GPUs are much more sensitive to the order of triangles
in the meshlet than to the number and fill percentage; so much so that
from pure rasterization performance, scan may win over proper clustering
because it implicitly generates a better order.

We do not know the precise criteria / mechanism that NV GPUs use here
but it helps to do locality optimization; most importantly, triangle
order, but also reordering meshlet-local vertices helps a little bit.

This change implements a simple meshlet optimizer; while this can also
be achieved by running existing optimization algorithms (vcache /
vfetch) on meshlet data, a custom optimizer is faster even when using
unoptimized quadratic implementation, and may allow us to implement
better locality reodering algorithms in the future assuming a small
input patch.

(work in progress, needs some cleanup / optimizations / tests)