### PR TITLE
simplify: Enable border->locked and seam->locked collapses

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -216,6 +216,9 @@ codecbench-simd.wasm: tools/codecbench.cpp $(LIBRARY_SOURCES)
 codecfuzz: tools/codecfuzz.cpp src/vertexcodec.cpp src/indexcodec.cpp
 	$(CXX) $^ -fsanitize=fuzzer,address,undefined -O1 -g -o $@
 
+simplifyfuzz: tools/simplifyfuzz.cpp src/simplifier.cpp
+	$(CXX) $^ -fsanitize=fuzzer,address,undefined -O1 -g -o $@
+
 $(LIBRARY): $(LIBRARY_OBJECTS)
 	ar rcs $@ $^
 

--- a/demo/simplify.html
+++ b/demo/simplify.html
@@ -235,8 +235,8 @@
 								var a = dres[0][i + e],
 									b = dres[0][i + ((e + 1) % 3)];
 
-								if (a >> 31 != 0 && ((a >> 28) & 7) == kind) {
-									// loop of current kind
+								if (a >> 31 != 0 && kind != 4 && (((a >> 28) & 7) == kind || ((b >> 28) & 7) == kind)) {
+									// loop of current kind (non-locked to allow one of the vertices to be locked)
 									dind.push(a & mask);
 									dind.push(a & mask);
 									dind.push(b & mask);

--- a/demo/tests.cpp
+++ b/demo/tests.cpp
@@ -1389,33 +1389,28 @@ static void simplifySeam()
 	};
 
 	// note: vertices 1-2 and 13-14 are classified as locked, because they are on a seam & a border
-	// since seam->locked collapses are restriced, we only get to 3 triangles on each side as the seam is simplified to 3 vertices
-
-	// so we get this structure initially, and then one of the internal seam vertices is collapsed to the other one:
 	// 0   1-2   3
 	//     5-6
 	//     9-10
 	// 12 13-14 15
 	unsigned int expected[] = {
-	    0, 1, 5,
-	    2, 3, 6,
-	    0, 5, 12,
-	    12, 5, 13,
-	    6, 3, 14,
+	    0, 1, 13,
+	    2, 3, 14,
+	    0, 13, 12,
 	    14, 3, 15, // clang-format :-/
 	};
 
 	unsigned int res[36];
 	float error = 0.f;
 
-	assert(meshopt_simplify(res, ib, 36, vb, 16, 16, 18, 1.f, 0, &error) == 18);
+	assert(meshopt_simplify(res, ib, 36, vb, 16, 16, 12, 1.f, 0, &error) == 12);
 	assert(memcmp(res, expected, sizeof(expected)) == 0);
-	assert(fabsf(error - 0.04f) < 0.01f); // note: the error is not zero because there is a small difference in height between the seam vertices
+	assert(fabsf(error - 0.09f) < 0.01f); // note: the error is not zero because there is a difference in height between the seam vertices
 
 	float aw = 1;
-	assert(meshopt_simplifyWithAttributes(res, ib, 36, vb, 16, 16, vb + 3, 16, &aw, 1, NULL, 18, 2.f, 0, &error) == 18);
+	assert(meshopt_simplifyWithAttributes(res, ib, 36, vb, 16, 16, vb + 3, 16, &aw, 1, NULL, 12, 2.f, 0, &error) == 12);
 	assert(memcmp(res, expected, sizeof(expected)) == 0);
-	assert(fabsf(error - 0.04f) < 0.01f); // note: this is the same error as above because the attribute is constant on either side of the seam
+	assert(fabsf(error - 0.09f) < 0.01f); // note: this is the same error as above because the attribute is constant on either side of the seam
 }
 
 static void simplifySeamFake()

--- a/demo/tests.cpp
+++ b/demo/tests.cpp
@@ -1418,6 +1418,24 @@ static void simplifySeam()
 	assert(fabsf(error - 0.04f) < 0.01f); // note: this is the same error as above because the attribute is constant on either side of the seam
 }
 
