### PR TITLE
gltfpack: Replace images that can't be found or encoded with invalid URI

### DIFF
--- a/gltf/gltfpack.cpp
+++ b/gltf/gltfpack.cpp
@@ -480,9 +480,9 @@ static void process(cgltf_data* data, const char* input_path, const char* output
 		if (encoded_images.size() && !encoded_images[i].empty())
 		{
 			if (encoded_images[i].compare(0, 5, "error") == 0)
-				fprintf(stderr, "Warning: unable to encode image %d (%s), skipping (%s)\n", int(i), image.uri ? image.uri : "?", encoded_images[i].c_str());
+				writeImageError(json_images, "encode", int(i), image.uri, encoded_images[i].c_str());
 			else
-				writeEncodedImage(json_images, views, image, encoded_images[i], images[i], output_path, settings);
+				writeEncodedImage(json_images, views, image, encoded_images[i], images[i], i, output_path, settings);
 
 			encoded_images[i] = std::string(); // reclaim memory early
 		}

--- a/gltf/gltfpack.h
+++ b/gltf/gltfpack.h
@@ -369,7 +369,8 @@ void writeMaterial(std::string& json, const cgltf_data* data, const cgltf_materi
 void writeBufferView(std::string& json, BufferView::Kind kind, StreamFormat::Filter filter, size_t count, size_t stride, size_t bin_offset, size_t bin_size, BufferView::Compression compression, size_t compressed_offset, size_t compressed_size);
 void writeSampler(std::string& json, const cgltf_sampler& sampler);
 void writeImage(std::string& json, std::vector<BufferView>& views, const cgltf_image& image, const ImageInfo& info, size_t index, const char* input_path, const char* output_path, const Settings& settings);
-void writeEncodedImage(std::string& json, std::vector<BufferView>& views, const cgltf_image& image, const std::string& encoded, const ImageInfo& info, const char* output_path, const Settings& settings);
+void writeImageError(std::string& json, const char* action, size_t index, const char* uri, const char* reason = NULL);
+void writeEncodedImage(std::string& json, std::vector<BufferView>& views, const cgltf_image& image, const std::string& encoded, const ImageInfo& info, size_t index, const char* output_path, const Settings& settings);
 void writeTexture(std::string& json, const cgltf_texture& texture, const ImageInfo* info, cgltf_data* data, const Settings& settings);
 void writeMeshAttributes(std::string& json, std::vector<BufferView>& views, std::string& json_accessors, size_t& accr_offset, const Mesh& mesh, int target, const QuantizationPosition& qp, const QuantizationTexture& qt, const Settings& settings);
 size_t writeMeshIndices(std::vector<BufferView>& views, std::string& json_accessors, size_t& accr_offset, const Mesh& mesh, const Settings& settings);

--- a/gltf/write.cpp
+++ b/gltf/write.cpp
@@ -948,7 +948,9 @@ void writeImage(std::string& json, std::vector<BufferView>& views, const cgltf_i
 
 void writeImageError(std::string& json, const char* action, size_t index, const char* uri, const char* reason)
 {
-	(void)json;
+	append(json, "\"uri\":\"");
+	append(json, "data:image/png;base64,ERR/");
+	append(json, "\"");
 
 	fprintf(stderr, "Warning: unable to %s image %d (%s), skipping%s%s%s\n", action, int(index), uri ? uri : "embedded", reason ? " (" : "", reason ? reason : "", reason ? ")" : "");
 }


### PR DESCRIPTION
This change consolidates error handling for images that can't be read, written, or encoded, and uniformly emits an invalid embedded Base64 URI in these cases.

This keeps the file invalid as per glTF spec, but allows various loaders to load it. The source file in cases like this was semantically invalid so maybe this is fine.

Ideally we would probably want to remove references to the image. Unfortunately, to preserve glTF file validity, this requires transitive removal of texture references from all materials as well as image/texture array compaction...

Fixes #675