### PR TITLE
simplify: Improve attribute metric computation

### DIFF
--- a/demo/main.cpp
+++ b/demo/main.cpp
@@ -474,7 +474,7 @@ void simplifyAttr(const Mesh& mesh, float threshold = 0.2f)
 	float target_error = 1e-2f;
 	float result_error = 0;
 
-	const float nrm_weight = 0.01f;
+	const float nrm_weight = 0.5f;
 	const float attr_weights[3] = {nrm_weight, nrm_weight, nrm_weight};
 
 	lod.indices.resize(mesh.indices.size()); // note: simplify needs space for index_count elements in the destination array, not target_index_count

--- a/demo/simplify.html
+++ b/demo/simplify.html
@@ -65,8 +65,8 @@
 				lockBorder: false,
 				useAttributes: false,
 				errorThresholdLog10: 1,
-				normalWeight: 0.01,
-				colorWeight: 0.01,
+				normalWeight: 0.5,
+				colorWeight: 1.0,
 
 				loadFile: function () {
 					var input = document.createElement('input');
@@ -96,8 +96,8 @@
 			guiSimplify.add(settings, 'lockBorder').onChange(simplify);
 			guiSimplify.add(settings, 'errorThresholdLog10', 0, 3, 0.1).onChange(simplify);
 			guiSimplify.add(settings, 'useAttributes').onChange(simplify);
-			guiSimplify.add(settings, 'normalWeight', 0, 0.1, 0.001).onChange(simplify);
-			guiSimplify.add(settings, 'colorWeight', 0, 0.1, 0.001).onChange(simplify);
+			guiSimplify.add(settings, 'normalWeight', 0, 2, 0.01).onChange(simplify);
+			guiSimplify.add(settings, 'colorWeight', 0, 2, 0.01).onChange(simplify);
 
 			var guiLoad = gui.addFolder('Load');
 			guiLoad.add(settings, 'loadFile');
@@ -175,7 +175,7 @@
 
 				console.timeEnd('simplify');
 
-				console.log('simplified to', res[0].length / 3);
+				console.log('simplified to', res[0].length / 3, 'with error', res[1]);
 
 				geo.index.array = res[0];
 				geo.index.count = res[0].length;

--- a/demo/tests.cpp
+++ b/demo/tests.cpp
@@ -1260,7 +1260,7 @@ static void simplifySparse()
 	};
 
 	float aw[] = {
-	    0.2f};
+	    0.5f};
 
 	unsigned char lock[9] = {
 	    8, 1, 8,

--- a/src/meshoptimizer.h
+++ b/src/meshoptimizer.h
@@ -364,7 +364,6 @@ MESHOPTIMIZER_API size_t meshopt_simplify(unsigned int* destination, const unsig
  * attribute_weights should have attribute_count floats in total; the weights determine relative priority of attributes between each other and wrt position. The recommended weight range is [1e-3..1e-1], assuming attribute data is in [0..1] range.
  * attribute_count must be <= 32
  * vertex_lock can be NULL; when it's not NULL, it should have a value for each vertex; 1 denotes vertices that can't be moved
- * TODO target_error/result_error currently use combined distance+attribute error; this may change in the future
  */
 MESHOPTIMIZER_EXPERIMENTAL size_t meshopt_simplifyWithAttributes(unsigned int* destination, const unsigned int* indices, size_t index_count, const float* vertex_positions, size_t vertex_count, size_t vertex_positions_stride, const float* vertex_attributes, size_t vertex_attributes_stride, const float* attribute_weights, size_t attribute_count, const unsigned char* vertex_lock, size_t target_index_count, float target_error, unsigned int options, float* result_error);
 

--- a/src/simplifier.cpp
+++ b/src/simplifier.cpp
@@ -598,7 +598,7 @@ static void quadricAdd(QuadricGrad* G, const QuadricGrad* R, size_t attribute_co
 	}
 }
 
-static float quadricError(const Quadric& Q, const Vector3& v)
+static float quadricEval(const Quadric& Q, const Vector3& v)
 {
 	float rx = Q.b0;
 	float ry = Q.b1;
@@ -621,6 +621,12 @@ static float quadricError(const Quadric& Q, const Vector3& v)
 	r += ry * v.y;
 	r += rz * v.z;
 
+	return r;
+}
+
+static float quadricError(const Quadric& Q, const Vector3& v)
+{
+	float r = quadricEval(Q, v);
 	float s = Q.w == 0.f ? 0.f : 1.f / Q.w;
 
 	return fabsf(r) * s;
@@ -628,26 +634,7 @@ static float quadricError(const Quadric& Q, const Vector3& v)
 
 static float quadricError(const Quadric& Q, const QuadricGrad* G, size_t attribute_count, const Vector3& v, const float* va)
 {
-	float rx = Q.b0;
-	float ry = Q.b1;
-	float rz = Q.b2;
-
-	rx += Q.a10 * v.y;
-	ry += Q.a21 * v.z;
-	rz += Q.a20 * v.x;
-
-	rx *= 2;
-	ry *= 2;
-	rz *= 2;
-
-	rx += Q.a00 * v.x;
-	ry += Q.a11 * v.y;
-	rz += Q.a22 * v.z;
-
-	float r = Q.c;
-	r += rx * v.x;
-	r += ry * v.y;
-	r += rz * v.z;
+	float r = quadricEval(Q, v);
 
 	// see quadricFromAttributes for general derivation; here we need to add the parts of (eval(pos) - attr)^2 that depend on attr
 	for (size_t k = 0; k < attribute_count; ++k)

--- a/src/simplifier.cpp
+++ b/src/simplifier.cpp
@@ -741,6 +741,7 @@ static void quadricFromAttributes(Quadric& Q, QuadricGrad* G, const Vector3& p0,
 	// w = (d00 * d21 - d01 * d20) / denom
 	// u = 1 - v - w
 	// here v0, v1 are triangle edge vectors, v2 is a vector from point to triangle corner, and dij = dot(vi, vj)
+	// note: v2 and d20/d21 can not be evaluated here as v2 is effectively an unknown variable; we need these only as variables for derivation of gradients
 	const Vector3& v0 = p10;
 	const Vector3& v1 = p20;
 	float d00 = v0.x * v0.x + v0.y * v0.y + v0.z * v0.z;
@@ -750,7 +751,7 @@ static void quadricFromAttributes(Quadric& Q, QuadricGrad* G, const Vector3& p0,
 	float denomr = denom == 0 ? 0.f : 1.f / denom;
 
 	// precompute gradient factors
-	// these are derived by directly computing derivative of eval(pos) = a0 * u + a1 * v + a2 * w and factoring out common factors that are shared between attributes
+	// these are derived by directly computing derivative of eval(pos) = a0 * u + a1 * v + a2 * w and factoring out expressions that are shared between attributes
 	float gx1 = (d11 * v0.x - d01 * v1.x) * denomr;
 	float gx2 = (d00 * v1.x - d01 * v0.x) * denomr;
 	float gy1 = (d11 * v0.y - d01 * v1.y) * denomr;
@@ -775,6 +776,7 @@ static void quadricFromAttributes(Quadric& Q, QuadricGrad* G, const Vector3& p0,
 
 		// quadric encodes (eval(pos)-attr)^2; this means that the resulting expansion needs to compute, for example, pos.x * pos.y * K
 		// since quadrics already encode factors for pos.x * pos.y, we can accumulate almost everything in basic quadric fields
+		// note: for simplicity we scale all factors by weight here instead of outside the loop
 		Q.a00 += w * (gx * gx);
 		Q.a11 += w * (gy * gy);
 		Q.a22 += w * (gz * gz);

--- a/src/simplifier.cpp
+++ b/src/simplifier.cpp
@@ -729,9 +729,11 @@ static void quadricFromAttributes(Quadric& Q, QuadricGrad* G, const Vector3& p0,
 	Vector3 p10 = {p1.x - p0.x, p1.y - p0.y, p1.z - p0.z};
 	Vector3 p20 = {p2.x - p0.x, p2.y - p0.y, p2.z - p0.z};
 
-	// weight is scaled linearly with edge length
+	// normal = cross(p1 - p0, p2 - p0)
 	Vector3 normal = {p10.y * p20.z - p10.z * p20.y, p10.z * p20.x - p10.x * p20.z, p10.x * p20.y - p10.y * p20.x};
-	float area = sqrtf(normal.x * normal.x + normal.y * normal.y + normal.z * normal.z);
+	float area = sqrtf(normal.x * normal.x + normal.y * normal.y + normal.z * normal.z) * 0.5f;
+
+	// weight is scaled linearly with edge length
 	float w = sqrtf(area); // TODO this needs more experimentation
 
 	// we compute gradients using barycentric coordinates; barycentric coordinates can be computed as follows:

--- a/src/simplifier.cpp
+++ b/src/simplifier.cpp
@@ -642,8 +642,7 @@ static float quadricError(const Quadric& Q, const QuadricGrad* G, size_t attribu
 		float a = va[k];
 		float g = v.x * G[k].gx + v.y * G[k].gy + v.z * G[k].gz + G[k].gw;
 
-		r += a * a * Q.w;
-		r -= 2 * a * g;
+		r += a * (a * Q.w - 2 * g);
 	}
 
 	// TODO: weight normalization is breaking attribute error somehow

--- a/src/simplifier.cpp
+++ b/src/simplifier.cpp
@@ -645,10 +645,8 @@ static float quadricError(const Quadric& Q, const QuadricGrad* G, size_t attribu
 		r += a * (a * Q.w - 2 * g);
 	}
 
-	// TODO: weight normalization is breaking attribute error somehow
-	float s = 1; // Q.w == 0.f ? 0.f : 1.f / Q.w;
-
-	return fabsf(r) * s;
+	// note: unlike position error, we do not normalize by Q.w to retain edge scaling as described in quadricFromAttributes
+	return fabsf(r);
 }
 
 static void quadricFromPlane(Quadric& Q, float a, float b, float c, float d, float w)
@@ -719,8 +717,10 @@ static void quadricFromAttributes(Quadric& Q, QuadricGrad* G, const Vector3& p0,
 	Vector3 normal = {p10.y * p20.z - p10.z * p20.y, p10.z * p20.x - p10.x * p20.z, p10.x * p20.y - p10.y * p20.x};
 	float area = sqrtf(normal.x * normal.x + normal.y * normal.y + normal.z * normal.z) * 0.5f;
 
-	// weight is scaled linearly with edge length
-	float w = sqrtf(area); // TODO this needs more experimentation
+	// quadric is weighted with the square of edge length (= area)
+	// this equalizes the units with the positional error (which, after normalization, is a square of distance)
+	// as a result, a change in weighted attribute of 1 along distance d is approximately equivalent to a change in position of d
+	float w = area;
 
 	// we compute gradients using barycentric coordinates; barycentric coordinates can be computed as follows:
 	// v = (d11 * d20 - d01 * d21) / denom


### PR DESCRIPTION
The goal of this set of changes is to bring the attribute metric closer to its ideal state by validating and refining the math and improving the weighting logic to make the error more composable and explainable.

The main user-visible change here is the switch to unnormalized area weighted quadrics; detailed reasoning is provided in 9efadb015bb3c9dcd1201771405bb81c8bfb6908 but the high level summary is that this makes the error closer to the ideal "distance traveled by the vertex times the attribute deviation" (squared) which results in a better match between (normalized) position and attribute metrics, making adding them more sensible, makes attribute weight tuning more intuitive and mesh scale-invariant, and makes the error limit and resulting error actually useful for LOD selection and tuning. This may not be the final form, as there are still issues with quadric accumulation with this (and previous!) metric, but this should be a better option overall.

> Curiously, this makes the attribute metric match the original Hoppe paper, although it's done for reasons that go beyond the scope of the paper, and the positional component remains different - which is crucial as that is what makes the combination more sensible.

Existing code that uses `meshopt_simplifyWithAttributes` with very small weights for unit-scaled attributes should be updated to use weights that are closer to 1; this change does that for a couple demo programs for consistency. Hopefully no more significant weight tuning will be necessary even if more metric updates were to follow. Based on extensive testing this seems to produce simplified meshes of comparable or slightly better quality but should make the results more coherent with a static set of weights.

As part of this change, the derivation and behavior of attribute metric was also fully validated vs original Hoppe paper (using re-derivation as well as numeric validation with the help of Eigen's matrix solvers); this code is not included in the PR, but notably this change also fixes area computation and improves precision of attribute error evaluation by reordering some computations. Other than the off-by-0.5 area and weighting issues, no mistakes have been found, but a couple tweaks were made for improved precision. The analytical formulation was found to be ~10x more precise and significantly faster (~4x in terms of overall simplification process, ~50x faster in terms of just the quadric computation) which is nice.

Finally, since with this change we should be closer to stabilizing `meshopt_simplifyWithAttributes` (although this likely will *not* happen in the next versioned release to allow room for interface changes), this change documents various advanced uses of simplification algorithms.

Contributes to #158.

*This contribution is sponsored by Valve.*