### PR TITLE
demo: Initial hierarchical clustered simplification (Nanite) demo

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,7 +100,7 @@ endif()
 set(TARGETS meshoptimizer)
 
 if(MESHOPT_BUILD_DEMO)
-    add_executable(demo demo/main.cpp demo/tests.cpp tools/objloader.cpp)
+    add_executable(demo demo/main.cpp demo/nanite.cpp demo/tests.cpp tools/objloader.cpp)
     target_link_libraries(demo meshoptimizer)
 endif()
 

--- a/Makefile
+++ b/Makefile
@@ -108,6 +108,9 @@ check: $(DEMO)
 dev: $(DEMO)
 	$(DEMO) -d $(files)
 
+nanite: $(DEMO)
+	$(DEMO) -n $(files)
+
 format:
 	clang-format -i $(LIBRARY_SOURCES) $(DEMO_SOURCES) $(GLTFPACK_SOURCES)
 

--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,11 @@ ifdef BASISU
     endif
 endif
 
+ifdef METIS
+    $(DEMO_OBJECTS): CXXFLAGS+=-DMETIS
+    $(DEMO): LDFLAGS+=-lmetis
+endif
+
 WASMCC?=$(WASI_SDK)/bin/clang++
 WASIROOT?=$(WASI_SDK)/share/wasi-sysroot
 

--- a/demo/main.cpp
+++ b/demo/main.cpp
@@ -138,21 +138,21 @@ Mesh parseObj(const char* path, double& reindex)
 	return result;
 }
 
-void dumpObj(const Mesh& mesh, bool recomputeNormals = false)
+void dumpObj(const std::vector<Vertex>& vertices, const std::vector<unsigned int>& indices, bool recomputeNormals = false)
 {
 	std::vector<float> normals;
 
 	if (recomputeNormals)
 	{
-		normals.resize(mesh.vertices.size() * 3);
+		normals.resize(vertices.size() * 3);
 
-		for (size_t i = 0; i < mesh.indices.size(); i += 3)
+		for (size_t i = 0; i < indices.size(); i += 3)
 		{
-			unsigned int a = mesh.indices[i], b = mesh.indices[i + 1], c = mesh.indices[i + 2];
+			unsigned int a = indices[i], b = indices[i + 1], c = indices[i + 2];
 
-			const Vertex& va = mesh.vertices[a];
-			const Vertex& vb = mesh.vertices[b];
-			const Vertex& vc = mesh.vertices[c];
+			const Vertex& va = vertices[a];
+			const Vertex& vb = vertices[b];
+			const Vertex& vc = vertices[c];
 
 			float nx = (vb.py - va.py) * (vc.pz - va.pz) - (vb.pz - va.pz) * (vc.py - va.py);
 			float ny = (vb.pz - va.pz) * (vc.px - va.px) - (vb.px - va.px) * (vc.pz - va.pz);
@@ -160,7 +160,7 @@ void dumpObj(const Mesh& mesh, bool recomputeNormals = false)
 
 			for (int k = 0; k < 3; ++k)
 			{
-				unsigned int index = mesh.indices[i + k];
+				unsigned int index = indices[i + k];
 
 				normals[index * 3 + 0] += nx;
 				normals[index * 3 + 1] += ny;
@@ -169,9 +169,9 @@ void dumpObj(const Mesh& mesh, bool recomputeNormals = false)
 		}
 	}
 
-	for (size_t i = 0; i < mesh.vertices.size(); ++i)
+	for (size_t i = 0; i < vertices.size(); ++i)
 	{
-		const Vertex& v = mesh.vertices[i];
+		const Vertex& v = vertices[i];
 
 		float nx = v.nx, ny = v.ny, nz = v.nz;
 
@@ -193,9 +193,9 @@ void dumpObj(const Mesh& mesh, bool recomputeNormals = false)
 		fprintf(stderr, "vn %f %f %f\n", nx, ny, nz);
 	}
 
-	for (size_t i = 0; i < mesh.indices.size(); i += 3)
+	for (size_t i = 0; i < indices.size(); i += 3)
 	{
-		unsigned int a = mesh.indices[i], b = mesh.indices[i + 1], c = mesh.indices[i + 2];
+		unsigned int a = indices[i], b = indices[i + 1], c = indices[i + 2];
 
 		fprintf(stderr, "f %d %d %d\n", a + 1, b + 1, c + 1);
 	}

--- a/demo/main.cpp
+++ b/demo/main.cpp
@@ -201,6 +201,18 @@ void dumpObj(const std::vector<Vertex>& vertices, const std::vector<unsigned int
 	}
 }
 
+void dumpObj(const char* section, const std::vector<unsigned int>& indices)
+{
+	fprintf(stderr, "o %s\n", section);
+
+	for (size_t j = 0; j < indices.size(); j += 3)
+	{
+		unsigned int a = indices[j], b = indices[j + 1], c = indices[j + 2];
+
+		fprintf(stderr, "f %d %d %d\n", a + 1, b + 1, c + 1);
+	}
+}
+
 bool isMeshValid(const Mesh& mesh)
 {
 	size_t index_count = mesh.indices.size();

--- a/demo/main.cpp
+++ b/demo/main.cpp
@@ -1155,6 +1155,8 @@ void provoking(const Mesh& mesh)
 	    int(mesh.indices.size() / 3), int(pcount), double(pcount) / double(bestv) * 100.0 - 100.0, (end - start) * 1000);
 }
 
