### PR TITLE
Add ES5 validation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,6 +68,12 @@ jobs:
       run: node js/meshopt_encoder.test.js
     - name: test simplifier
       run: node js/meshopt_simplifier.test.js
+    - name: check es5
+      run: |
+        npm install -g es-check
+        npx es-check es5 js/meshopt_decoder.js js/meshopt_encoder.js js/meshopt_simplifier.js
+        npx es-check --module es5 js/meshopt_decoder.module.js js/meshopt_encoder.module.js js/meshopt_simplifier.module.js
+        npx es-check es5 gltf/library.js
 
   gltfpack:
     runs-on: ubuntu-latest

--- a/.prettierrc
+++ b/.prettierrc
@@ -4,4 +4,5 @@
 	"semi": true,
 	"singleQuote": true,
 	"printWidth": 150,
+	"trailingComma": "es5",
 }

--- a/demo/index.html
+++ b/demo/index.html
@@ -105,7 +105,7 @@
 						}
 					},
 					onProgress,
-					onError,
+					onError
 				);
 
 				renderer = new THREE.WebGLRenderer();

--- a/demo/simplify.html
+++ b/demo/simplify.html
@@ -402,7 +402,7 @@
 						}
 					},
 					onProgress,
-					onError,
+					onError
 				);
 			}
 

--- a/gltf/library.js
+++ b/gltf/library.js
@@ -368,5 +368,5 @@ if (typeof window === 'undefined' && typeof process !== 'undefined' && process.r
 		root.gltfpack = factory();
 	}
 })(typeof self !== 'undefined' ? self : this, function () {
-	return { init, pack };
+	return { init: init, pack: pack };
 });

