### PR TITLE
gltfpack: Use vertex attributes to guide simplification

### DIFF
--- a/gltf/gltfpack.cpp
+++ b/gltf/gltfpack.cpp
@@ -387,7 +387,7 @@ static void process(cgltf_data* data, const char* input_path, const char* output
 		{
 			Mesh kinds = {};
 			Mesh loops = {};
-			debugSimplify(mesh, kinds, loops, settings.simplify_debug);
+			debugSimplify(mesh, kinds, loops, settings.simplify_debug, settings.simplify_attributes);
 			debug_meshes.push_back(kinds);
 			debug_meshes.push_back(loops);
 		}

--- a/gltf/gltfpack.cpp
+++ b/gltf/gltfpack.cpp
@@ -1324,6 +1324,10 @@ int main(int argc, char** argv)
 		{
 			settings.simplify_lock_borders = true;
 		}
+		else if (strcmp(arg, "-sv") == 0)
+		{
+			settings.simplify_attributes = true;
+		}
 #ifndef NDEBUG
 		else if (strcmp(arg, "-sd") == 0 && i + 1 < argc && isdigit(argv[i + 1][0]))
 		{
@@ -1509,6 +1513,7 @@ int main(int argc, char** argv)
 			fprintf(stderr, "\nSimplification:\n");
 			fprintf(stderr, "\t-si R: simplify meshes targeting triangle/point count ratio R (default: 1; R should be between 0 and 1)\n");
 			fprintf(stderr, "\t-sa: aggressively simplify to the target ratio disregarding quality\n");
+			fprintf(stderr, "\t-sv: take vertex attributes into account when simplifying meshes\n");
 			fprintf(stderr, "\t-slb: lock border vertices during simplification to avoid gaps on connected meshes\n");
 			fprintf(stderr, "\nVertex precision:\n");
 			fprintf(stderr, "\t-vp N: use N-bit quantization for positions (default: 14; N should be between 1 and 16)\n");

--- a/gltf/gltfpack.h
+++ b/gltf/gltfpack.h
@@ -303,7 +303,7 @@ cgltf_data* parseGlb(const void* buffer, size_t size, std::vector<Mesh>& meshes,
 void processAnimation(Animation& animation, const Settings& settings);
 void processMesh(Mesh& mesh, const Settings& settings);
 
-void debugSimplify(const Mesh& mesh, Mesh& kinds, Mesh& loops, float ratio);
+void debugSimplify(const Mesh& mesh, Mesh& kinds, Mesh& loops, float ratio, bool attributes);
 void debugMeshlets(const Mesh& mesh, Mesh& meshlets, Mesh& bounds, int max_vertices, bool scan);
 
 bool compareMeshTargets(const Mesh& lhs, const Mesh& rhs);

--- a/gltf/gltfpack.h
+++ b/gltf/gltfpack.h
@@ -136,6 +136,7 @@ struct Settings
 	float simplify_threshold;
 	bool simplify_aggressive;
 	bool simplify_lock_borders;
+	bool simplify_attributes;
 	float simplify_debug;
 
 	int meshlet_debug;

--- a/gltf/mesh.cpp
+++ b/gltf/mesh.cpp
@@ -551,7 +551,7 @@ static void simplifyMesh(Mesh& mesh, float threshold, bool attributes, bool aggr
 	const Stream* attr = getStream(mesh, cgltf_attribute_type_color);
 	attr = attr ? attr : getStream(mesh, cgltf_attribute_type_normal);
 
-	const float attrw[3] = {1e-2, 1e-2, 1e-2};
+	const float attrw[3] = {1e-2f, 1e-2f, 1e-2f};
 
 	std::vector<unsigned int> indices(mesh.indices.size());
 	if (attributes && attr)

--- a/gltf/mesh.cpp
+++ b/gltf/mesh.cpp
@@ -791,7 +791,7 @@ extern MESHOPTIMIZER_API unsigned char* meshopt_simplifyDebugKind;
 extern MESHOPTIMIZER_API unsigned int* meshopt_simplifyDebugLoop;
 extern MESHOPTIMIZER_API unsigned int* meshopt_simplifyDebugLoopBack;
 
-void debugSimplify(const Mesh& source, Mesh& kinds, Mesh& loops, float ratio)
+void debugSimplify(const Mesh& source, Mesh& kinds, Mesh& loops, float ratio, bool attributes)
 {
 	Mesh mesh = source;
 	assert(mesh.type == cgltf_primitive_type_triangles);
@@ -814,7 +814,7 @@ void debugSimplify(const Mesh& source, Mesh& kinds, Mesh& loops, float ratio)
 	meshopt_simplifyDebugLoop = &loop[0];
 	meshopt_simplifyDebugLoopBack = &loopback[0];
 
-	simplifyMesh(mesh, ratio, /* attributes= */ false, /* aggressive= */ false, /* lock_borders= */ false);
+	simplifyMesh(mesh, ratio, attributes, /* aggressive= */ false, /* lock_borders= */ false);
 
 	meshopt_simplifyDebugKind = NULL;
 	meshopt_simplifyDebugLoop = NULL;

--- a/gltf/mesh.cpp
+++ b/gltf/mesh.cpp
@@ -548,12 +548,14 @@ static void simplifyMesh(Mesh& mesh, float threshold, bool attributes, bool aggr
 	if (target_index_count < 1)
 		return;
 
-	const Stream* colors = getStream(mesh, cgltf_attribute_type_color);
-	const float colw[3] = {1e-2, 1e-2, 1e-2};
+	const Stream* attr = getStream(mesh, cgltf_attribute_type_color);
+	attr = attr ? attr : getStream(mesh, cgltf_attribute_type_normal);
+
+	const float attrw[3] = {1e-2, 1e-2, 1e-2};
 
 	std::vector<unsigned int> indices(mesh.indices.size());
-	if (attributes && colors)
-		indices.resize(meshopt_simplifyWithAttributes(&indices[0], &mesh.indices[0], mesh.indices.size(), positions->data[0].f, vertex_count, sizeof(Attr), colors->data[0].f, sizeof(Attr), colw, 3, NULL, target_index_count, target_error, options));
+	if (attributes && attr)
+		indices.resize(meshopt_simplifyWithAttributes(&indices[0], &mesh.indices[0], mesh.indices.size(), positions->data[0].f, vertex_count, sizeof(Attr), attr->data[0].f, sizeof(Attr), attrw, 3, NULL, target_index_count, target_error, options));
 	else
 		indices.resize(meshopt_simplify(&indices[0], &mesh.indices[0], mesh.indices.size(), positions->data[0].f, vertex_count, sizeof(Attr), target_index_count, target_error, options));
 	mesh.indices.swap(indices);


### PR DESCRIPTION
When -sv command line argument is specified, we will use vertex colors
or vertex normals as part of attribute aware simplification to produce better
results. For now the intention is to use a single argument to
incorporate multiple different types of attributes with fixed weights,
in the future we might expose more detailed control via '-sv?' prefix.

Fixes #652