### PR TITLE
gltfpack: Improve simplification integration

### DIFF
--- a/gltf/gltfpack.cpp
+++ b/gltf/gltfpack.cpp
@@ -1178,6 +1178,7 @@ Settings defaults()
 	settings.scl_bits = 16;
 	settings.anim_freq = 30;
 	settings.simplify_ratio = 1.f;
+	settings.simplify_error = 1e-2f;
 	settings.texture_scale = 1.f;
 	for (int kind = 0; kind < TextureKind__Count; ++kind)
 		settings.texture_quality[kind] = 8;
@@ -1327,7 +1328,7 @@ int main(int argc, char** argv)
 		}
 		else if (strcmp(arg, "-se") == 0 && i + 1 < argc && isdigit(argv[i + 1][0]))
 		{
-			settings.simplify_error = clamp(float(atof(argv[++i])), 1e-4f, 1.f);
+			settings.simplify_error = clamp(float(atof(argv[++i])), 0.f, 1.f);
 		}
 		else if (strcmp(arg, "-sa") == 0)
 		{
@@ -1525,7 +1526,7 @@ int main(int argc, char** argv)
 			fprintf(stderr, "\t... where C is a comma-separated list (no spaces) with valid values color,normal,attrib\n");
 			fprintf(stderr, "\nSimplification:\n");
 			fprintf(stderr, "\t-si R: simplify meshes targeting triangle/point count ratio R (default: 1; R should be between 0 and 1)\n");
-			fprintf(stderr, "\t-se E: limit simplification error to E (E should be between 0 and 1; 0.01 means 1%% deviation)\n");
+			fprintf(stderr, "\t-se E: limit simplification error to E (default: 0.01 = 1%% deviation; E should be between 0 and 1)\n");
 			fprintf(stderr, "\t-sa: aggressively simplify to the target ratio disregarding quality\n");
 			fprintf(stderr, "\t-sv: take vertex attributes into account when simplifying meshes\n");
 			fprintf(stderr, "\t-slb: lock border vertices during simplification to avoid gaps on connected meshes\n");

--- a/gltf/gltfpack.cpp
+++ b/gltf/gltfpack.cpp
@@ -393,7 +393,7 @@ static void process(cgltf_data* data, const char* input_path, const char* output
 		{
 			Mesh kinds = {};
 			Mesh loops = {};
-			debugSimplify(mesh, kinds, loops, settings.simplify_debug, settings.simplify_attributes);
+			debugSimplify(mesh, kinds, loops, settings.simplify_debug, settings.simplify_error, settings.simplify_attributes);
 			debug_meshes.push_back(kinds);
 			debug_meshes.push_back(loops);
 		}
@@ -1177,7 +1177,7 @@ Settings defaults()
 	settings.rot_bits = 12;
 	settings.scl_bits = 16;
 	settings.anim_freq = 30;
-	settings.simplify_threshold = 1.f;
+	settings.simplify_ratio = 1.f;
 	settings.texture_scale = 1.f;
 	for (int kind = 0; kind < TextureKind__Count; ++kind)
 		settings.texture_quality[kind] = 8;
@@ -1323,7 +1323,11 @@ int main(int argc, char** argv)
 		}
 		else if (strcmp(arg, "-si") == 0 && i + 1 < argc && isdigit(argv[i + 1][0]))
 		{
-			settings.simplify_threshold = clamp(float(atof(argv[++i])), 0.f, 1.f);
+			settings.simplify_ratio = clamp(float(atof(argv[++i])), 0.f, 1.f);
+		}
+		else if (strcmp(arg, "-se") == 0 && i + 1 < argc && isdigit(argv[i + 1][0]))
+		{
+			settings.simplify_error = clamp(float(atof(argv[++i])), 1e-4f, 1.f);
 		}
 		else if (strcmp(arg, "-sa") == 0)
 		{
@@ -1521,6 +1525,7 @@ int main(int argc, char** argv)
 			fprintf(stderr, "\t... where C is a comma-separated list (no spaces) with valid values color,normal,attrib\n");
 			fprintf(stderr, "\nSimplification:\n");
 			fprintf(stderr, "\t-si R: simplify meshes targeting triangle/point count ratio R (default: 1; R should be between 0 and 1)\n");
+			fprintf(stderr, "\t-se E: limit simplification error to E (E should be between 0 and 1; 0.01 means 1%% deviation)\n");
 			fprintf(stderr, "\t-sa: aggressively simplify to the target ratio disregarding quality\n");
 			fprintf(stderr, "\t-sv: take vertex attributes into account when simplifying meshes\n");
 			fprintf(stderr, "\t-slb: lock border vertices during simplification to avoid gaps on connected meshes\n");

--- a/gltf/gltfpack.h
+++ b/gltf/gltfpack.h
@@ -134,7 +134,8 @@ struct Settings
 	bool mesh_merge;
 	bool mesh_instancing;
 
-	float simplify_threshold;
+	float simplify_ratio;
+	float simplify_error;
 	bool simplify_aggressive;
 	bool simplify_lock_borders;
 	bool simplify_attributes;
@@ -306,7 +307,7 @@ cgltf_data* parseGlb(const void* buffer, size_t size, std::vector<Mesh>& meshes,
 void processAnimation(Animation& animation, const Settings& settings);
 void processMesh(Mesh& mesh, const Settings& settings);
 
-void debugSimplify(const Mesh& mesh, Mesh& kinds, Mesh& loops, float ratio, bool attributes);
+void debugSimplify(const Mesh& mesh, Mesh& kinds, Mesh& loops, float ratio, float error, bool attributes);
 void debugMeshlets(const Mesh& mesh, Mesh& meshlets, int max_vertices, bool scan);
 
 bool compareMeshTargets(const Mesh& lhs, const Mesh& rhs);

--- a/gltf/mesh.cpp
+++ b/gltf/mesh.cpp
@@ -584,8 +584,8 @@ static void simplifyMesh(Mesh& mesh, float threshold, float error, bool attribut
 	size_t vertex_count = mesh.streams[0].data.size();
 
 	size_t target_index_count = size_t(double(mesh.indices.size() / 3) * threshold) * 3;
-	float target_error = error == 0 ? 1e-2f : error;
-	float target_error_aggressive = error == 0 ? 1e-1f : error;
+	float target_error = error;
+	float target_error_aggressive = 1e-1f;
 	unsigned int options = 0;
 	if (lock_borders)
 		options |= meshopt_SimplifyLockBorder;


### PR DESCRIPTION
This change exposes simplification error via command line argument `-se`, which can be valuable to control simplification more precisely and may also be used to slightly increase the defaults when `-sv` is used.

Also this change completes https://github.com/zeux/meshoptimizer/pull/688 by incorporating both normals and colors when `-sv` is specified, which improves quality on models with vertex colors further.

Fixes #494.