### PR TITLE
gltfpack: Preserve mesh attributes if the texture exists with no image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,7 +84,7 @@ jobs:
     - name: test
       run: find glTF-Sample-Assets -name *.gltf -or -name *.glb | xargs -d '\n' ./gltfpack -cc -test
     - name: pack
-      run: find glTF-Sample-Assets -name *.gltf | grep -v 'glTF-Draco\|glTF-KTX' | xargs -d '\n' -I '{}' ./gltfpack -i '{}' -o '{}pack.gltf'
+      run: find glTF-Sample-Assets -name *.gltf | grep -v 'glTF-Draco\|DiffuseTransmissionPlant' | xargs -d '\n' -I '{}' ./gltfpack -i '{}' -o '{}pack.gltf'
     - name: validate
       run: |
         curl -sL $VALIDATOR | tar xJ

--- a/gltf/material.cpp
+++ b/gltf/material.cpp
@@ -457,14 +457,17 @@ static void analyzeMaterialTexture(const cgltf_texture_view& view, TextureKind k
 	mi.usesTextureTransform |= hasValidTransform(view);
 
 	if (view.texture)
+	{
 		textures[view.texture - data->textures].keep = true;
+
+		mi.textureSetMask |= 1u << view.texcoord;
+		mi.needsTangents |= (kind == TextureKind_Normal);
+	}
 
 	if (const cgltf_image* image = getTextureImage(view.texture))
 	{
 		ImageInfo& info = images[image - data->images];
 
-		mi.textureSetMask |= 1u << view.texcoord;
-		mi.needsTangents |= (kind == TextureKind_Normal);
 
 		if (info.kind == TextureKind_Generic)
 			info.kind = kind;


### PR DESCRIPTION
There are some cases when the texture refers to a NULL image, eg when an unknown image extension is used such as EXT_texture_webp. In this case we used to remove UV coordinates which triggered excessive validation errors; we now preserve UV coordinates even though the texture object is not fully serialized/processed.