### PR TITLE
gltfpack: Update fast_obj to 1.3

### DIFF
--- a/gltf/parseobj.cpp
+++ b/gltf/parseobj.cpp
@@ -37,8 +37,8 @@ static void parseMaterialsObj(fastObjMesh* obj, cgltf_data* data)
 	{
 		fastObjMaterial& om = obj->materials[mi];
 
-		if (om.map_Kd.name && textureIndex(textures, om.map_Kd.name) < 0)
-			textures.push_back(om.map_Kd.name);
+		if (obj->textures[om.map_Kd].name && textureIndex(textures, obj->textures[om.map_Kd].name) < 0)
+			textures.push_back(obj->textures[om.map_Kd].name);
 	}
 
 	data->images = (cgltf_image*)calloc(textures.size(), sizeof(cgltf_image));
@@ -81,9 +81,9 @@ static void parseMaterialsObj(fastObjMesh* obj, cgltf_data* data)
 
 		gm.alpha_cutoff = 0.5f;
 
-		if (om.map_Kd.name)
+		if (obj->textures[om.map_Kd].name)
 		{
-			gm.pbr_metallic_roughness.base_color_texture.texture = &data->textures[textureIndex(textures, om.map_Kd.name)];
+			gm.pbr_metallic_roughness.base_color_texture.texture = &data->textures[textureIndex(textures, obj->textures[om.map_Kd].name)];
 			gm.pbr_metallic_roughness.base_color_texture.scale = 1.0f;
 
 			gm.alpha_mode = (om.illum == 4 || om.illum == 6 || om.illum == 7 || om.illum == 9) ? cgltf_alpha_mode_mask : cgltf_alpha_mode_opaque;
@@ -95,10 +95,10 @@ static void parseMaterialsObj(fastObjMesh* obj, cgltf_data* data)
 			gm.pbr_metallic_roughness.base_color_factor[2] = om.Kd[2];
 		}
 
-		if (om.map_d.name)
+		if (obj->textures[om.map_d].name)
 		{
-			if (om.map_Kd.name && strcmp(om.map_Kd.name, om.map_d.name) != 0)
-				fprintf(stderr, "Warning: material has different diffuse and alpha textures (Kd: %s, d: %s) and might not render correctly\n", om.map_Kd.name, om.map_d.name);
+			if (obj->textures[om.map_Kd].name && strcmp(obj->textures[om.map_Kd].name, obj->textures[om.map_d].name) != 0)
+				fprintf(stderr, "Warning: material has different diffuse and alpha textures (Kd: %s, d: %s) and might not render correctly\n", obj->textures[om.map_Kd].name, obj->textures[om.map_d].name);
 
 			gm.alpha_mode = cgltf_alpha_mode_blend;
 		}

--- a/gltf/parseobj.cpp
+++ b/gltf/parseobj.cpp
@@ -12,7 +12,7 @@ static void defaultFree(void*, void* p)
 	free(p);
 }
 
-static int textureIndex(const std::vector<std::string>& textures, const char* name)
+static int textureIndex(const std::vector<unsigned int>& textures, unsigned int name)
 {
 	for (size_t i = 0; i < textures.size(); ++i)
 		if (textures[i] == name)
@@ -31,14 +31,16 @@ static void fixupUri(char* uri)
 
 static void parseMaterialsObj(fastObjMesh* obj, cgltf_data* data)
 {
-	std::vector<std::string> textures;
+	// every texture in obj has a unique id (1+); we convert it to a 0-based index
+	// this effectively extracts only used textures out of the obj, as we don't remove unused textures later in the processing
+	std::vector<unsigned int> textures;
 
 	for (unsigned int mi = 0; mi < obj->material_count; ++mi)
 	{
 		fastObjMaterial& om = obj->materials[mi];
 
-		if (obj->textures[om.map_Kd].name && textureIndex(textures, obj->textures[om.map_Kd].name) < 0)
-			textures.push_back(obj->textures[om.map_Kd].name);
+		if (om.map_Kd && textureIndex(textures, om.map_Kd) < 0)
+			textures.push_back(om.map_Kd);
 	}
 
 	data->images = (cgltf_image*)calloc(textures.size(), sizeof(cgltf_image));
@@ -46,7 +48,8 @@ static void parseMaterialsObj(fastObjMesh* obj, cgltf_data* data)
 
 	for (size_t i = 0; i < textures.size(); ++i)
 	{
-		data->images[i].uri = strdup(textures[i].c_str());
+		unsigned int id = textures[i];
+		data->images[i].uri = strdup(obj->textures[id].name);
 		fixupUri(data->images[i].uri);
 	}
 
@@ -81,9 +84,9 @@ static void parseMaterialsObj(fastObjMesh* obj, cgltf_data* data)
 
 		gm.alpha_cutoff = 0.5f;
 
-		if (obj->textures[om.map_Kd].name)
+		if (om.map_Kd)
 		{
-			gm.pbr_metallic_roughness.base_color_texture.texture = &data->textures[textureIndex(textures, obj->textures[om.map_Kd].name)];
+			gm.pbr_metallic_roughness.base_color_texture.texture = &data->textures[textureIndex(textures, om.map_Kd)];
 			gm.pbr_metallic_roughness.base_color_texture.scale = 1.0f;
 
 			gm.alpha_mode = (om.illum == 4 || om.illum == 6 || om.illum == 7 || om.illum == 9) ? cgltf_alpha_mode_mask : cgltf_alpha_mode_opaque;
@@ -95,9 +98,9 @@ static void parseMaterialsObj(fastObjMesh* obj, cgltf_data* data)
 			gm.pbr_metallic_roughness.base_color_factor[2] = om.Kd[2];
 		}
 
-		if (obj->textures[om.map_d].name)
+		if (om.map_d)
 		{
-			if (obj->textures[om.map_Kd].name && strcmp(obj->textures[om.map_Kd].name, obj->textures[om.map_d].name) != 0)
+			if (om.map_Kd && strcmp(obj->textures[om.map_Kd].name, obj->textures[om.map_d].name) != 0)
 				fprintf(stderr, "Warning: material has different diffuse and alpha textures (Kd: %s, d: %s) and might not render correctly\n", obj->textures[om.map_Kd].name, obj->textures[om.map_d].name);
 
 			gm.alpha_mode = cgltf_alpha_mode_blend;


### PR DESCRIPTION
fast_obj 1.3 makes a change to internal data structures to use indexed
texture objects; as such the .obj material parsing code had to be reworked
to accommodate that.