### PR TITLE
Improve support for cluster simplification

### DIFF
--- a/demo/main.cpp
+++ b/demo/main.cpp
@@ -522,6 +522,8 @@ void simplifyPoints(const Mesh& mesh, float threshold = 0.2f)
 	double start = timestamp();
 
 	size_t target_vertex_count = size_t(mesh.vertices.size() * threshold);
+	if (target_vertex_count == 0)
+		return;
 
 	std::vector<unsigned int> indices(target_vertex_count);
 	indices.resize(meshopt_simplifyPoints(&indices[0], &mesh.vertices[0].px, mesh.vertices.size(), sizeof(Vertex), NULL, 0, 0, target_vertex_count));
@@ -1286,6 +1288,7 @@ void process(const char* path)
 	simplifySloppy(mesh);
 	simplifyComplete(mesh);
 	simplifyPoints(mesh);
+	simplifyClusters(mesh);
 
 	spatialSort(mesh);
 	spatialSortTriangles(mesh);

--- a/demo/main.cpp
+++ b/demo/main.cpp
@@ -670,7 +670,7 @@ void simplifyClusters(const Mesh& mesh, float threshold = 0.2f)
 		for (size_t j = 0; j < m.triangle_count * 3; ++j)
 			lod.push_back(meshlet_vertices[m.vertex_offset + meshlet_triangles[m.triangle_offset + j]]);
 
-		unsigned int options = meshopt_SimplifyLockBorder;
+		unsigned int options = meshopt_SimplifyLockBorder | meshopt_SimplifySparse;
 
 		size_t cluster_target = size_t(float(m.triangle_count) * threshold) * 3;
 		size_t cluster_size = meshopt_simplify(&lod[cluster_offset], &lod[cluster_offset], m.triangle_count * 3, &mesh.vertices[0].px, mesh.vertices.size(), sizeof(Vertex), cluster_target, threshold, options, 0);