+void nanite(const std::vector<Vertex>& vertices, const std::vector<unsigned int>& indices); // nanite.cpp
+
 bool loadMesh(Mesh& mesh, const char* path)
 {
 	double start = timestamp();
@@ -1344,6 +1346,15 @@ void processDev(const char* path)
 	simplifyAttr(mesh);
 }
 
+void processNanite(const char* path)
+{
+	Mesh mesh;
+	if (!loadMesh(mesh, path))
+		return;
+
+	nanite(mesh.vertices, mesh.indices);
+}
+
 int main(int argc, char** argv)
 {
 	void runTests();
@@ -1360,16 +1371,17 @@ int main(int argc, char** argv)
 		if (strcmp(argv[1], "-d") == 0)
 		{
 			for (int i = 2; i < argc; ++i)
-			{
 				processDev(argv[i]);
-			}
+		}
+		else if (strcmp(argv[1], "-n") == 0)
+		{
+			for (int i = 2; i < argc; ++i)
+				processNanite(argv[i]);
 		}
 		else
 		{
 			for (int i = 1; i < argc; ++i)
-			{
 				process(argv[i]);
-			}
 
 			runTests();
 		}

--- a/demo/nanite.cpp
+++ b/demo/nanite.cpp
@@ -1,9 +1,17 @@
+// Brian Karis. Nanite: A Deep Dive. 2021
 #include "../src/meshoptimizer.h"
+
+#include <float.h>
+#include <stdio.h>
 
 #include <vector>
 
 #ifdef METIS
 #include <metis.h>
+#endif
+
+#ifndef TRACE
+#define TRACE 0
 #endif
 
 struct Vertex
@@ -13,10 +21,109 @@ struct Vertex
 	float tx, ty;
 };
 
+struct Cluster
+{
+	std::vector<unsigned int> indices;
+};
+
 double timestamp();
