### PR TITLE
Implement provoking vertex generation for visibility buffers

### DIFF
--- a/demo/tests.cpp
+++ b/demo/tests.cpp
@@ -1476,6 +1476,42 @@ static void tessellation()
 	assert(memcmp(tessib, expected, sizeof(expected)) == 0);
 }
 
+static void provoking()
+{
+	// 0 1 2
+	// 3 4 5
+	const unsigned int ib[] = {
+	    0, 1, 3,
+	    3, 1, 4,
+	    1, 2, 4,
+	    4, 2, 5,
+	    0, 2, 4,
+	    // clang-format :-/
+	};
+
+	unsigned int pib[15];
+	unsigned int pre[6 + 5]; // limit is vertex count + triangle count
+	size_t res = meshopt_generateProvokingIndexBuffer(pib, pre, ib, 15, 6);
+
+	unsigned int expectedib[] = {
+	    0, 5, 1,
+	    1, 4, 0,
+	    2, 4, 1,
+	    3, 4, 2,
+	    4, 5, 2,
+	    // clang-format :-/
+	};
+
+	unsigned int expectedre[] = {
+	    3, 1, 2, 5, 4, 0,
+	    // clang-format :-/
+	};
+
+	assert(res == 6);
+	assert(memcmp(pib, expectedib, sizeof(expectedib)) == 0);
+	assert(memcmp(pre, expectedre, sizeof(expectedre)) == 0);
+}
+
 static void quantizeFloat()
 {
 	volatile float zero = 0.f; // avoids div-by-zero warnings
@@ -1640,6 +1676,7 @@ void runTests()
 
 	adjacency();
 	tessellation();
+	provoking();
 
 	quantizeFloat();
 	quantizeHalf();

--- a/src/indexgenerator.cpp
+++ b/src/indexgenerator.cpp
@@ -631,27 +631,19 @@ size_t meshopt_generateProvokingIndexBuffer(unsigned int* destination, unsigned 
 
 		unsigned int newidx = reorder_offset;
 
-		// now remap[a] = ~0u or all three verts are old
+		// now remap[a] = ~0u or all three vertices are old
+		// recording remap[a] makes it possible to remap future references to the same index, conserving space
 		if (remap[a] == ~0u)
-		{
 			remap[a] = newidx;
-			reorder[reorder_offset++] = a;
 
-			destination[i + 0] = newidx;
-			destination[i + 1] = b;
-			destination[i + 2] = c;
-		}
-		else
-		{
-			// all three verts are old; we need to clone one of them
-			// for now clone a
-			// TODO: predict based on valence if above isn't enough
-			reorder[reorder_offset++] = a;
+		// we need to clone the provoking vertex to get a unique index
+		// if all three are used the choice is arbitrary since no future triangle will be able to reuse any of these
+		reorder[reorder_offset++] = a;
 
-			destination[i + 0] = newidx;
-			destination[i + 1] = b;
-			destination[i + 2] = c;
-		}
+		// note: first vertex is final, the other two will be fixed up in next pass
+		destination[i + 0] = newidx;
+		destination[i + 1] = b;
+		destination[i + 2] = c;
 
 		// update vertex valences for corner heuristic
 		valence[a]--;

--- a/src/indexgenerator.cpp
+++ b/src/indexgenerator.cpp
@@ -588,8 +588,9 @@ size_t meshopt_generateProvokingIndexBuffer(unsigned int* destination, unsigned 
 	memset(remap, -1, vertex_count * sizeof(unsigned int));
 
 	// compute vertex valence; this is used to prioritize least used corner
-	unsigned int* valence = allocator.allocate<unsigned int>(vertex_count);
-	memset(valence, 0, vertex_count * sizeof(unsigned int));
+	// note: we use 8-bit counters for performance; for outlier vertices the valence is incorrect but that just affects the heuristic
+	unsigned char* valence = allocator.allocate<unsigned char>(vertex_count);
+	memset(valence, 0, vertex_count);
 
 	for (size_t i = 0; i < index_count; ++i)
 	{

--- a/src/indexgenerator.cpp
+++ b/src/indexgenerator.cpp
@@ -6,6 +6,7 @@
 
 // This work is based on:
 // John McDonald, Mark Kilgard. Crack-Free Point-Normal Triangles using Adjacent Edge Normals. 2010
+// John Hable. Variable Rate Shading with Visibility Buffer Rendering. 2024
 namespace meshopt
 {
 

--- a/src/meshoptimizer.h
+++ b/src/meshoptimizer.h
@@ -145,7 +145,8 @@ MESHOPTIMIZER_API void meshopt_generateTessellationIndexBuffer(unsigned int* des
  * The reorder table stores the original vertex id for each vertex in the new index buffer, and needs to be used in the vertex shader.
  * This is important for performance of visibility buffer based renderers on hardware where primitive id can't be accessed efficiently in fragment shader.
  * Returns the size of the reorder table.
- * The function assumes provoking vertex is the first vertex in the triangle; if this is not the case, rotate ach triangle indices before using the resulting index buffer.
+ * The function assumes provoking vertex is the first vertex in the triangle; if this is not the case, rotate each triangle indices before using the resulting index buffer.
+ * For maximum efficiency the input index buffer should be optimized for vertex cache first.
  *
  * destination must contain enough space for the resulting index buffer (index_count elements)
  * reorder must contain enough space for the worst case reorder table (vertex_count + index_count/3 elements)

--- a/src/meshoptimizer.h
+++ b/src/meshoptimizer.h
@@ -139,6 +139,17 @@ MESHOPTIMIZER_API void meshopt_generateAdjacencyIndexBuffer(unsigned int* destin
  */
 MESHOPTIMIZER_API void meshopt_generateTessellationIndexBuffer(unsigned int* destination, const unsigned int* indices, size_t index_count, const float* vertex_positions, size_t vertex_count, size_t vertex_positions_stride);
 
+/**
+ * Experimental: Generate index buffer that can be used for visibility buffer rendering
+ * Each triangle's provoking vertex index is equal to primitive id; this allows passing the vertex id to the fragment shader using nointerpolate attribute.
+ * The reorder table stores the original vertex id for each vertex in the new index buffer, and needs to be used in the vertex shader.
+ * This is important for performance of visibility buffer based renderers on hardware where primitive id can't be accessed efficiently in fragment shader.
+ * Returns the size of the reorder table.
+ * The function assumes provoking vertex is the first vertex in the triangle; if this is not the case, rotate ach triangle indices before using the resulting index buffer.
+ *
+ * destination must contain enough space for the resulting index buffer (index_count elements)
+ * reorder must contain enough space for the worst case reorder table (vertex_count + index_count/3 elements)
+ */
 MESHOPTIMIZER_EXPERIMENTAL size_t meshopt_generateProvokingIndexBuffer(unsigned int* destination, unsigned int* reorder, const unsigned int* indices, size_t index_count, size_t vertex_count);
 
 /**

--- a/src/meshoptimizer.h
+++ b/src/meshoptimizer.h
@@ -666,6 +666,8 @@ inline void meshopt_generateAdjacencyIndexBuffer(T* destination, const T* indice
 template <typename T>
 inline void meshopt_generateTessellationIndexBuffer(T* destination, const T* indices, size_t index_count, const float* vertex_positions, size_t vertex_count, size_t vertex_positions_stride);
 template <typename T>
+inline size_t meshopt_generateProvokingIndexBuffer(T* destination, unsigned int* reorder, const T* indices, size_t index_count, size_t vertex_count);
+template <typename T>
 inline void meshopt_optimizeVertexCache(T* destination, const T* indices, size_t index_count, size_t vertex_count);
 template <typename T>
 inline void meshopt_optimizeVertexCacheStrip(T* destination, const T* indices, size_t index_count, size_t vertex_count);
@@ -900,6 +902,19 @@ inline void meshopt_generateTessellationIndexBuffer(T* destination, const T* ind
 	meshopt_IndexAdapter<T> out(destination, NULL, index_count * 4);
 
 	meshopt_generateTessellationIndexBuffer(out.data, in.data, index_count, vertex_positions, vertex_count, vertex_positions_stride);
+}
+
+template <typename T>
+inline size_t meshopt_generateProvokingIndexBuffer(T* destination, unsigned int* reorder, const T* indices, size_t index_count, size_t vertex_count)
+{
+	meshopt_IndexAdapter<T> in(NULL, indices, index_count);
+	meshopt_IndexAdapter<T> out(destination, NULL, index_count);
+
+	size_t bound = vertex_count + (index_count / 3);
+	assert(size_t(T(bound - 1)) == bound - 1); // bound - 1 must fit in T
+	(void)bound;
+
+	return meshopt_generateProvokingIndexBuffer(out.data, reorder, in.data, index_count, vertex_count);
 }
 
 template <typename T>

--- a/src/meshoptimizer.h
+++ b/src/meshoptimizer.h
@@ -140,12 +140,11 @@ MESHOPTIMIZER_API void meshopt_generateAdjacencyIndexBuffer(unsigned int* destin
 MESHOPTIMIZER_API void meshopt_generateTessellationIndexBuffer(unsigned int* destination, const unsigned int* indices, size_t index_count, const float* vertex_positions, size_t vertex_count, size_t vertex_positions_stride);
 
 /**
- * Experimental: Generate index buffer that can be used for visibility buffer rendering
- * Each triangle's provoking vertex index is equal to primitive id; this allows passing the vertex id to the fragment shader using nointerpolate attribute.
- * The reorder table stores the original vertex id for each vertex in the new index buffer, and needs to be used in the vertex shader.
- * This is important for performance of visibility buffer based renderers on hardware where primitive id can't be accessed efficiently in fragment shader.
- * Returns the size of the reorder table.
- * The function assumes provoking vertex is the first vertex in the triangle; if this is not the case, rotate each triangle indices before using the resulting index buffer.
+ * Experimental: Generate index buffer that can be used for visibility buffer rendering and returns the size of the reorder table
+ * Each triangle's provoking vertex index is equal to primitive id; this allows passing it to the fragment shader using nointerpolate attribute.
+ * This is important for performance on hardware where primitive id can't be accessed efficiently in fragment shader.
+ * The reorder table stores the original vertex id for each vertex in the new index buffer, and should be used in the vertex shader to load vertex data.
+ * The provoking vertex is assumed to be the first vertex in the triangle; if this is not the case (OpenGL), rotate each triangle (abc -> bca) before rendering.
  * For maximum efficiency the input index buffer should be optimized for vertex cache first.
  *
  * destination must contain enough space for the resulting index buffer (index_count elements)

--- a/src/meshoptimizer.h
+++ b/src/meshoptimizer.h
@@ -139,6 +139,8 @@ MESHOPTIMIZER_API void meshopt_generateAdjacencyIndexBuffer(unsigned int* destin
  */
 MESHOPTIMIZER_API void meshopt_generateTessellationIndexBuffer(unsigned int* destination, const unsigned int* indices, size_t index_count, const float* vertex_positions, size_t vertex_count, size_t vertex_positions_stride);
 
+MESHOPTIMIZER_EXPERIMENTAL size_t meshopt_generateProvokingIndexBuffer(unsigned int* destination, unsigned int* reorder, const unsigned int* indices, size_t index_count, size_t vertex_count);
+
 /**
  * Vertex transform cache optimizer
  * Reorders indices to reduce the number of GPU vertex shader invocations

--- a/src/stripifier.cpp
+++ b/src/stripifier.cpp
@@ -10,14 +10,14 @@
 namespace meshopt
 {
 
-static unsigned int findStripFirst(const unsigned int buffer[][3], unsigned int buffer_size, const unsigned int* valence)
+static unsigned int findStripFirst(const unsigned int buffer[][3], unsigned int buffer_size, const unsigned char* valence)
 {
 	unsigned int index = 0;
 	unsigned int iv = ~0u;
 
 	for (size_t i = 0; i < buffer_size; ++i)
 	{
-		unsigned int va = valence[buffer[i][0]], vb = valence[buffer[i][1]], vc = valence[buffer[i][2]];
+		unsigned char va = valence[buffer[i][0]], vb = valence[buffer[i][1]], vc = valence[buffer[i][2]];
 		unsigned int v = (va < vb && va < vc) ? va : (vb < vc ? vb : vc);
 
 		if (v < iv)
@@ -71,8 +71,9 @@ size_t meshopt_stripify(unsigned int* destination, const unsigned int* indices, 
 	size_t strip_size = 0;
 
 	// compute vertex valence; this is used to prioritize starting triangle for strips
-	unsigned int* valence = allocator.allocate<unsigned int>(vertex_count);
-	memset(valence, 0, vertex_count * sizeof(unsigned int));
+	// note: we use 8-bit counters for performance; for outlier vertices the valence is incorrect but that just affects the heuristic
+	unsigned char* valence = allocator.allocate<unsigned char>(vertex_count);
+	memset(valence, 0, vertex_count);
 
 	for (size_t i = 0; i < index_count; ++i)
 	{
@@ -151,7 +152,7 @@ size_t meshopt_stripify(unsigned int* destination, const unsigned int* indices, 
 		{
 			// if we didn't find anything, we need to find the next new triangle
 			// we use a heuristic to maximize the strip length
-			unsigned int i = findStripFirst(buffer, buffer_size, &valence[0]);
+			unsigned int i = findStripFirst(buffer, buffer_size, valence);
 			unsigned int a = buffer[i][0], b = buffer[i][1], c = buffer[i][2];
 
 			// ordered removal from the buffer


### PR DESCRIPTION
This PR implements a new algorithm, `meshopt_generateProvokingIndexBuffer`,
that can be used to generate a special index buffer along with a reorder table that
can be used to efficiently implement visibility buffer rendering using traditional
rasterization pipeline. It is based on [Variable Rate Shading with Visibility Buffer Rendering](https://advances.realtimerendering.com/s2024/index.html#hable)
(John Hable, SIGGRAPH 2024).

Without this, and without the use of mesh shaders, the applications that need to
output per-pixel primitive ID need to either use geometry shaders or unindexed
geometry (both lead to a significant slowdown) or access primitive ID in fragment
shader via `SV_PrimitiveID`/`gl_PrimitiveID` inputs. The latter seems tailor-made and
optimal, but unfortunately it triggers inefficient paths on some GPUs (~1.5x-2x
slowdown depending on the GPU). In my testing, this is not a problem for RDNA2/3,
but *is* a significant problem on RDNA1 as well as latest NVidia GPUs. Additionally,
in Vulkan `gl_PrimitiveID` is not available on some mobile platforms.

It is possible to construct a special index buffer that satisfies two constraints:

- `indices[3 * tri] == tri`
- `reorder[indices[x]]` refers to the original triangle vertices

This index buffer requires a vertex shader that performs the indirection through
reorder[], and because this construction requires at least one vertex per triangle
it can be less efficient to render, however this allows passing the vertex id to the
fragment shader using `flat`/`nointerpolation` attribute (via provoking vertex), which
is equal to primitive id per construction above. It's also sometimes possible to
encode the reorder table into the index buffer by splitting the indices into 16-bit
halves (requires small input meshes and `fullDrawIndexUint32` support in Vulkan).

`meshopt_generateProvokingIndexBuffer` is inspired by the algorithm proposed
by the SIGGRAPH talk, but does not follow it exactly. Notably, it operates on the
entire mesh as opposed to individual clusters; this makes the algorithm more
immediately useful for traditional rasterization (for clustered renderers that use
mesh shaders this technique is not necessary to achieve peak performance), and
allows to produce more efficient output because of the lack of clusterization
constraints that may require more degenerate triangles or extra vertices.

Because it doesn't work on clusters, it's not trivial to perform the redistribution
of corner indices; this currently does not seem critical to achieving great results
(again due to lack of clusterization constraints), and it makes the algorithm linear
and fast, which may allow applications to invoke it at load time instead of in asset
pipeline.

> Clustered renderers that don't use mesh shaders could decide to use this algorithm
and split the output into clusters using `meshopt_buildMeshletsScan`; this seems to
work reasonably well provided that cluster vertex limit is a little higher than triangle
limit (eg 128t 192v, 64t 96v or similar configurations); if the vertex limit is the same
as triangle limit, this method will produce more clusters than is optimal.

The algorithm assumes provoking vertex is the first vertex of a triangle. This is
the case for all graphics APIs except for OpenGL/WebGL. Applications that target
these APIs may need to rotate each triangle (abc -> bca) in the resulting index buffer.
Notably, desktop OpenGL 3.2+ allows switching the provoking vertex to first via
`glProvokingVertex`; WebGL2 exposes this functionality via `WEBGL_provoking_vertex`
extension. Because WebGL2 is almost always emulated using an API that uses first
vertex as provoking, it is highly recommended to use this extension to avoid a variety
of emulation slowdowns that happen by default if `flat` attributes are used (such as
an implicit use of geometry shaders).

*This contribution is sponsored by Valve.*