### PR TITLE
Large perf improvement

### DIFF
--- a/src/simplifier.cpp
+++ b/src/simplifier.cpp
@@ -1011,9 +1011,10 @@ static size_t pickEdgeCollapses(Collapse* collapses, size_t collapse_capacity, c
 
 static void rankEdgeCollapses(Collapse* collapses, size_t collapse_count, const Vector3* vertex_positions, const float* vertex_attributes, const Quadric* vertex_quadrics, const Quadric* attribute_quadrics, const QuadricGrad* attribute_gradients, size_t attribute_count, const unsigned int* remap)
 {
+	Collapse& c = collapses[0];
 	for (size_t i = 0; i < collapse_count; ++i)
 	{
-		Collapse& c = collapses[i];
+		c = collapses[i];
 
 		unsigned int i0 = c.v0;
 		unsigned int i1 = c.v1;


### PR DESCRIPTION
I was working in Godots main branch, trying to improve load times and made a ton of changes to this file. I ultimately found that this one small change accounted for 90% or more of my total improvements. In godot, loading a ~34 MB glb file went from 18 seconds to 4.9 seconds.