### PR TITLE
gltfpack: Implement EXT_mesh_gpu_instancing support for input scenes

### DIFF
--- a/extern/cgltf.h
+++ b/extern/cgltf.h
@@ -1697,7 +1697,20 @@ cgltf_result cgltf_validate(cgltf_data* data)
 	{
 		if (data->nodes[i].weights && data->nodes[i].mesh)
 		{
-			CGLTF_ASSERT_IF (data->nodes[i].mesh->primitives_count && data->nodes[i].mesh->primitives[0].targets_count != data->nodes[i].weights_count, cgltf_result_invalid_gltf);
+			CGLTF_ASSERT_IF(data->nodes[i].mesh->primitives_count && data->nodes[i].mesh->primitives[0].targets_count != data->nodes[i].weights_count, cgltf_result_invalid_gltf);
+		}
+
+		if (data->nodes[i].has_mesh_gpu_instancing)
+		{
+			CGLTF_ASSERT_IF(data->nodes[i].mesh == NULL, cgltf_result_invalid_gltf);
+			CGLTF_ASSERT_IF(data->nodes[i].mesh_gpu_instancing.attributes_count == 0, cgltf_result_invalid_gltf);
+
+			cgltf_accessor* first = data->nodes[i].mesh_gpu_instancing.attributes[0].data;
+
+			for (cgltf_size k = 0; k < data->nodes[i].mesh_gpu_instancing.attributes_count; ++k)
+			{
+				CGLTF_ASSERT_IF(data->nodes[i].mesh_gpu_instancing.attributes[k].data->count != first->count, cgltf_result_invalid_gltf);
+			}
 		}
 	}
 

--- a/gltf/README.md
+++ b/gltf/README.md
@@ -83,6 +83,7 @@ gltfpack supports most Khronos extensions and some multi-vendor extensions in th
 - KHR_mesh_quantization
 - KHR_texture_basisu
 - KHR_texture_transform
+- EXT_mesh_gpu_instancing
 - EXT_meshopt_compression
 
 Even if the source file does not use extensions, gltfpack may use some extensions in the output file either by default or when certain options are used:

