### PR TITLE
Update CONTRIBUTING.md with contributing agreement

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,3 +52,9 @@ Changes to documentation are always welcome and should use issues/pull requests 
 ## Sensitive communication
 
 If you prefer to not disclose the issues or information relevant to the issue such as reproduction case to the public, you can always contact the author via e-mail (arseny.kapoulkine@gmail.com).
+
+## Contributor agreement
+
+Any code you submit will become part of the repository and be distributed under the [meshoptimizer license](https://github.com/zeux/meshoptimizer/blob/master/LICENSE.md). By submitting code to the project you agree that the code is your work and that you can give it to the project.
+
+You also agree by submitting your code that you grant all transferrable rights to the code to the project maintainer, including for example re-licensing the code, modifying the code, and distributing it in source or binary forms. Specifically, this includes a requirement that you assign copyright to the project maintainer.


### PR DESCRIPTION
Add a section to contributing guide regarding the agreement to distribute the code under the terms of MIT license and transfer various rights to the project maintainer.

Prior art (using the same language):

- https://github.com/baldurk/renderdoc/blob/v1.x/docs/CONTRIBUTING.md#copyright--contributor-license-agreement
- https://github.com/ocornut/imgui/blob/master/docs/CONTRIBUTING.md#copyright--contributor-license-agreement

This change naturally does not retroactively affect existing contributions (although the first paragraph is partially established by [GitHub Terms of Service](https://docs.github.com/en/site-policy/github-terms/github-terms-of-service#6-contributions-under-repository-license)); the vast majority of the code is written by the project author anyway so this should not significantly affect future development.

There are no future plans to relicense the project or do anything else that affects the users of the project in any way. This change, however, sets the project up for consistent ownership and allows companies to sponsor development of the project via contracts without the contributed code being owned by the sponsoring entity.