+
+static std::vector<Cluster> clusterize(const std::vector<Vertex>& vertices, const std::vector<unsigned int>& indices)
+{
+	const size_t max_vertices = 255;
+	const size_t max_triangles = 128;
+
+	size_t max_meshlets = meshopt_buildMeshletsBound(indices.size(), max_vertices, max_triangles);
+
+	std::vector<meshopt_Meshlet> meshlets(max_meshlets);
+	std::vector<unsigned int> meshlet_vertices(max_meshlets * max_vertices);
+	std::vector<unsigned char> meshlet_triangles(max_meshlets * max_triangles * 3);
+
+	meshlets.resize(meshopt_buildMeshlets(&meshlets[0], &meshlet_vertices[0], &meshlet_triangles[0], &indices[0], indices.size(), &vertices[0].px, vertices.size(), sizeof(Vertex), max_vertices, max_triangles, 0.f));
+
+	std::vector<Cluster> clusters(meshlets.size());
+
+	for (size_t i = 0; i < meshlets.size(); ++i)
+	{
+		const meshopt_Meshlet& meshlet = meshlets[i];
+
+		meshopt_optimizeMeshlet(&meshlet_vertices[meshlet.vertex_offset], &meshlet_triangles[meshlet.triangle_offset], meshlet.triangle_count, meshlet.vertex_count);
+
+		// note: for now we discard meshlet-local indices; they are valuable for shader code so in the future we should bring them back
+		clusters[i].indices.resize(meshlet.triangle_count * 3);
+		for (size_t j = 0; j < meshlet.triangle_count * 3; ++j)
+			clusters[i].indices[j] = meshlet_vertices[meshlet.vertex_offset + meshlet_triangles[meshlet.triangle_offset + j]];
+
+#if TRACE
+		printf("cluster %d: %d triangles\n", int(i), int(meshlet.triangle_count));
+#endif
+	}
+
+	return clusters;
+}
+
+static Cluster simplify(const std::vector<Vertex>& vertices, const std::vector<unsigned int>& indices, size_t target_count)
+{
+	std::vector<unsigned int> lod(indices.size());
+	float error = 0.f;
+	unsigned int options = meshopt_SimplifyLockBorder | meshopt_SimplifySparse;
+	lod.resize(meshopt_simplify(&lod[0], &indices[0], indices.size(), &vertices[0].px, vertices.size(), sizeof(Vertex), target_count, FLT_MAX, options, &error));
+
+#if TRACE
+	printf("cluster: %d => %d triangles\n", int(indices.size() / 3), int(lod.size() / 3));
+#endif
+
+	Cluster result;
+	result.indices = lod;
+	return result;
+}
 
 void nanite(const std::vector<Vertex>& vertices, const std::vector<unsigned int>& indices)
 {
-	(void)vertices;
-	(void)indices;
+	std::vector<Cluster> clusters;
+
+	// initial clusterization splits the original mesh
+	std::vector<Cluster> pending = clusterize(vertices, indices);
+	printf("lod 0: %d clusters\n", int(pending.size()));
+
+	int depth = 0;
+
+	// merge and simplify clusters until we can't merge anymore
+	while (!pending.empty())
+	{
+		size_t start = clusters.size();
+
+		for (size_t i = 0; i < pending.size(); ++i)
+			clusters.push_back(pending[i]); // std::move
+		pending.clear();
+
+		std::vector<Cluster> merged;
+
+		// rough merge; while clusters are approximately spatially ordered, this should use a proper partitioning algorithm
+		for (size_t i = start; i < clusters.size(); ++i)
+		{
+			if (merged.empty() || merged.back().indices.size() + clusters[i].indices.size() > 128 * 4 * 3)
+				merged.push_back(Cluster());
+
+			merged.back().indices.insert(merged.back().indices.end(), clusters[i].indices.begin(), clusters[i].indices.end());
+		}
+
+		// every merged cluster needs to be simplified now
+		for (size_t i = 0; i < merged.size(); ++i)
+		{
+			if (merged[i].indices.size() < 128 * 3 * 3)
+				continue; // didn't merge enough
+
+			Cluster simplified = simplify(vertices, merged[i].indices, 128 * 2 * 3);
+			if (simplified.indices.size() > 128 * 3 * 3)
+				continue; // simplification is stuck; abandon the merge
+
+			std::vector<Cluster> split = clusterize(vertices, simplified.indices);
+			for (size_t j = 0; j < split.size(); ++j)
+				pending.push_back(split[j]); // std::move
+		}
+
+		depth++;
+		printf("lod %d: %d clusters\n", depth, int(pending.size()));
+	}
 }