--- a/gltf/gltfpack.cpp
+++ b/gltf/gltfpack.cpp
@@ -281,7 +281,10 @@ static void process(cgltf_data* data, const char* input_path, const char* output
 	for (size_t i = 0; i < meshes.size(); ++i)
 	{
 		Mesh& mesh = meshes[i];
-		assert(mesh.instances.empty());
+
+		// mesh is already instanced, skip
+		if (!mesh.instances.empty())
+			continue;
 
 		// mesh is already world space, skip
 		if (mesh.nodes.empty())
@@ -664,9 +667,6 @@ static void process(cgltf_data* data, const char* input_path, const char* output
 
 		append(json_meshes, "}");
 
-		assert(mesh.nodes.empty() || mesh.instances.empty());
-		ext_instancing = ext_instancing || !mesh.instances.empty();
-
 		if (mesh.nodes.size())
 		{
 			for (size_t j = 0; j < mesh.nodes.size(); ++j)
@@ -691,7 +691,8 @@ static void process(cgltf_data* data, const char* input_path, const char* output
 				}
 			}
 		}
-		else if (mesh.instances.size())
+
+		if (mesh.instances.size())
 		{
 			assert(mesh.scene >= 0);
 			comma(json_roots[mesh.scene]);
@@ -704,7 +705,8 @@ static void process(cgltf_data* data, const char* input_path, const char* output
 
 			node_offset++;
 		}
-		else
+
+		if (mesh.nodes.empty() && mesh.instances.empty())
 		{
 			assert(mesh.scene >= 0);
 			comma(json_roots[mesh.scene]);
@@ -716,6 +718,7 @@ static void process(cgltf_data* data, const char* input_path, const char* output
 		}
 
 		mesh_offset++;
+		ext_instancing = ext_instancing || !mesh.instances.empty();
 
 		// skip all meshes that we've written in this iteration
 		assert(pi > i);

--- a/gltf/parsegltf.cpp
+++ b/gltf/parsegltf.cpp
@@ -346,15 +346,16 @@ static void parseMeshNodesGltf(cgltf_data* data, std::vector<Mesh>& meshes, cons
 				mesh = &meshes.back();
 			}
 
-			mesh->skin = node.skin;
-
 			if (node.has_mesh_gpu_instancing)
 			{
-				mesh->scene = 0; // TODO
+				mesh->scene = 0; // TODO: we need to assign scene index since instances are attached to a scene; for now we assume 0
 				parseMeshInstancesGltf(mesh->instances, &node);
 			}
 			else
+			{
+				mesh->skin = node.skin;
 				mesh->nodes.push_back(&node);
+			}
 		}
 	}
 

--- a/gltf/parsegltf.cpp
+++ b/gltf/parsegltf.cpp
@@ -275,7 +275,7 @@ static void parseMeshesGltf(cgltf_data* data, std::vector<Mesh>& meshes, std::ve
 	}
 }
 
-static void parseMeshInstancesGltf(cgltf_data* data, std::vector<Transform>& instances, cgltf_node* node)
+static void parseMeshInstancesGltf(std::vector<Transform>& instances, cgltf_node* node)
 {
 	cgltf_accessor* translation = NULL;
 	cgltf_accessor* rotation = NULL;
@@ -293,14 +293,7 @@ static void parseMeshInstancesGltf(cgltf_data* data, std::vector<Transform>& ins
 			scale = attr.data;
 	}
 
-	size_t count = translation ? translation->count : (rotation ? rotation->count : (scale ? scale->count : 0));
-
-	// todo move to cgltf?
-	if (count == 0 || (translation && translation->count != count) || (rotation && rotation->count != count) || (scale && scale->count != count))
-	{
-		fprintf(stderr, "Warning: ignoring instancing data in node %d as no transforms are present\n", int(node - data->nodes));
-		return;
-	}
+	size_t count = node->mesh_gpu_instancing.attributes[0].data->count;
 
 	instances.reserve(instances.size() + count);
 
@@ -358,7 +351,7 @@ static void parseMeshNodesGltf(cgltf_data* data, std::vector<Mesh>& meshes, cons
 			if (node.has_mesh_gpu_instancing)
 			{
 				mesh->scene = 0; // TODO
-				parseMeshInstancesGltf(data, mesh->instances, &node);
+				parseMeshInstancesGltf(mesh->instances, &node);
 			}
 			else
 				mesh->nodes.push_back(&node);

--- a/gltf/parsegltf.cpp
+++ b/gltf/parsegltf.cpp
@@ -348,7 +348,7 @@ static void parseMeshNodesGltf(cgltf_data* data, std::vector<Mesh>& meshes, cons
 
 			if (node.has_mesh_gpu_instancing)
 			{
-				mesh->scene = 0; // TODO: we need to assign scene index since instances are attached to a scene; for now we assume 0
+				mesh->scene = 0; // we need to assign scene index since instances are attached to a scene; for now we assume 0
 				parseMeshInstancesGltf(mesh->instances, &node);
 			}
 			else
@@ -597,6 +597,8 @@ static cgltf_data* parseGltf(cgltf_data* data, cgltf_result result, std::vector<
 
 	if (requiresExtension(data, "KHR_mesh_quantization"))
 		fprintf(stderr, "Warning: file uses quantized geometry; repacking may result in increased quantization error\n");
+	if (requiresExtension(data, "EXT_mesh_gpu_instancing") && data->scenes_count > 1)
+		fprintf(stderr, "Warning: file uses instancing and has more than one scene; results may be incorrect\n");
 
 	std::vector<std::pair<size_t, size_t> > mesh_remap;
 


### PR DESCRIPTION
When -mi is not specified but the input scene has instancing extension,
we convert the instances to the internal world-space transform
representation, which can then be serialized using our existing code.

Note that instances are not attached to nodes in the internal
representation; animation and scene data is thus silently discarded for
now. This is not ideal but is not trivial to change as it would require
reworking other parts of the processing pipeline. This also means that
the relationship between named nodes and instances isn't preserved,
and instances for a given mesh are always concatenated - which is good
for efficiency (assuming per instance culling) but may restrict some
use cases.

Fixes #685.