--- a/js/meshopt_simplifier.js
+++ b/js/meshopt_simplifier.js
@@ -110,7 +110,7 @@ var MeshoptSimplifier = (function () {
 		vertex_lock,
 		target_index_count,
 		target_error,
-		options,
+		options
 	) {
 		var sbrk = instance.exports.sbrk;
 		var te = sbrk(4);
@@ -143,7 +143,7 @@ var MeshoptSimplifier = (function () {
 			target_index_count,
 			target_error,
 			options,
-			te,
+			te
 		);
 		// heap may have grown
 		heap = new Uint8Array(instance.exports.memory.buffer);
@@ -173,7 +173,7 @@ var MeshoptSimplifier = (function () {
 		vertex_colors,
 		vertex_colors_stride,
 		color_weight,
-		target_vertex_count,
+		target_vertex_count
 	) {
 		var sbrk = instance.exports.sbrk;
 		var ti = sbrk(target_vertex_count * 4);
@@ -210,7 +210,7 @@ var MeshoptSimplifier = (function () {
 
 		compactMesh: function (indices) {
 			assert(
-				indices instanceof Uint32Array || indices instanceof Int32Array || indices instanceof Uint16Array || indices instanceof Int16Array,
+				indices instanceof Uint32Array || indices instanceof Int32Array || indices instanceof Uint16Array || indices instanceof Int16Array
 			);
 			assert(indices.length % 3 == 0);
 
@@ -220,7 +220,7 @@ var MeshoptSimplifier = (function () {
 
 		simplify: function (indices, vertex_positions, vertex_positions_stride, target_index_count, target_error, flags) {
 			assert(
-				indices instanceof Uint32Array || indices instanceof Int32Array || indices instanceof Uint16Array || indices instanceof Int16Array,
+				indices instanceof Uint32Array || indices instanceof Int32Array || indices instanceof Uint16Array || indices instanceof Int16Array
 			);
 			assert(indices.length % 3 == 0);
 			assert(vertex_positions instanceof Float32Array);
@@ -246,7 +246,7 @@ var MeshoptSimplifier = (function () {
 				vertex_positions_stride * 4,
 				target_index_count,
 				target_error,
-				options,
+				options
 			);
 			result[0] = indices instanceof Uint32Array ? result[0] : new indices.constructor(result[0]);
 
@@ -263,11 +263,11 @@ var MeshoptSimplifier = (function () {
 			vertex_lock,
 			target_index_count,
 			target_error,
-			flags,
+			flags
 		) {
 			assert(this.useExperimentalFeatures); // set useExperimentalFeatures to use this; note that this function is experimental and may change interface in a way that will require revising calling code
 			assert(
-				indices instanceof Uint32Array || indices instanceof Int32Array || indices instanceof Uint16Array || indices instanceof Int16Array,
+				indices instanceof Uint32Array || indices instanceof Int32Array || indices instanceof Uint16Array || indices instanceof Int16Array
 			);
 			assert(indices.length % 3 == 0);
 			assert(vertex_positions instanceof Float32Array);
@@ -307,7 +307,7 @@ var MeshoptSimplifier = (function () {
 				vertex_lock ? new Uint8Array(vertex_lock) : null,
 				target_index_count,
 				target_error,
-				options,
+				options
 			);
 			result[0] = indices instanceof Uint32Array ? result[0] : new indices.constructor(result[0]);
 
@@ -322,7 +322,7 @@ var MeshoptSimplifier = (function () {
 				instance.exports.meshopt_simplifyScale,
 				vertex_positions,
 				vertex_positions.length / vertex_positions_stride,
-				vertex_positions_stride * 4,
+				vertex_positions_stride * 4
 			);
 		},
 
@@ -345,7 +345,7 @@ var MeshoptSimplifier = (function () {
 					vertex_colors,
 					vertex_colors_stride * 4,
 					color_weight,
-					target_vertex_count,
+					target_vertex_count
 				);
 			} else {
 				return simplifyPoints(
@@ -356,7 +356,7 @@ var MeshoptSimplifier = (function () {
 					undefined,
 					0,
 					0,
-					target_vertex_count,
+					target_vertex_count
 				);
 			}
 		},

--- a/js/meshopt_simplifier.module.d.ts
+++ b/js/meshopt_simplifier.module.d.ts
@@ -16,7 +16,7 @@ export const MeshoptSimplifier: {
 		vertex_positions_stride: number,
 		target_index_count: number,
 		target_error: number,
-		flags?: Flags[],
+		flags?: Flags[]
 	) => [Uint32Array, number];
 
 	// Experimental; requires useExperimentalFeatures to be set to true
@@ -30,7 +30,7 @@ export const MeshoptSimplifier: {
 		vertex_lock: boolean[] | null,
 		target_index_count: number,
 		target_error: number,
-		flags?: Flags[],
+		flags?: Flags[]
 	) => [Uint32Array, number];
 
 	getScale: (vertex_positions: Float32Array, vertex_positions_stride: number) => number;
@@ -42,6 +42,6 @@ export const MeshoptSimplifier: {
 		target_vertex_count: number,
 		vertex_colors?: Float32Array,
 		vertex_colors_stride?: number,
-		color_weight?: number,
+		color_weight?: number
 	) => Uint32Array;
 };

--- a/js/meshopt_simplifier.module.js
+++ b/js/meshopt_simplifier.module.js
@@ -109,7 +109,7 @@ var MeshoptSimplifier = (function () {
 		vertex_lock,
 		target_index_count,
 		target_error,
-		options,
+		options
 	) {
 		var sbrk = instance.exports.sbrk;
 		var te = sbrk(4);
@@ -142,7 +142,7 @@ var MeshoptSimplifier = (function () {
 			target_index_count,
 			target_error,
 			options,
-			te,
+			te
 		);
 		// heap may have grown
 		heap = new Uint8Array(instance.exports.memory.buffer);
@@ -172,7 +172,7 @@ var MeshoptSimplifier = (function () {
 		vertex_colors,
 		vertex_colors_stride,
 		color_weight,
-		target_vertex_count,
+		target_vertex_count
 	) {
 		var sbrk = instance.exports.sbrk;
 		var ti = sbrk(target_vertex_count * 4);
@@ -209,7 +209,7 @@ var MeshoptSimplifier = (function () {
 
 		compactMesh: function (indices) {
 			assert(
-				indices instanceof Uint32Array || indices instanceof Int32Array || indices instanceof Uint16Array || indices instanceof Int16Array,
+				indices instanceof Uint32Array || indices instanceof Int32Array || indices instanceof Uint16Array || indices instanceof Int16Array
 			);
 			assert(indices.length % 3 == 0);
 
@@ -219,7 +219,7 @@ var MeshoptSimplifier = (function () {
 
 		simplify: function (indices, vertex_positions, vertex_positions_stride, target_index_count, target_error, flags) {
 			assert(
-				indices instanceof Uint32Array || indices instanceof Int32Array || indices instanceof Uint16Array || indices instanceof Int16Array,
+				indices instanceof Uint32Array || indices instanceof Int32Array || indices instanceof Uint16Array || indices instanceof Int16Array
 			);
 			assert(indices.length % 3 == 0);
 			assert(vertex_positions instanceof Float32Array);
@@ -245,7 +245,7 @@ var MeshoptSimplifier = (function () {
 				vertex_positions_stride * 4,
 				target_index_count,
 				target_error,
-				options,
+				options
 			);
 			result[0] = indices instanceof Uint32Array ? result[0] : new indices.constructor(result[0]);
 
@@ -262,11 +262,11 @@ var MeshoptSimplifier = (function () {
 			vertex_lock,
 			target_index_count,
 			target_error,
-			flags,
+			flags
 		) {
 			assert(this.useExperimentalFeatures); // set useExperimentalFeatures to use this; note that this function is experimental and may change interface in a way that will require revising calling code
 			assert(
-				indices instanceof Uint32Array || indices instanceof Int32Array || indices instanceof Uint16Array || indices instanceof Int16Array,
+				indices instanceof Uint32Array || indices instanceof Int32Array || indices instanceof Uint16Array || indices instanceof Int16Array
 			);
 			assert(indices.length % 3 == 0);
 			assert(vertex_positions instanceof Float32Array);
@@ -306,7 +306,7 @@ var MeshoptSimplifier = (function () {
 				vertex_lock ? new Uint8Array(vertex_lock) : null,
 				target_index_count,
 				target_error,
-				options,
+				options
 			);
 			result[0] = indices instanceof Uint32Array ? result[0] : new indices.constructor(result[0]);
 
@@ -321,7 +321,7 @@ var MeshoptSimplifier = (function () {
 				instance.exports.meshopt_simplifyScale,
 				vertex_positions,
 				vertex_positions.length / vertex_positions_stride,
-				vertex_positions_stride * 4,
+				vertex_positions_stride * 4
 			);
 		},
 
@@ -344,7 +344,7 @@ var MeshoptSimplifier = (function () {
 					vertex_colors,
 					vertex_colors_stride * 4,
 					color_weight,
-					target_vertex_count,
+					target_vertex_count
 				);
 			} else {
 				return simplifyPoints(
@@ -355,7 +355,7 @@ var MeshoptSimplifier = (function () {
 					undefined,
 					0,
 					0,
-					target_vertex_count,
+					target_vertex_count
 				);
 			}
 		},


### PR DESCRIPTION
This makes sure that the main library code is ES5 compatible and ES6 features aren't used accidentally.

As part of this, Prettier settings were changed to format code with ES5 compliant trailing commas; this was a regression that didn't make it into any versioned builds.