+static void simplifySeamFake()
+{
+	// xyz+attr
+	float vb[] = {
+	    0, 0, 0, 0,
+	    1, 0, 0, 1,
+	    1, 0, 0, 2,
+	    0, 0, 0, 3, // clang-format :-/
+	};
+
+	unsigned int ib[] = {
+	    0, 1, 2,
+	    2, 1, 3, // clang-format :-/
+	};
+
+	assert(meshopt_simplify(ib, ib, 6, vb, 4, 16, 0, 1.f, 0, NULL) == 6);
+}
+
 static void adjacency()
 {
 	// 0 1/4
@@ -1673,6 +1691,7 @@ void runTests()
 	simplifySparse();
 	simplifyErrorAbsolute();
 	simplifySeam();
+	simplifySeamFake();
 
 	adjacency();
 	tessellation();

--- a/src/simplifier.cpp
+++ b/src/simplifier.cpp
@@ -407,7 +407,7 @@ static void classifyVertices(unsigned char* result, unsigned int* loop, unsigned
 				if (openiv != ~0u && openiv != i && openov != ~0u && openov != i &&
 				    openiw != ~0u && openiw != w && openow != ~0u && openow != w)
 				{
-					if (remap[openiv] == remap[openow] && remap[openov] == remap[openiw])
+					if (remap[openiv] == remap[openow] && remap[openov] == remap[openiw] && remap[openiv] != remap[openov])
 					{
 						result[i] = Kind_Seam;
 					}

--- a/src/simplifier.cpp
+++ b/src/simplifier.cpp
@@ -1276,13 +1276,19 @@ static void remapEdgeLoops(unsigned int* loop, size_t vertex_count, const unsign
 {
 	for (size_t i = 0; i < vertex_count; ++i)
 	{
+		// note: this is a no-op for vertices that were remapped
+		// ideally we would clear the loop entries for those for consistency, even though they aren't going to be used
+		// however, the remapping process needs loop information for remapped vertices, so this would require a separate pass
 		if (loop[i] != ~0u)
 		{
 			unsigned int l = loop[i];
 			unsigned int r = collapse_remap[l];
 
 			// i == r is a special case when the seam edge is collapsed in a direction opposite to where loop goes
-			loop[i] = (i == r) ? loop[l] : r;
+			if (i == r)
+				loop[i] = (loop[l] != ~0u) ? collapse_remap[loop[l]] : ~0u;
+			else
+				loop[i] = r;
 		}
 	}
 }

--- a/src/simplifier.cpp
+++ b/src/simplifier.cpp
@@ -288,7 +288,7 @@ enum VertexKind
 };
 
 // manifold vertices can collapse onto anything
-// border/seam vertices can only be collapsed onto border/seam respectively
+// border/seam vertices can collapse onto border/seam respectively, or locked
 // complex vertices can collapse onto complex/locked
 // a rule of thumb is that collapsing kind A into kind B preserves the kind B in the target vertex
 // for example, while we could collapse Complex into Manifold, this would mean the target vertex isn't Manifold anymore

--- a/src/simplifier.cpp
+++ b/src/simplifier.cpp
@@ -1202,6 +1202,9 @@ static size_t performEdgeCollapses(unsigned int* collapse_remap, unsigned char* 
 				assert(s0 != i0 && wedge[s0] == i0);
 				assert(s1 != ~0u && remap[s1] == r1);
 
+				// note: this should never happen due to the assertion above, but when disabled if we ever hit this case we'll get a memory safety issue; for now play it safe
+				s1 = s1 != ~0u ? s1 : wedge[i1];
+
 				quadricAdd(attribute_quadrics[s1], attribute_quadrics[s0]);
 				quadricAdd(&attribute_gradients[s1 * attribute_count], &attribute_gradients[s0 * attribute_count], attribute_count);
 			}
@@ -1230,6 +1233,9 @@ static size_t performEdgeCollapses(unsigned int* collapse_remap, unsigned char* 
 			assert(kind != vertex_kind[i1] || s1 == wedge[i1]);
 			assert(loop[i0] == i1 || loopback[i0] == i1);
 			assert(loop[s0] == s1 || loopback[s0] == s1);
+
+			// note: this should never happen due to the assertion above, but when disabled if we ever hit this case we'll get a memory safety issue; for now play it safe
+			s1 = s1 != ~0u ? s1 : wedge[i1];
 
 			collapse_remap[i0] = i1;
 			collapse_remap[s0] = s1;

--- a/src/simplifier.cpp
+++ b/src/simplifier.cpp
@@ -1186,6 +1186,25 @@ static size_t performEdgeCollapses(unsigned int* collapse_remap, unsigned char* 
 		assert(collapse_remap[r0] == r0);
 		assert(collapse_remap[r1] == r1);
 
+		unsigned int sx = i1;
+
+		// for seam collapses we need to move the seam pair together; this is a bit tricky to compute since we need to rely on edge loops as target vertex may be locked (and thus have more than two wedges)
+		if (kind == Kind_Seam)
+		{
+			unsigned int s0 = wedge[i0];
+			unsigned int s1 = loop[i0] == i1 ? loopback[s0] : loop[s0];
+			assert(s0 != i0 && wedge[s0] == i0);
+			assert(s1 != ~0u && remap[s1] == r1);
+
+			// additional asserts to verify that the seam pair is consistent
+			assert(kind != vertex_kind[i1] || s1 == wedge[i1]);
+			assert(loop[i0] == i1 || loopback[i0] == i1);
+			assert(loop[s0] == s1 || loopback[s0] == s1);
+
+			// note: this should never happen due to the assertion above, but when disabled if we ever hit this case we'll get a memory safety issue; for now play it safe
+			sx = (s1 != ~0u) ? s1 : wedge[i1];
+		}
+
 		quadricAdd(vertex_quadrics[r1], vertex_quadrics[r0]);
 
 		if (attribute_count)
@@ -1197,13 +1216,7 @@ static size_t performEdgeCollapses(unsigned int* collapse_remap, unsigned char* 
 			if (kind == Kind_Seam)
 			{
 				// seam collapses involve two edges so we need to update attribute quadrics for both target vertices; position quadrics are shared
-				unsigned int s0 = wedge[i0];
-				unsigned int s1 = loop[i0] == i1 ? loopback[s0] : loop[s0];
-				assert(s0 != i0 && wedge[s0] == i0);
-				assert(s1 != ~0u && remap[s1] == r1);
-
-				// note: this should never happen due to the assertion above, but when disabled if we ever hit this case we'll get a memory safety issue; for now play it safe
-				s1 = s1 != ~0u ? s1 : wedge[i1];
+				unsigned int s0 = wedge[i0], s1 = sx;
 
 				quadricAdd(attribute_quadrics[s1], attribute_quadrics[s0]);
 				quadricAdd(&attribute_gradients[s1 * attribute_count], &attribute_gradients[s0 * attribute_count], attribute_count);
@@ -1224,18 +1237,9 @@ static size_t performEdgeCollapses(unsigned int* collapse_remap, unsigned char* 
 		else if (kind == Kind_Seam)
 		{
 			// remap v0 to v1 and seam pair of v0 to seam pair of v1
-			unsigned int s0 = wedge[i0];
-			unsigned int s1 = loop[i0] == i1 ? loopback[s0] : loop[s0];
+			unsigned int s0 = wedge[i0], s1 = sx;
 			assert(s0 != i0 && wedge[s0] == i0);
-			assert(s1 != ~0u && remap[s1] == r1);
-
-			// additional asserts to verify that the seam pair is consistent
-			assert(kind != vertex_kind[i1] || s1 == wedge[i1]);
-			assert(loop[i0] == i1 || loopback[i0] == i1);
-			assert(loop[s0] == s1 || loopback[s0] == s1);
-
-			// note: this should never happen due to the assertion above, but when disabled if we ever hit this case we'll get a memory safety issue; for now play it safe
-			s1 = s1 != ~0u ? s1 : wedge[i1];
+			assert(remap[s1] == r1);
 
 			collapse_remap[i0] = i1;
 			collapse_remap[s0] = s1;

--- a/tools/simplifyfuzz.cpp
+++ b/tools/simplifyfuzz.cpp
@@ -1,0 +1,38 @@
+#include "../src/meshoptimizer.h"
+
+#include <float.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* buffer, size_t size)
+{
+	if (size == 0)
+		return 0;
+
+	srand(buffer[0]);
+
+	float vb[100][4];
+
+	for (int i = 0; i < 100; ++i)
+	{
+		vb[i][0] = rand() % 10;
+		vb[i][1] = rand() % 10;
+		vb[i][2] = rand() % 10;
+		vb[i][3] = rand() % 10;
+	}
+
+	unsigned int ib[999];
+	int indices = (size - 1) < 999 ? (size - 1) / 3 * 3 : 999;
+
+	for (int i = 0; i < indices; ++i)
+		ib[i] = buffer[1 + i] % 100;
+
+	unsigned int res[999];
+
+	meshopt_simplify(res, ib, indices, vb[0], 100, sizeof(float) * 4, 0, 1e-1f, 0, NULL);
+	meshopt_simplify(res, ib, indices, vb[0], 100, sizeof(float) * 4, 0, FLT_MAX, 0, NULL);
+	meshopt_simplify(res, ib, indices, vb[0], 100, sizeof(float) * 4, 0, FLT_MAX, meshopt_SimplifyLockBorder, NULL);
+	meshopt_simplify(res, ib, indices, vb[0], 100, sizeof(float) * 4, 0, FLT_MAX, meshopt_SimplifySparse, NULL);
+
+	return 0;
+}


### PR DESCRIPTION
While locked vertices can't move by themselves, ideally we should be
able to move any vertex into a locked vertex; currently this is allowed
for manifold but not allowed for border/seam. This artificially limits
the allowed collapses which can lead to larger than necessary result or
worse than necessary error as the simplifier is forced to consider edges
with worse error.

To enable border collapses, we simply need to extend the picking logic;
border-border edges are symmetric so it is enough to validate them in
one direction, but border-locked edges may be forward or backward (as
in, they may align with the topological edge direction or be opposite to
it), so we need to check loop or loopback depending on which vertex is
border.

Seam->locked collapses require special handling to discover seam pair:
a seam-seam edge is bidirectional whereas a seam-locked edge is
unidirectional and may be connected to any wedge out of an arbitrary
count in the locked vertex. Because of this we can't use wedge[] to find
the seam pair anymore, and need to switch to using loop/loopback based
on whether the edge is forward or backward wrt original topology.

This is somewhat risky as it requires loop/loopback to stay valid and
coherent throughout the entire simplification process, whereas
previously bugs here would simply block certain collapses; now it's
theoretically possible to get an out of bounds read if the loop data for
the other wedge points nowhere.

To mitigate this, this code expands validation of this data with more
assertions and adds a fuzzer that tries to discover topology based bugs.
Additionally, there were two bugs in the classification of seam vertices and
in seam edge updates (the later bug by itself could artifically limit
collapses along seam loops in complex meshes) that have been fixed.

The effect of this change depends on the mesh. For smooth meshes with
few seams or borders the impact is minimal; for some meshes with a
reasonable balance of edge types this can result in significant improvements,
e.g. 20% fewer triangles at the same error or 15% smaller error at the same
triangle count for one of the meshes tested.

*This contribution is sponsored by Valve.*