### PR TITLE
gltfpack: Use quantized normal/tangents for reindexing by default

### DIFF
--- a/gltf/gltfpack.cpp
+++ b/gltf/gltfpack.cpp
@@ -393,7 +393,7 @@ static void process(cgltf_data* data, const char* input_path, const char* output
 		{
 			Mesh kinds = {};
 			Mesh loops = {};
-			debugSimplify(mesh, kinds, loops, settings.simplify_debug, settings.simplify_error, settings.simplify_attributes);
+			debugSimplify(mesh, kinds, loops, settings.simplify_debug, settings.simplify_error, settings.simplify_attributes, settings.quantize && !settings.nrm_float);
 			debug_meshes.push_back(kinds);
 			debug_meshes.push_back(loops);
 		}

--- a/gltf/gltfpack.h
+++ b/gltf/gltfpack.h
@@ -307,7 +307,7 @@ cgltf_data* parseGlb(const void* buffer, size_t size, std::vector<Mesh>& meshes,
 void processAnimation(Animation& animation, const Settings& settings);
 void processMesh(Mesh& mesh, const Settings& settings);
 
-void debugSimplify(const Mesh& mesh, Mesh& kinds, Mesh& loops, float ratio, float error, bool attributes);
+void debugSimplify(const Mesh& mesh, Mesh& kinds, Mesh& loops, float ratio, float error, bool attributes, bool quantize_tbn);
 void debugMeshlets(const Mesh& mesh, Mesh& meshlets, int max_vertices, bool scan);
 
 bool compareMeshTargets(const Mesh& lhs, const Mesh& rhs);


### PR DESCRIPTION
While reindexing full precision streams is usually sufficient to get a good non-redundant index buffer, some meshes go through export or processing pipelines that introduce imprecision in individual normals or tangents, creating artificial seams. This increases the storage size and decreases rendering efficiency, in addition to creating issues for simplification.

This can be solved with a tolerance-based weld pass, but for now we can simply use quantized normals/tangents during reindexing. Note that this by itself does not reduce precision of individual vertices, so in theory we can be *more* aggressive here with quantization bits - for now we always use 8 bits which should not cause issues even if the requested normal bits is 16.