### PR TITLE
simplify: Avoid early termination of passes for complex meshes

### DIFF
--- a/demo/tests.cpp
+++ b/demo/tests.cpp
@@ -1151,7 +1151,7 @@ static void simplifyAttr(bool skip_g)
 		{
 			vb[y * 3 + x][0] = float(x);
 			vb[y * 3 + x][1] = float(y);
-			vb[y * 3 + x][2] = 0.03f * x + 0.03f * (y % 2);
+			vb[y * 3 + x][2] = 0.03f * x + 0.03f * (y % 2) + (x == 2 && y == 7) * 0.03f;
 			vb[y * 3 + x][3] = r;
 			vb[y * 3 + x][4] = g;
 			vb[y * 3 + x][5] = b;

--- a/src/simplifier.cpp
+++ b/src/simplifier.cpp
@@ -1129,7 +1129,7 @@ static size_t performEdgeCollapses(unsigned int* collapse_remap, unsigned char* 
 
 		// on average, each collapse is expected to lock 6 other collapses; to avoid degenerate passes on meshes with odd
 		// topology, we only abort if we got over 1/6 collapses accordingly.
-		if (c.error > error_goal && triangle_collapses > triangle_collapse_goal / 6)
+		if (c.error > error_goal && c.error > result_error && triangle_collapses > triangle_collapse_goal / 6)
 		{
 			TRACESTATS(6);
 			break;


### PR DESCRIPTION
In large meshes with complex topology we occasionally hit a case where
error_goal cutoff is not monotonic: a previous pass would simplify up to
a certain goal, but a subsequent pass would arrive at a smaller goal
(for example as invalid collapses get eliminated) and hit it before an
error that it already encountered.

If we already collapsed an edge with a given error it is always correct
to collapse other edges with a smaller error. This change tweaks the
conditional, which results in fewer passes on some meshes (e.g.
thai_buddha gets ~10% faster to simplify), 2-3% smaller error on some
meshes, and occasionally 1-2% larger error; most meshes simplify as they
did before however.

Additionally, this PR improves collapse sorting by making it a little more
precise at minimal extra cost; this improves the collapse ordering and can
yield lower overall error, and also in some cases reduces the pass count
by performing eligible collapses in earlier passes.

*This contribution is sponsored by Valve.*