### PR TITLE
gltfpack: Use UTF-8 encoding during gltfpack processing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,6 +58,10 @@ set(GLTF_SOURCES
     gltf/write.cpp
 )
 
+if(WIN32)
+    list(APPEND GLTF_SOURCES gltf/gltfpack.manifest)
+endif()
+
 if(MSVC)
     add_compile_options(/W4)
 else()

--- a/gltf/gltfpack.cpp
+++ b/gltf/gltfpack.cpp
@@ -1217,8 +1217,12 @@ unsigned int textureMask(const char* arg)
 }
 
 #ifndef GLTFFUZZ
-int run(int argc, char** argv)
+int main(int argc, char** argv)
 {
+#ifndef __wasi__
+	setlocale(LC_ALL, "C"); // disable locale specific convention for number parsing/printing
+#endif
+
 	meshopt_encodeVertexVersion(0);
 	meshopt_encodeIndexVersion(1);
 
@@ -1629,43 +1633,12 @@ int run(int argc, char** argv)
 }
 #endif
 
-#if !defined(_WIN32) && !defined(__wasi__)
-int main(int argc, char** argv)
-{
-	setlocale(LC_ALL, "C"); // disable locale specific convention for number parsing/printing
-	return run(argc, argv);
-}
-#endif
-
-#ifdef _WIN32
-int wmain(int argc, wchar_t* argv[])
-{
-	setlocale(LC_ALL, "en_us.utf8"); // use utf8 as ansi codepage
-
-	std::vector<char*> args;
-	for (int i = 0; i < argc; ++i)
-	{
-		std::mbstate_t state = {};
-		const wchar_t* argw = argv[i];
-		size_t len = wcsrtombs(NULL, &argw, 0, &state);
-		if (len == size_t(-1))
-			return -1;
-
-		char* argu = new char[len + 1];
-		wcsrtombs(argu, &argw, len + 1, &state);
-		args.push_back(argu);
-	}
-
-	return run(int(args.size()), args.data());
-}
-#endif
-
 #ifdef __wasi__
 extern "C" int pack(int argc, char** argv)
 {
 	chdir("/gltfpack-$pwd");
 
-	int result = run(argc, argv);
+	int result = main(argc, argv);
 	fflush(NULL);
 	return result;
 }

--- a/gltf/gltfpack.cpp
+++ b/gltf/gltfpack.cpp
@@ -1217,12 +1217,8 @@ unsigned int textureMask(const char* arg)
 }
 
 #ifndef GLTFFUZZ
-int main(int argc, char** argv)
+int run(int argc, char** argv)
 {
-#ifndef __wasi__
-	setlocale(LC_ALL, "C"); // disable locale specific convention for number parsing/printing
-#endif
-
 	meshopt_encodeVertexVersion(0);
 	meshopt_encodeIndexVersion(1);
 
@@ -1633,12 +1629,43 @@ int main(int argc, char** argv)
 }
 #endif
 
+#if !defined(_WIN32) && !defined(__wasi__)
+int main(int argc, char** argv)
+{
+	setlocale(LC_ALL, "C"); // disable locale specific convention for number parsing/printing
+	return run(argc, argv);
+}
+#endif
+
+#ifdef _WIN32
+int wmain(int argc, wchar_t* argv[])
+{
+	setlocale(LC_ALL, "en_us.utf8"); // use utf8 as ansi codepage
+
+	std::vector<char*> args;
+	for (int i = 0; i < argc; ++i)
+	{
+		std::mbstate_t state = {};
+		const wchar_t* argw = argv[i];
+		size_t len = wcsrtombs(NULL, &argw, 0, &state);
+		if (len == size_t(-1))
+			return -1;
+
+		char* argu = new char[len + 1];
+		wcsrtombs(argu, &argw, len + 1, &state);
+		args.push_back(argu);
+	}
+
+	return run(int(args.size()), args.data());
+}
+#endif
+
 #ifdef __wasi__
 extern "C" int pack(int argc, char** argv)
 {
 	chdir("/gltfpack-$pwd");
 
-	int result = main(argc, argv);
+	int result = run(argc, argv);
 	fflush(NULL);
 	return result;
 }

--- a/gltf/gltfpack.manifest
+++ b/gltf/gltfpack.manifest
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+  <assemblyIdentity type="win32" name="..." version="6.0.0.0"/>
+  <application>
+    <windowsSettings>
+      <activeCodePage xmlns="http://schemas.microsoft.com/SMI/2019/WindowsSettings">UTF-8</activeCodePage>
+    </windowsSettings>
+  </application>
+</assembly>


### PR DESCRIPTION
When main() is used, the inputs are ANSI according to the current code page; this is fine if the file paths can be converted to ANSI, but may fail to open some files and will use ANSI file paths inside .gltf files which violates glTF specification.

This can be worked around by using UTF8 as ANSI code page via a manifest; however, to avoid having to bundle a manifest we can also convert the command line arguments to UTF8 and set UTF8 as the codepage instead.

This requires Windows 10 1803; on earlier Windows versions setlocale should silently fail so this should be more or less equivalent to the previous code.

Fixes #767 