--- a/demo/tests.cpp
+++ b/demo/tests.cpp
@@ -1188,15 +1188,15 @@ static void simplifyAttr()
 static void simplifyLockFlags()
 {
 	float vb[] = {
-	    0.000000f, 0.000000f, 0.000000f,
-	    0.000000f, 1.000000f, 0.000000f,
-	    0.000000f, 2.000000f, 0.000000f,
-	    1.000000f, 0.000000f, 0.000000f,
-	    1.000000f, 1.000000f, 0.000000f,
-	    1.000000f, 2.000000f, 0.000000f,
-	    2.000000f, 0.000000f, 0.000000f,
-	    2.000000f, 1.000000f, 0.000000f,
-	    2.000000f, 2.000000f, 0.000000f, // clang-format :-/
+	    0, 0, 0,
+	    0, 1, 0,
+	    0, 2, 0,
+	    1, 0, 0,
+	    1, 1, 0,
+	    1, 2, 0,
+	    2, 0, 0,
+	    2, 1, 0,
+	    2, 2, 0, // clang-format :-/
 	};
 
 	unsigned char lock[9] = {
@@ -1231,6 +1231,40 @@ static void simplifyLockFlags()
 
 	assert(meshopt_simplifyWithAttributes(ib, ib, 24, vb, 9, 12, NULL, 0, NULL, 0, lock, 3, 1e-3f, 0) == 18);
 	assert(memcmp(ib, expected, sizeof(expected)) == 0);
+}
+
+static void simplifyErrorAbsolute()
+{
+	float vb[] = {
+	    0, 0, 0,
+	    0, 1, 0,
+	    0, 2, 0,
+	    1, 0, 0,
+	    1, 1, 1,
+	    1, 2, 0,
+	    2, 0, 0,
+	    2, 1, 0,
+	    2, 2, 0, // clang-format :-/
+	};
+
+	// 0 1 2
+	// 3 4 5
+	// 6 7 8
+
+	unsigned int ib[] = {
+	    0, 1, 3,
+	    3, 1, 4,
+	    1, 2, 4,
+	    4, 2, 5,
+	    3, 4, 6,
+	    6, 4, 7,
+	    4, 5, 7,
+	    7, 5, 8, // clang-format :-/
+	};
+
+	float error = 0.f;
+	assert(meshopt_simplify(ib, ib, 24, vb, 9, 12, 18, 2.f, meshopt_SimplifyLockBorder | meshopt_SimplifyErrorAbsolute, &error) == 18);
+	assert(fabsf(error - 0.85f) < 0.01f);
 }
 
 static void adjacency()
@@ -1448,6 +1482,7 @@ void runTests()
 	simplifyLockBorder();
 	simplifyAttr();
 	simplifyLockFlags();
+	simplifyErrorAbsolute();
 
 	adjacency();
 	tessellation();

--- a/js/meshopt_simplifier.js
+++ b/js/meshopt_simplifier.js
@@ -155,6 +155,8 @@ var MeshoptSimplifier = (function() {
 
 	var simplifyOptions = {
 		LockBorder: 1,
+		Sparse: 2,
+		ErrorAbsolute: 4,
 	};
 
 	return {

--- a/js/meshopt_simplifier.module.d.ts
+++ b/js/meshopt_simplifier.module.d.ts
@@ -1,6 +1,6 @@
 // This file is part of meshoptimizer library and is distributed under the terms of MIT License.
 // Copyright (C) 2016-2024, by Arseny Kapoulkine (arseny.kapoulkine@gmail.com)
-export type Flags = "LockBorder";
+export type Flags = "LockBorder" | "Sparse" | "ErrorAbsolute";
 
 export const MeshoptSimplifier: {
     supported: boolean;

--- a/js/meshopt_simplifier.module.js
+++ b/js/meshopt_simplifier.module.js
@@ -154,6 +154,8 @@ var MeshoptSimplifier = (function() {
 
 	var simplifyOptions = {
 		LockBorder: 1,
+		Sparse: 2,
+		ErrorAbsolute: 4,
 	};
 
 	return {

--- a/src/meshoptimizer.h
+++ b/src/meshoptimizer.h
@@ -330,6 +330,8 @@ enum
 {
     /* Do not move vertices that are located on the topological border (vertices on triangle edges that don't have a paired triangle). Useful for simplifying portions of the larger mesh. */
     meshopt_SimplifyLockBorder = 1 << 0,
+    /* Improve simplification performance assuming input indices are a sparse subset of the mesh. Note that error becomes relative to subset extents. */
+    meshopt_SimplifySparse = 1 << 1,
 };
 
 /**

--- a/src/meshoptimizer.h
+++ b/src/meshoptimizer.h
@@ -332,6 +332,8 @@ enum
     meshopt_SimplifyLockBorder = 1 << 0,
     /* Improve simplification performance assuming input indices are a sparse subset of the mesh. Note that error becomes relative to subset extents. */
     meshopt_SimplifySparse = 1 << 1,
+    /* Treat error limit and resulting error as absolute instead of relative to mesh extents. */
+    meshopt_SimplifyErrorAbsolute = 1 << 2,
 };
 
 /**

--- a/src/simplifier.cpp
+++ b/src/simplifier.cpp
@@ -442,7 +442,7 @@ static float rescalePositions(Vector3* result, const float* vertex_positions_dat
 
 	for (size_t i = 0; i < vertex_count; ++i)
 	{
-		unsigned int ri = sparse_remap ? sparse_remap[i] : i;
+		unsigned int ri = sparse_remap ? sparse_remap[i] : unsigned(i);
 		const float* v = vertex_positions_data + ri * vertex_stride_float;
 
 		if (result)

--- a/src/simplifier.cpp
+++ b/src/simplifier.cpp
@@ -223,27 +223,35 @@ static unsigned int* buildSparseRemap(unsigned int* indices, size_t index_count,
 		filter[indices[i]] = 1;
 	}
 
-	unsigned int* revremap = allocator.allocate<unsigned int>(vertex_count);
-
 	unsigned int* remap = allocator.allocate<unsigned int>(unique);
 	size_t offset = 0;
+
+	// temporary map dense => sparse; we allocate it last so that we can deallocate it
+	unsigned int* revremap = allocator.allocate<unsigned int>(vertex_count);
+
 	for (size_t i = 0; i < index_count; ++i)
 	{
-		if (filter[indices[i]] == 1)
+		unsigned int index = indices[i];
+
+		if (filter[index] == 1)
 		{
 			remap[offset] = indices[i];
-			filter[indices[i]] = 0;
-			revremap[indices[i]] = unsigned(offset);
+			revremap[index] = unsigned(offset);
 			indices[i] = unsigned(offset);
+			filter[index] = 0;
 			offset++;
 		}
 		else
 		{
-			indices[i] = revremap[indices[i]];
+			indices[i] = revremap[index];
 		}
 	}
 
+	allocator.deallocate(revremap);
+
+	assert(offset == unique);
 	*out_vertex_count = unique;
+
 	return remap;
 }
 

--- a/src/simplifier.cpp
+++ b/src/simplifier.cpp
@@ -307,7 +307,7 @@ static bool hasEdge(const EdgeAdjacency& adjacency, unsigned int a, unsigned int
 	return false;
 }
 
-static void classifyVertices(unsigned char* result, unsigned int* loop, unsigned int* loopback, size_t vertex_count, const EdgeAdjacency& adjacency, const unsigned int* remap, const unsigned int* wedge, const unsigned char* vertex_lock, unsigned int options)
+static void classifyVertices(unsigned char* result, unsigned int* loop, unsigned int* loopback, size_t vertex_count, const EdgeAdjacency& adjacency, const unsigned int* remap, const unsigned int* wedge, const unsigned char* vertex_lock, const unsigned int* sparse_remap, unsigned int options)
 {
 	memset(loop, -1, vertex_count * sizeof(unsigned int));
 	memset(loopback, -1, vertex_count * sizeof(unsigned int));
@@ -353,7 +353,7 @@ static void classifyVertices(unsigned char* result, unsigned int* loop, unsigned
 	{
 		if (remap[i] == i)
 		{
-			if (vertex_lock && vertex_lock[i])
+			if (vertex_lock && vertex_lock[sparse_remap ? sparse_remap[i] : i])
 			{
 				// vertex is explicitly locked
 				result[i] = Kind_Locked;
@@ -1570,7 +1570,7 @@ size_t meshopt_simplifyEdge(unsigned int* destination, const unsigned int* indic
 	unsigned char* vertex_kind = allocator.allocate<unsigned char>(vertex_count);
 	unsigned int* loop = allocator.allocate<unsigned int>(vertex_count);
 	unsigned int* loopback = allocator.allocate<unsigned int>(vertex_count);
-	classifyVertices(vertex_kind, loop, loopback, vertex_count, adjacency, remap, wedge, vertex_lock, options);
+	classifyVertices(vertex_kind, loop, loopback, vertex_count, adjacency, remap, wedge, vertex_lock, sparse_remap, options);
 
 #if TRACE
 	size_t unique_positions = 0;

--- a/src/simplifier.cpp
+++ b/src/simplifier.cpp
@@ -111,10 +111,12 @@ struct PositionHasher
 {
 	const float* vertex_positions;
 	size_t vertex_stride_float;
+	const unsigned int* sparse_remap;
 
 	size_t hash(unsigned int index) const
 	{
-		const unsigned int* key = reinterpret_cast<const unsigned int*>(vertex_positions + index * vertex_stride_float);
+		unsigned int ri = sparse_remap ? sparse_remap[index] : index;
+		const unsigned int* key = reinterpret_cast<const unsigned int*>(vertex_positions + ri * vertex_stride_float);
 
 		// scramble bits to make sure that integer coordinates have entropy in lower bits
 		unsigned int x = key[0] ^ (key[0] >> 17);
@@ -127,7 +129,10 @@ struct PositionHasher
 
 	bool equal(unsigned int lhs, unsigned int rhs) const
 	{
-		return memcmp(vertex_positions + lhs * vertex_stride_float, vertex_positions + rhs * vertex_stride_float, sizeof(float) * 3) == 0;
+		unsigned int li = sparse_remap ? sparse_remap[lhs] : lhs;
+		unsigned int ri = sparse_remap ? sparse_remap[rhs] : rhs;
+
+		return memcmp(vertex_positions + li * vertex_stride_float, vertex_positions + ri * vertex_stride_float, sizeof(float) * 3) == 0;
 	}
 };
 
@@ -167,9 +172,9 @@ static T* hashLookup2(T* table, size_t buckets, const Hash& hash, const T& key, 
 	return NULL;
 }
 
-static void buildPositionRemap(unsigned int* remap, unsigned int* wedge, const float* vertex_positions_data, size_t vertex_count, size_t vertex_positions_stride, meshopt_Allocator& allocator)
+static void buildPositionRemap(unsigned int* remap, unsigned int* wedge, const float* vertex_positions_data, size_t vertex_count, size_t vertex_positions_stride, const unsigned int* sparse_remap, meshopt_Allocator& allocator)
 {
-	PositionHasher hasher = {vertex_positions_data, vertex_positions_stride / sizeof(float)};
+	PositionHasher hasher = {vertex_positions_data, vertex_positions_stride / sizeof(float), sparse_remap};
 
 	size_t table_size = hashBuckets2(vertex_count);
 	unsigned int* table = allocator.allocate<unsigned int>(table_size);
@@ -203,6 +208,43 @@ static void buildPositionRemap(unsigned int* remap, unsigned int* wedge, const f
 		}
 
 	allocator.deallocate(table);
+}
+
+static unsigned int* buildSparseRemap(unsigned int* indices, size_t index_count, size_t vertex_count, size_t* out_vertex_count, meshopt_Allocator& allocator)
+{
+	unsigned char* filter = allocator.allocate<unsigned char>(vertex_count);
+	memset(filter, 0, vertex_count);
+
+	size_t unique = 0;
+	for (size_t i = 0; i < index_count; ++i)
+	{
+		assert(indices[i] < vertex_count);
+		unique += filter[indices[i]] == 0;
+		filter[indices[i]] = 1;
+	}
+
+	unsigned int* revremap = allocator.allocate<unsigned int>(vertex_count);
+
+	unsigned int* remap = allocator.allocate<unsigned int>(unique);
+	size_t offset = 0;
+	for (size_t i = 0; i < index_count; ++i)
+	{
+		if (filter[indices[i]] == 1)
+		{
+			remap[offset] = indices[i];
+			filter[indices[i]] = 0;
+			revremap[indices[i]] = unsigned(offset);
+			indices[i] = unsigned(offset);
+			offset++;
+		}
+		else
+		{
+			indices[i] = revremap[indices[i]];
+		}
+	}
+
+	*out_vertex_count = unique;
+	return remap;
 }
 
 enum VertexKind
@@ -383,7 +425,7 @@ struct Vector3
 	float x, y, z;
 };
 
-static float rescalePositions(Vector3* result, const float* vertex_positions_data, size_t vertex_count, size_t vertex_positions_stride)
+static float rescalePositions(Vector3* result, const float* vertex_positions_data, size_t vertex_count, size_t vertex_positions_stride, const unsigned int* sparse_remap = NULL)
 {
 	size_t vertex_stride_float = vertex_positions_stride / sizeof(float);
 
@@ -392,7 +434,8 @@ static float rescalePositions(Vector3* result, const float* vertex_positions_dat
 
 	for (size_t i = 0; i < vertex_count; ++i)
 	{
-		const float* v = vertex_positions_data + i * vertex_stride_float;
+		unsigned int ri = sparse_remap ? sparse_remap[i] : i;
+		const float* v = vertex_positions_data + ri * vertex_stride_float;
 
 		if (result)
 		{
@@ -431,15 +474,17 @@ static float rescalePositions(Vector3* result, const float* vertex_positions_dat
 	return extent;
 }
 
-static void rescaleAttributes(float* result, const float* vertex_attributes_data, size_t vertex_count, size_t vertex_attributes_stride, const float* attribute_weights, size_t attribute_count)
+static void rescaleAttributes(float* result, const float* vertex_attributes_data, size_t vertex_count, size_t vertex_attributes_stride, const float* attribute_weights, size_t attribute_count, const unsigned int* sparse_remap)
 {
 	size_t vertex_attributes_stride_float = vertex_attributes_stride / sizeof(float);
 
 	for (size_t i = 0; i < vertex_count; ++i)
 	{
+		unsigned int ri = sparse_remap ? sparse_remap[i] : unsigned(i);
+
 		for (size_t k = 0; k < attribute_count; ++k)
 		{
-			float a = vertex_attributes_data[i * vertex_attributes_stride_float + k];
+			float a = vertex_attributes_data[ri * vertex_attributes_stride_float + k];
 
 			result[i * attribute_count + k] = a * attribute_weights[k];
 		}
@@ -1481,7 +1526,7 @@ size_t meshopt_simplifyEdge(unsigned int* destination, const unsigned int* indic
 	assert(vertex_positions_stride >= 12 && vertex_positions_stride <= 256);
 	assert(vertex_positions_stride % sizeof(float) == 0);
 	assert(target_index_count <= index_count);
-	assert((options & ~(meshopt_SimplifyLockBorder)) == 0);
+	assert((options & ~(meshopt_SimplifyLockBorder | meshopt_SimplifySparse)) == 0);
 	assert(vertex_attributes_stride >= attribute_count * sizeof(float) && vertex_attributes_stride <= 256);
 	assert(vertex_attributes_stride % sizeof(float) == 0);
 	assert(attribute_count <= kMaxAttributes);
@@ -1489,16 +1534,24 @@ size_t meshopt_simplifyEdge(unsigned int* destination, const unsigned int* indic
 	meshopt_Allocator allocator;
 
 	unsigned int* result = destination;
+	if (result != indices)
+		memcpy(result, indices, index_count * sizeof(unsigned int));
+
+	// build an index remap and update indices/vertex_count to minimize the subsequent work
+	// note: as a consequence, errors will be computed relative to the subset extent
+	unsigned int* sparse_remap = NULL;
+	if (options & meshopt_SimplifySparse)
+		sparse_remap = buildSparseRemap(result, index_count, vertex_count, &vertex_count, allocator);
 
 	// build adjacency information
 	EdgeAdjacency adjacency = {};
 	prepareEdgeAdjacency(adjacency, index_count, vertex_count, allocator);
-	updateEdgeAdjacency(adjacency, indices, index_count, vertex_count, NULL);
+	updateEdgeAdjacency(adjacency, result, index_count, vertex_count, NULL);
 
 	// build position remap that maps each vertex to the one with identical position
 	unsigned int* remap = allocator.allocate<unsigned int>(vertex_count);
 	unsigned int* wedge = allocator.allocate<unsigned int>(vertex_count);
-	buildPositionRemap(remap, wedge, vertex_positions_data, vertex_count, vertex_positions_stride, allocator);
+	buildPositionRemap(remap, wedge, vertex_positions_data, vertex_count, vertex_positions_stride, sparse_remap, allocator);
 
 	// classify vertices; vertex kind determines collapse rules, see kCanCollapse
 	unsigned char* vertex_kind = allocator.allocate<unsigned char>(vertex_count);
@@ -1522,14 +1575,14 @@ size_t meshopt_simplifyEdge(unsigned int* destination, const unsigned int* indic
 #endif
 
 	Vector3* vertex_positions = allocator.allocate<Vector3>(vertex_count);
-	rescalePositions(vertex_positions, vertex_positions_data, vertex_count, vertex_positions_stride);
+	rescalePositions(vertex_positions, vertex_positions_data, vertex_count, vertex_positions_stride, sparse_remap);
 
 	float* vertex_attributes = NULL;
 
 	if (attribute_count)
 	{
 		vertex_attributes = allocator.allocate<float>(vertex_count * attribute_count);
-		rescaleAttributes(vertex_attributes, vertex_attributes_data, vertex_count, vertex_attributes_stride, attribute_weights, attribute_count);
+		rescaleAttributes(vertex_attributes, vertex_attributes_data, vertex_count, vertex_attributes_stride, attribute_weights, attribute_count, sparse_remap);
 	}
 
 	Quadric* vertex_quadrics = allocator.allocate<Quadric>(vertex_count);
@@ -1547,14 +1600,11 @@ size_t meshopt_simplifyEdge(unsigned int* destination, const unsigned int* indic
 		memset(attribute_gradients, 0, vertex_count * attribute_count * sizeof(QuadricGrad));
 	}
 
-	fillFaceQuadrics(vertex_quadrics, indices, index_count, vertex_positions, remap);
-	fillEdgeQuadrics(vertex_quadrics, indices, index_count, vertex_positions, remap, vertex_kind, loop, loopback);
+	fillFaceQuadrics(vertex_quadrics, result, index_count, vertex_positions, remap);
+	fillEdgeQuadrics(vertex_quadrics, result, index_count, vertex_positions, remap, vertex_kind, loop, loopback);
 
 	if (attribute_count)
-		fillAttributeQuadrics(attribute_quadrics, attribute_gradients, indices, index_count, vertex_positions, vertex_attributes, attribute_count, remap);
-
-	if (result != indices)
-		memcpy(result, indices, index_count * sizeof(unsigned int));
+		fillAttributeQuadrics(attribute_quadrics, attribute_gradients, result, index_count, vertex_positions, vertex_attributes, attribute_count, remap);
 
 #if TRACE
 	size_t pass_count = 0;
@@ -1629,6 +1679,11 @@ size_t meshopt_simplifyEdge(unsigned int* destination, const unsigned int* indic
 	if (meshopt_simplifyDebugLoopBack)
 		memcpy(meshopt_simplifyDebugLoopBack, loopback, vertex_count * sizeof(unsigned int));
 #endif
+
+	// convert resulting indices back into the dense space of the larger mesh
+	if (sparse_remap)
+		for (size_t i = 0; i < result_count; ++i)
+			result[i] = sparse_remap[result[i]];
 
 	// result_error is quadratic; we need to remap it back to linear
 	if (out_result_error)


### PR DESCRIPTION
When simplifying a small subset of the larger mesh, all computations
that go over the entire vertex buffer become expensive; this adds up
even when done once, and especially when done for every pass. This
is a critical part of some workflows that combine clusterization and
simplification, notably Nanite-style virtual geometry renderers.

This change introduces a sparse simplification mode that instructs the
simplifier to optimize based on the assumption that the subset of the
mesh that is being simplified is small. In that case it's worth spending
extra time to convert indices into a small 0..U subrange, do all
internal processing assuming we are working with a small vertex/index
buffer, and remap the indices at the end. While this processing could be
done externally, that is less efficient as it requires constant copying
of position/attribute data; in constrast, we can do it fairly cheaply.

When using sparse simplification, the error is treated as relative to
the mesh subset. This is a performance requirement as computing the full
mesh extents is too expensive when the subset is small relative to the
mesh, but it means that it can be difficult to rely on exact error
metrics.

There are also cases in general, when not using sparse simplification,
when an absolute error is more convenient. These can be achieved right
now via `meshopt_simplifyScale` but that is an extra step that is not
always necessary.

The new features can be accessed by adding `meshopt_SimplifySparse` and
`meshopt_SimplifyErrorAbsolute` bit flags to simplification options.

As an example of a performance delta, the newly added `simplifyClusters`
demo call takes 17.7 seconds to simplify a 870K triangle mesh one cluster
at a time, with the new sparse mode it takes ~150 msec (100x faster).