### PR TITLE
gltfpack: Implement support for KHR_texture_basisu inputs 

### DIFF
--- a/gltf/README.md
+++ b/gltf/README.md
@@ -81,6 +81,7 @@ gltfpack supports most Khronos extensions and some multi-vendor extensions in th
 - KHR_materials_variants
 - KHR_materials_volume
 - KHR_mesh_quantization
+- KHR_texture_basisu
 - KHR_texture_transform
 - EXT_meshopt_compression
 

--- a/gltf/basisenc.cpp
+++ b/gltf/basisenc.cpp
@@ -98,10 +98,12 @@ static const char* prepareEncode(basisu::basis_compressor_params& params, const 
 {
 	std::string img_data;
 	std::string mime_type;
-	std::string result;
 
 	if (!readImage(image, input_path, img_data, mime_type))
 		return "error reading source file";
+
+	if (mime_type != "image/png" && mime_type != "image/jpeg")
+		return NULL;
 
 	int width = 0, height = 0;
 	if (!getDimensions(img_data, mime_type.c_str(), width, height))

--- a/gltf/gltfpack.cpp
+++ b/gltf/gltfpack.cpp
@@ -452,6 +452,7 @@ static void process(cgltf_data* data, const char* input_path, const char* output
 	bool ext_unlit = false;
 	bool ext_instancing = false;
 	bool ext_texture_transform = false;
+	bool ext_texture_basisu = false;
 
 	size_t accr_offset = 0;
 	size_t node_offset = 0;
@@ -509,6 +510,7 @@ static void process(cgltf_data* data, const char* input_path, const char* output
 
 		assert(textures[i].remap == int(texture_offset));
 		texture_offset++;
+		ext_texture_basisu = ext_texture_basisu || texture.has_basisu;
 	}
 
 	for (size_t i = 0; i < data->materials_count; ++i)
@@ -834,7 +836,7 @@ static void process(cgltf_data* data, const char* input_path, const char* output
 	    {"KHR_materials_unlit", ext_unlit, false},
 	    {"KHR_materials_variants", data->variants_count > 0, false},
 	    {"KHR_lights_punctual", data->lights_count > 0, false},
-	    {"KHR_texture_basisu", !json_textures.empty() && settings.texture_ktx2, true},
+	    {"KHR_texture_basisu", (!json_textures.empty() && settings.texture_ktx2) || ext_texture_basisu, true},
 	    {"EXT_mesh_gpu_instancing", ext_instancing, true},
 	};
 

--- a/gltf/material.cpp
+++ b/gltf/material.cpp
@@ -11,6 +11,12 @@ static bool areTexturesEqual(const cgltf_texture& lhs, const cgltf_texture& rhs)
 	if (lhs.sampler != rhs.sampler)
 		return false;
 
+	if (lhs.has_basisu != rhs.has_basisu)
+		return false;
+
+	if (lhs.basisu_image != rhs.basisu_image)
+		return false;
+
 	return true;
 }
 

--- a/gltf/material.cpp
+++ b/gltf/material.cpp
@@ -443,7 +443,13 @@ bool hasValidTransform(const cgltf_texture_view& view)
 
 static const cgltf_image* getTextureImage(const cgltf_texture* texture)
 {
-       return texture ? (texture->has_basisu ? texture->basisu_image : texture->image) : NULL;
+	if (texture && texture->image)
+		return texture->image;
+
+	if (texture && texture->has_basisu && texture->basisu_image)
+		return texture->basisu_image;
+
+	return NULL;
 }
 
 static void analyzeMaterialTexture(const cgltf_texture_view& view, TextureKind kind, MaterialInfo& mi, cgltf_data* data, std::vector<TextureInfo>& textures, std::vector<ImageInfo>& images)

--- a/gltf/parsegltf.cpp
+++ b/gltf/parsegltf.cpp
@@ -530,8 +530,6 @@ static cgltf_data* parseGltf(cgltf_data* data, cgltf_result result, std::vector<
 		*error = getError(result, data);
 	else if (requiresExtension(data, "KHR_draco_mesh_compression"))
 		*error = "file requires Draco mesh compression support";
-	else if (requiresExtension(data, "KHR_texture_basisu"))
-		*error = "file requires BasisU texture support";
 	else if (requiresExtension(data, "EXT_mesh_gpu_instancing"))
 		*error = "file requires mesh instancing support";
 	else if (needsDummyBuffers(data))

--- a/gltf/write.cpp
+++ b/gltf/write.cpp
@@ -952,26 +952,34 @@ void writeImage(std::string& json, std::vector<BufferView>& views, const cgltf_i
 
 void writeTexture(std::string& json, const cgltf_texture& texture, const ImageInfo* info, cgltf_data* data, const Settings& settings)
 {
+	if (texture.sampler)
+	{
+		append(json, "\"sampler\":");
+		append(json, size_t(texture.sampler - data->samplers));
+	}
+
 	if (texture.image)
 	{
-		if (texture.sampler)
-		{
-			append(json, "\"sampler\":");
-			append(json, size_t(texture.sampler - data->samplers));
-			append(json, ",");
-		}
-
 		if (info && settings.texture_mode[info->kind] != TextureMode_Raw)
 		{
+			comma(json);
 			append(json, "\"extensions\":{\"KHR_texture_basisu\":{\"source\":");
 			append(json, size_t(texture.image - data->images));
 			append(json, "}}");
 		}
 		else
 		{
+			comma(json);
 			append(json, "\"source\":");
 			append(json, size_t(texture.image - data->images));
 		}
+	}
+	else if (texture.has_basisu)
+	{
+		comma(json);
+		append(json, "\"extensions\":{\"KHR_texture_basisu\":{\"source\":");
+		append(json, size_t(texture.basisu_image - data->images));
+		append(json, "}}");
 	}
 }
 

--- a/gltf/write.cpp
+++ b/gltf/write.cpp
@@ -966,6 +966,8 @@ void writeTexture(std::string& json, const cgltf_texture& texture, const ImageIn
 			append(json, "\"extensions\":{\"KHR_texture_basisu\":{\"source\":");
 			append(json, size_t(texture.image - data->images));
 			append(json, "}}");
+
+			return; // skip input basisu image if present, as we replace it with the one we encoded
 		}
 		else
 		{
@@ -974,7 +976,8 @@ void writeTexture(std::string& json, const cgltf_texture& texture, const ImageIn
 			append(json, size_t(texture.image - data->images));
 		}
 	}
-	else if (texture.has_basisu)
+
+	if (texture.has_basisu && texture.basisu_image)
 	{
 		comma(json);
 		append(json, "\"extensions\":{\"KHR_texture_basisu\":{\"source\":");


### PR DESCRIPTION
When the input file has KHR_texture_basisu extension, we now will
preserve the images along with the extension in the output file instead
of discarding it.

When `-tc` is specified, images like this will not be recompressed; accordingly,
some flags like `-tl` and `-tp` will not work with pre-compressed inputs.

When the input textures specify both uncompressed and compressed image,
the behavior is likely to be suboptimal...

Fixes #537.