### PR TITLE
gltfpack: Attach meshes directly to nodes when quantization is a no-op

### DIFF
--- a/gltf/gltfpack.cpp
+++ b/gltf/gltfpack.cpp
@@ -675,7 +675,7 @@ static void process(cgltf_data* data, const char* input_path, const char* output
 				assert(ni.keep);
 
 				// if we don't use position quantization, prefer attaching the mesh to its node directly
-				if (!ni.has_mesh && (!settings.quantize || settings.pos_float))
+				if (!ni.has_mesh && (!settings.quantize || settings.pos_float || (qp.offset[0] == 0.f && qp.offset[1] == 0.f && qp.offset[2] == 0 && qp.node_scale == 1.f)))
 				{
 					ni.has_mesh = true;
 					ni.mesh_index = mesh_offset;

--- a/gltf/gltfpack.h
+++ b/gltf/gltfpack.h
@@ -170,6 +170,8 @@ struct QuantizationPosition
 	float scale;
 	int bits;
 	bool normalized;
+
+	float node_scale; // computed from scale/bits/normalized
 };
 
 struct QuantizationTexture

--- a/gltf/stream.cpp
+++ b/gltf/stream.cpp
@@ -97,6 +97,8 @@ QuantizationPosition prepareQuantizationPosition(const std::vector<Mesh>& meshes
 		result.scale = std::max(b.max.f[0] - b.min.f[0], std::max(b.max.f[1] - b.min.f[1], b.max.f[2] - b.min.f[2]));
 	}
 
+	result.node_scale = result.scale / float((1 << result.bits) - 1) * (result.normalized ? 65535.f : 1.f);
+
 	return result;
 }
 


### PR DESCRIPTION
If the input model is already quantized with the same settings wrt
position encoding, then the computed quantization parameters result in a
no-op transform (offset 0, scale 1). However, repeat invocations of
gltfpack will each add one extra node with a no-op transform. With this
change, if we can afford to attach the mesh directly we will do so.

Note that in the future, we could also merge node transforms via the
hierarchy, but that should be a separate optional optimization as it can
interfere with application processing logic.