### PR TITLE
simplify: Minor improvements in quadricFromTriangleEdge

### DIFF
--- a/demo/tests.cpp
+++ b/demo/tests.cpp
@@ -1151,7 +1151,7 @@ static void simplifyAttr(bool skip_g)
 		{
 			vb[y * 3 + x][0] = float(x);
 			vb[y * 3 + x][1] = float(y);
-			vb[y * 3 + x][2] = 0.03f * x;
+			vb[y * 3 + x][2] = 0.03f * x + 0.03f * (y % 2);
 			vb[y * 3 + x][3] = r;
 			vb[y * 3 + x][4] = g;
 			vb[y * 3 + x][5] = b;
@@ -1173,12 +1173,20 @@ static void simplifyAttr(bool skip_g)
 		}
 	}
 
-	float attr_weights[3] = {0.01f, skip_g ? 0.f : 0.01f, 0.01f};
+	float attr_weights[3] = {0.5f, skip_g ? 0.f : 0.5f, 0.5f};
 
+	// *0  1   *2
+	//  3  4    5
+	//  6  7    8
+	// *9  10 *11
+	// *12 13 *14
+	//  15 16  17
+	//  18 19  20
+	// *21 22 *23
 	unsigned int expected[3][6] = {
-	    {0, 2, 9, 9, 2, 11},
+	    {0, 2, 11, 0, 11, 9},
 	    {9, 11, 12, 12, 11, 14},
-	    {12, 14, 21, 21, 14, 23},
+	    {12, 14, 23, 12, 23, 21},
 	};
 
 	assert(meshopt_simplifyWithAttributes(ib[0], ib[0], 7 * 2 * 6, vb[0], 8 * 3, 6 * sizeof(float), vb[0] + 3, 6 * sizeof(float), attr_weights, 3, NULL, 6 * 3, 1e-2f) == 18);

--- a/src/simplifier.cpp
+++ b/src/simplifier.cpp
@@ -689,18 +689,18 @@ static void quadricFromTriangleEdge(Quadric& Q, const Vector3& p0, const Vector3
 	Vector3 p10 = {p1.x - p0.x, p1.y - p0.y, p1.z - p0.z};
 	float length = normalize(p10);
 
-	// p20p = length of projection of p2-p0 onto normalize(p1 - p0)
+	// p20p = length of projection of p2 - p0 onto normalize(p1 - p0)
 	Vector3 p20 = {p2.x - p0.x, p2.y - p0.y, p2.z - p0.z};
 	float p20p = p20.x * p10.x + p20.y * p10.y + p20.z * p10.z;
 
-	// normal = altitude of triangle from point p2 onto edge p1-p0
-	Vector3 normal = {p20.x - p10.x * p20p, p20.y - p10.y * p20p, p20.z - p10.z * p20p};
-	normalize(normal);
+	// perp = perpendicular vector from p2 to line segment p1-p0
+	Vector3 perp = {p20.x - p10.x * p20p, p20.y - p10.y * p20p, p20.z - p10.z * p20p};
+	normalize(perp);
 
-	float distance = normal.x * p0.x + normal.y * p0.y + normal.z * p0.z;
+	float distance = perp.x * p0.x + perp.y * p0.y + perp.z * p0.z;
 
 	// note: the weight is scaled linearly with edge length; this has to match the triangle weight
-	quadricFromPlane(Q, normal.x, normal.y, normal.z, -distance, length * weight);
+	quadricFromPlane(Q, perp.x, perp.y, perp.z, -distance, length * weight);
 }
 
 static void quadricFromAttributes(Quadric& Q, QuadricGrad* G, const Vector3& p0, const Vector3& p1, const Vector3& p2, const float* va0, const float* va1, const float* va2, size_t attribute_count)

--- a/src/simplifier.cpp
+++ b/src/simplifier.cpp
@@ -687,14 +687,18 @@ static void quadricFromTriangle(Quadric& Q, const Vector3& p0, const Vector3& p1
 static void quadricFromTriangleEdge(Quadric& Q, const Vector3& p0, const Vector3& p1, const Vector3& p2, float weight)
 {
 	Vector3 p10 = {p1.x - p0.x, p1.y - p0.y, p1.z - p0.z};
-	float length = normalize(p10);
 
-	// p20p = length of projection of p2 - p0 onto normalize(p1 - p0)
+	// edge length; keep squared length around for projection correction
+	float lengthsq = p10.x * p10.x + p10.y * p10.y + p10.z * p10.z;
+	float length = sqrtf(lengthsq);
+
+	// p20p = length of projection of p2-p0 onto p1-p0; note that p10 is unnormalized so we need to correct it later
 	Vector3 p20 = {p2.x - p0.x, p2.y - p0.y, p2.z - p0.z};
 	float p20p = p20.x * p10.x + p20.y * p10.y + p20.z * p10.z;
 
 	// perp = perpendicular vector from p2 to line segment p1-p0
-	Vector3 perp = {p20.x - p10.x * p20p, p20.y - p10.y * p20p, p20.z - p10.z * p20p};
+	// note: since p10 is unnormalized we need to correct the projection; we scale p20 instead to take advantage of normalize below
+	Vector3 perp = {p20.x * lengthsq - p10.x * p20p, p20.y * lengthsq - p10.y * p20p, p20.z * lengthsq - p10.z * p20p};
 	normalize(perp);
 
 	float distance = perp.x * p0.x + perp.y * p0.y + perp.z * p0.z;


### PR DESCRIPTION
Instead of normalizing p10 we can correct the projection by the edge
length; since we normalize the vector anyway we instead scale p20 as
this avoids the need to handle singularity.

This makes the function a little faster; more importantly it reduces the
average error by ~1.5x (computed by comparing sqrt(quadric error) for p2
with the double precision distance-to-line computation)

*This contribution is sponsored by Valve.*