### PR TITLE
gltfpack: Implement support for EXT_meshopt_compression inputs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,7 +84,7 @@ jobs:
     - name: test
       run: find glTF-Sample-Assets -name *.gltf -or -name *.glb | xargs -d '\n' ./gltfpack -cc -test
     - name: pack
-      run: find glTF-Sample-Assets -name *.gltf | grep -v 'glTF-Draco\|glTF-KTX\|glTF-Meshopt' | xargs -d '\n' -I '{}' ./gltfpack -i '{}' -o '{}pack.gltf'
+      run: find glTF-Sample-Assets -name *.gltf | grep -v 'glTF-Draco\|glTF-KTX' | xargs -d '\n' -I '{}' ./gltfpack -i '{}' -o '{}pack.gltf'
     - name: validate
       run: |
         curl -sL $VALIDATOR | tar xJ

--- a/gltf/README.md
+++ b/gltf/README.md
@@ -82,6 +82,7 @@ gltfpack supports most Khronos extensions and some multi-vendor extensions in th
 - KHR_materials_volume
 - KHR_mesh_quantization
 - KHR_texture_transform
+- EXT_meshopt_compression
 
 Even if the source file does not use extensions, gltfpack may use some extensions in the output file either by default or when certain options are used:
 

--- a/gltf/parsegltf.cpp
+++ b/gltf/parsegltf.cpp
@@ -571,8 +571,8 @@ cgltf_data* parseGltf(const char* path, std::vector<Mesh>& meshes, std::vector<A
 		freeFile(data);
 
 	result = (result == cgltf_result_success) ? cgltf_load_buffers(&options, data, path) : result;
-	result = (result == cgltf_result_success) ? decompressMeshopt(data) : result;
 	result = (result == cgltf_result_success) ? cgltf_validate(data) : result;
+	result = (result == cgltf_result_success) ? decompressMeshopt(data) : result;
 
 	return parseGltf(data, result, meshes, animations, error);
 }
@@ -587,8 +587,8 @@ cgltf_data* parseGlb(const void* buffer, size_t size, std::vector<Mesh>& meshes,
 	cgltf_result result = cgltf_parse(&options, buffer, size, &data);
 
 	result = (result == cgltf_result_success) ? cgltf_load_buffers(&options, data, NULL) : result;
-	result = (result == cgltf_result_success) ? decompressMeshopt(data) : result;
 	result = (result == cgltf_result_success) ? cgltf_validate(data) : result;
+	result = (result == cgltf_result_success) ? decompressMeshopt(data) : result;
 
 	return parseGltf(data, result, meshes, animations, error);
 }


### PR DESCRIPTION
When the input file contains EXT_meshopt_compression encoded buffer
views we can now decompress them and process the data as usual. This
should help with interoperability.

If the input uses filters, decompression and recompression  may
introduce extra precision issues; this is mostly captured by an existing
quantization warning though.