### PR TITLE
simplify: Separate attribute quadrics on attribute discontinuities

### DIFF
--- a/demo/tests.cpp
+++ b/demo/tests.cpp
@@ -1347,12 +1347,12 @@ static void simplifySeam()
 	    0, 1, 0, 1,
 	    0, 2, 0, 1,
 	    1, 0, 0, 0,
-	    1, 1, 1, 0,
-	    1, 1, 1, 1,
+	    1, 1, 0.3f, 0,
+	    1, 1, 0.3f, 1,
 	    1, 2, 0, 1,
 	    2, 0, 0, 0,
-	    2, 1, 0, 0,
-	    2, 1, 0, 1,
+	    2, 1, 0.1f, 0,
+	    2, 1, 0.1f, 1,
 	    2, 2, 0, 1,
 	    3, 0, 0, 0,
 	    3, 1, 0, 0,
@@ -1402,12 +1402,12 @@ static void simplifySeam()
 
 	assert(meshopt_simplify(res, ib, 36, vb, 16, 16, 18, 1.f, 0, &error) == 18);
 	assert(memcmp(res, expected, sizeof(expected)) == 0);
-	assert(fabsf(error - 0.22f) < 0.01f); // TODO: this is higher than normal due to border errors?
+	assert(fabsf(error - 0.04f) < 0.01f); // note: the error is not zero because there is a small difference in height between the seam vertices
 
 	float aw = 1;
 	assert(meshopt_simplifyWithAttributes(res, ib, 36, vb, 16, 16, vb + 3, 16, &aw, 1, NULL, 18, 2.f, 0, &error) == 18);
 	assert(memcmp(res, expected, sizeof(expected)) == 0);
-	assert(fabsf(error - 0.22f) < 0.01f); // note: this is the same error as above because the attribute is constant on either side of the seam
+	assert(fabsf(error - 0.04f) < 0.01f); // note: this is the same error as above because the attribute is constant on either side of the seam
 }
 
 static void adjacency()

--- a/demo/tests.cpp
+++ b/demo/tests.cpp
@@ -1338,6 +1338,78 @@ static void simplifyErrorAbsolute()
 	assert(fabsf(error - 0.85f) < 0.01f);
 }
 
+static void simplifySeam()
+{
+	// xyz+attr
+	float vb[] = {
+	    0, 0, 0, 0,
+	    0, 1, 0, 0,
+	    0, 1, 0, 1,
+	    0, 2, 0, 1,
+	    1, 0, 0, 0,
+	    1, 1, 1, 0,
+	    1, 1, 1, 1,
+	    1, 2, 0, 1,
+	    2, 0, 0, 0,
+	    2, 1, 0, 0,
+	    2, 1, 0, 1,
+	    2, 2, 0, 1,
+	    3, 0, 0, 0,
+	    3, 1, 0, 0,
+	    3, 1, 0, 1,
+	    3, 2, 0, 1, // clang-format :-/
+	};
+
+	// 0   1-2   3
+	// 4   5-6   7
+	// 8   9-10 11
+	// 12 13-14 15
+
+	unsigned int ib[] = {
+	    0, 1, 4,
+	    4, 1, 5,
+	    2, 3, 6,
+	    6, 3, 7,
+	    4, 5, 8,
+	    8, 5, 9,
+	    6, 7, 10,
+	    10, 7, 11,
+	    8, 9, 12,
+	    12, 9, 13,
+	    10, 11, 14,
+	    14, 11, 15, // clang-format :-/
+	};
+
+	// note: vertices 1-2 and 13-14 are classified as locked, because they are on a seam & a border
+	// since seam->locked collapses are restriced, we only get to 3 triangles on each side as the seam is simplified to 3 vertices
+
+	// so we get this structure initially, and then one of the internal seam vertices is collapsed to the other one:
+	// 0   1-2   3
+	//     5-6
+	//     9-10
+	// 12 13-14 15
+	unsigned int expected[] = {
+	    0, 1, 5,
+	    2, 3, 6,
+	    0, 5, 12,
+	    12, 5, 13,
+	    6, 3, 14,
+	    14, 3, 15, // clang-format :-/
+	};
+
+	unsigned int res[36];
+	float error = 0.f;
+
+	assert(meshopt_simplify(res, ib, 36, vb, 16, 16, 18, 1.f, 0, &error) == 18);
+	assert(memcmp(res, expected, sizeof(expected)) == 0);
+	assert(fabsf(error - 0.22f) < 0.01f); // TODO: this is higher than normal due to border errors?
+
+	float aw = 1;
+	assert(meshopt_simplifyWithAttributes(res, ib, 36, vb, 16, 16, vb + 3, 16, &aw, 1, NULL, 18, 2.f, 0, &error) == 18);
+	assert(memcmp(res, expected, sizeof(expected)) == 0);
+	assert(fabsf(error - 0.49f) < 0.01f); // TODO: this is higher than normal due to merged attributes?
+}
+
 static void adjacency()
 {
 	// 0 1/4
@@ -1556,6 +1628,7 @@ void runTests()
 	simplifyLockFlags();
 	simplifySparse();
 	simplifyErrorAbsolute();
+	simplifySeam();
 
 	adjacency();
 	tessellation();

--- a/demo/tests.cpp
+++ b/demo/tests.cpp
@@ -1407,7 +1407,7 @@ static void simplifySeam()
 	float aw = 1;
 	assert(meshopt_simplifyWithAttributes(res, ib, 36, vb, 16, 16, vb + 3, 16, &aw, 1, NULL, 18, 2.f, 0, &error) == 18);
 	assert(memcmp(res, expected, sizeof(expected)) == 0);
-	assert(fabsf(error - 0.49f) < 0.01f); // TODO: this is higher than normal due to merged attributes?
+	assert(fabsf(error - 0.22f) < 0.01f); // note: this is the same error as above because the attribute is constant on either side of the seam
 }
 
 static void adjacency()


### PR DESCRIPTION
Initial implementation of attribute metric used the same indexing that
we use for positional quadrics, where multiple vertices with the same
position are collapsed into a single element. This is correct and
optimal for positions, but results in problems for attributes when the
vertex is on a seam: two associated vertices carry very different
attributes, and evaluating any attribute against a vertex from an
opposite side of the seam results in a large error. This results in a
suboptimal collapse sequence and an artificially inflated resulting
error.

This change fixes this by preserving the original indexing for attribute
quadrics and carefully aggregating these during collapses. For simplicity,
and because it does not seem crucial for quality, we still approximate
an error for one edge collapse using only one side of the seam (this
distinction only matters for seam-seam edges).

Also includes improved complex vertex handling and much more detailed
trace logging which is helpful for debugging unit tests or very small
reproducers.

Contributes to #158.

*This contribution is sponsored by Valve.*