--- a/demo/nanite.cpp
+++ b/demo/nanite.cpp
@@ -448,6 +448,9 @@ void nanite(const std::vector<Vertex>& vertices, const std::vector<unsigned int>
 				printf("stuck cluster: singleton with %d triangles\n", int(clusters[groups[i][0]].indices.size() / 3));
 #endif
 
+				if (dump && depth == atoi(dump))
+					dumpObj("cluster", clusters[groups[i][0]].indices);
+
 				stuck_clusters++;
 				stuck_triangles += clusters[groups[i][0]].indices.size() / 3;
 				retry.push_back(groups[i][0]);

--- a/demo/nanite.cpp
+++ b/demo/nanite.cpp
@@ -2,6 +2,10 @@
 
 #include <vector>
 
+#ifdef METIS
+#include <metis.h>
+#endif
+
 struct Vertex
 {
 	float px, py, pz;

--- a/demo/nanite.cpp
+++ b/demo/nanite.cpp
@@ -5,6 +5,11 @@
 
 // For reference, see the original Nanite paper:
 // Brian Karis. Nanite: A Deep Dive. 2021
+
+#ifndef _CRT_SECURE_NO_WARNINGS
+#define _CRT_SECURE_NO_WARNINGS
+#endif
+
 #include "../src/meshoptimizer.h"
 
 #include <float.h>

--- a/demo/nanite.cpp
+++ b/demo/nanite.cpp
@@ -442,6 +442,7 @@ void nanite(const std::vector<Vertex>& vertices, const std::vector<unsigned int>
 
 		size_t triangles = 0;
 		size_t stuck_triangles = 0;
+		int single_clusters = 0;
 		int stuck_clusters = 0;
 		int full_clusters = 0;
 
@@ -463,6 +464,7 @@ void nanite(const std::vector<Vertex>& vertices, const std::vector<unsigned int>
 				if (dump && depth == atoi(dump))
 					dumpObj("cluster", clusters[groups[i][0]].indices);
 
+				single_clusters++;
 				stuck_clusters++;
 				stuck_triangles += clusters[groups[i][0]].indices.size() / 3;
 				retry.push_back(groups[i][0]);
@@ -525,8 +527,8 @@ void nanite(const std::vector<Vertex>& vertices, const std::vector<unsigned int>
 		}
 
 		depth++;
-		printf("lod %d: simplified %d clusters (%d full), %d triangles; stuck %d clusters, %d triangles\n", depth,
-		    int(pending.size()), full_clusters, int(triangles), stuck_clusters, int(stuck_triangles));
+		printf("lod %d: simplified %d clusters (%d full, %.1f tri/cl), %d triangles; stuck %d clusters (%d single), %d triangles\n", depth,
+		    int(pending.size()), full_clusters, pending.empty() ? 0 : double(triangles) / double(pending.size()), int(triangles), stuck_clusters, single_clusters, int(stuck_triangles));
 
 		if (triangles < stuck_triangles / 3)
 			break;

--- a/demo/nanite.cpp
+++ b/demo/nanite.cpp
@@ -1,3 +1,9 @@
+// This is a playground for experimenting with algorithms necessary for Nanite like hierarchical clustering
+// The code is not optimized, not robust, and not intended for production use.
+// It optionally supports METIS for clustering and partitioning, with an eventual goal of removing this code
+// in favor of meshopt algorithms.
+
+// For reference, see the original Nanite paper:
 // Brian Karis. Nanite: A Deep Dive. 2021
 #include "../src/meshoptimizer.h"
 
@@ -58,6 +64,7 @@ static LODBounds boundsMerge(const std::vector<Cluster>& clusters, const std::ve
 	LODBounds result = {};
 
 	// we approximate merged bounds center as weighted average of cluster centers
+	// (could also use bounds() center, but we can't use bounds() radius so might as well just merge manually)
 	float weight = 0.f;
 	for (size_t j = 0; j < group.size(); ++j)
 	{

--- a/demo/nanite.cpp
+++ b/demo/nanite.cpp
@@ -1,0 +1,18 @@
+#include "../src/meshoptimizer.h"
+
+#include <vector>
+
+struct Vertex
+{
+	float px, py, pz;
+	float nx, ny, nz;
+	float tx, ty;
+};
+
+double timestamp();
+
+void nanite(const std::vector<Vertex>& vertices, const std::vector<unsigned int>& indices)
+{
+	(void)vertices;
+	(void)indices;
+}

--- a/demo/nanite.cpp
+++ b/demo/nanite.cpp
@@ -183,18 +183,15 @@ static void clusterizeMetisRec(std::vector<Cluster>& result, const std::vector<u
 
 static std::vector<Cluster> clusterizeMetis(const std::vector<Vertex>& vertices, const std::vector<unsigned int>& indices)
 {
-	std::vector<unsigned int> remap(vertices.size());
-	meshopt_Stream stream = {&vertices[0].px, sizeof(float) * 3, sizeof(Vertex)};
-	meshopt_generateVertexRemapMulti(&remap[0], NULL, vertices.size(), vertices.size(), &stream, 1);
+	std::vector<unsigned int> shadowib(indices.size());
+	meshopt_generateShadowIndexBuffer(&shadowib[0], &indices[0], indices.size(), &vertices[0].px, vertices.size(), sizeof(float) * 3, sizeof(Vertex));
 
 	std::map<std::pair<unsigned int, unsigned int>, unsigned int> edges;
 
 	for (size_t i = 0; i < indices.size(); ++i)
 	{
-		unsigned int v0 = indices[i + 0];
-		unsigned int v1 = indices[i + (i % 3 == 2 ? -2 : 1)];
-		v0 = remap[v0];
-		v1 = remap[v1];
+		unsigned int v0 = shadowib[i + 0];
+		unsigned int v1 = shadowib[i + (i % 3 == 2 ? -2 : 1)];
 
 		// we don't track adjacency fully on non-manifold edges for now
 		edges[std::make_pair(v0, v1)] = unsigned(i / 3);
@@ -204,10 +201,7 @@ static std::vector<Cluster> clusterizeMetis(const std::vector<Vertex>& vertices,
 
 	for (size_t i = 0; i < indices.size(); i += 3)
 	{
-		unsigned int v0 = indices[i + 0], v1 = indices[i + 1], v2 = indices[i + 2];
-		v0 = remap[v0];
-		v1 = remap[v1];
-		v2 = remap[v2];
+		unsigned int v0 = shadowib[i + 0], v1 = shadowib[i + 1], v2 = shadowib[i + 2];
 
 		std::map<std::pair<unsigned int, unsigned int>, unsigned int>::iterator oab = edges.find(std::make_pair(v1, v0));
 		std::map<std::pair<unsigned int, unsigned int>, unsigned int>::iterator obc = edges.find(std::make_pair(v2, v1));


### PR DESCRIPTION
This PR adds a new demo file, nanite.cpp, that implements Nanite-style hierarchical simplification.
Working off the SIGGRAPH presentation by Brian Karis, it builds a DAG of clusters; for each cluster,
it tracks the bounds and error that can be used to do LOD selection in parallel / independently at
runtime.

The goal of this code is *not* to be a production quality pipeline (yet!); it is to serve as a testing
ground for future improvements in meshoptimizer's algorithms as well as development of new
algorithms. In the future this may become a good starting point, but for now the main purpose
is to be a test harness, as such there's a bunch of statistics / visualization support code here (and
more to come in the future at some point).

Also, to have a reasonable baseline, this code integrates with METIS to optionally use it to build
clusters, as well as to partition clusters. Without METIS we can still build clusters using meshopt,
but for partitioning we resolve to just sequentially merge clusters (which is obviously suboptimal).

METIS triangle partitioning is generally better in terms of maintaining contiguous clusters, but
worse in terms of generating a good cluster fill. There might be a way to coerce METIS to generate
better clusters with more tweaks; currently what often happens is that it decides to split a 256-size
partition into 127 and 129 triangles, and then has no choice but to split the 129-triangle partition
into two smaller ones. This may be fixable by repeatedly asking METIS to generate partitions with
different triangle counts but this becomes even more expensive... since METIS is only used here to
set a baseline, this is probably fine.

METIS cluster partitioning has surprising failure cases where it decides that a good partition should
consist of 4 clusters that barely connect; this was unexpected because it doesn't seem to happen during
triangle builds. Maybe with this in mind, a reasonable (unordered) greedy cluster merge could work
better, but this will need to be investigated separately in the future anyway.

The actual simplification currently uses automatic border detection; it would be better to switch to
using external vertex tagging via `vertex_lock`, but for now models I use for testing that have a lot of
room to improvement are not bottlenecked by this.

The actual DAG build is also very sensitive to all of the details above in ways that seem somewhat
difficult to control. If a group at any point earlier in the pipeline is stuck (eg can't be simplified too
much), it could be because the group has internally bad topology (faceting, UV seams), but could
also be because the group is formed of disjointed clusters, or the clusters themselves are formed
of disjointed triangles. This is bad because a) the group itself is kept at a high resolution, b) removing
this group from future simplification permanently locks the boundary edges for other clusters,
which exacerbates the problem.

To try to get around this, the DAG flow has very lax simplification limits (we keep anything where we
can remove 15% of triangles without breaking borders), and also keeps anything that gets stuck in
the queue and retries later - this in some cases makes things worse but often helps.

The error propagation is using a simpler variant of the full error described in Nanite paper; their
error looks at projected bounds whereas we just approximate it, but that doesn't matter as much.
What does matter for correctness is enforcing that the error is monotonic, which we do by ensuring
spherical group bounds are merged conservatively.

Finally, the METIS support code is written with zero regards towards efficiency; it uses bad containers
and inefficient algorithms in some places for expediency. This is because hopefully in a year or so
all of the METIS code can be removed because meshopt replacements will be superior. :crossed_fingers: 

The demo can be coerced to dump parts of the mesh as .obj via DUMP env var, which can be pretty
conveniently visualized in Blender:

![image](https://github.com/user-attachments/assets/ab2f7165-7d0c-4862-b733-c536d1207fd0)

Future work here includes more statistics around meshlet quality, maybe fixes around METIS usage
to improve the baseline a bit, and more importantly this will be used to improve the library in the future :)

*This contribution is sponsored by Valve.*