### PR TITLE
Use -Werror in Makefile builds in CI only

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,6 +17,8 @@ jobs:
         os: [{ name: ubuntu, version: ubuntu-latest }, { name: macos-intel, version: macos-13 }, { name: macos-arm, version: macos-14 }]
     name: ${{matrix.os.name}}
     runs-on: ${{matrix.os.version}}
+    env:
+      werror: 1
     steps:
       - uses: actions/checkout@v4
       - name: work around ASLR+ASAN compatibility
@@ -131,6 +133,8 @@ jobs:
 
   gltfpack-basis:
     runs-on: ubuntu-latest
+    env:
+      werror: 1
     steps:
       - uses: actions/checkout@v4
       - uses: actions/checkout@v4

--- a/Makefile
+++ b/Makefile
@@ -19,8 +19,8 @@ OBJECTS=$(LIBRARY_OBJECTS) $(DEMO_OBJECTS) $(GLTFPACK_OBJECTS)
 LIBRARY=$(BUILD)/libmeshoptimizer.a
 DEMO=$(BUILD)/meshoptimizer
 
-CFLAGS=-g -Wall -Wextra -Werror -std=c89
-CXXFLAGS=-g -Wall -Wextra -Wshadow -Wno-missing-field-initializers -Werror -std=gnu++98
+CFLAGS=-g -Wall -Wextra -std=c89
+CXXFLAGS=-g -Wall -Wextra -Wshadow -Wno-missing-field-initializers -std=gnu++98
 LDFLAGS=
 
 $(GLTFPACK_OBJECTS): CXXFLAGS+=-std=c++11
@@ -62,6 +62,11 @@ WASM_SIMPLIFIER_EXPORTS=meshopt_simplify meshopt_simplifyWithAttributes meshopt_
 
 WASM_CLUSTERIZER_SOURCES=src/clusterizer.cpp tools/wasmstubs.cpp
 WASM_CLUSTERIZER_EXPORTS=meshopt_buildMeshletsBound meshopt_buildMeshlets meshopt_computeClusterBounds meshopt_computeMeshletBounds meshopt_optimizeMeshlet sbrk __wasm_call_ctors
+
+ifneq ($(werror),)
+	CFLAGS+=-Werror
+	CXXFLAGS+=-Werror
+endif
 
 ifeq ($(config),iphone)
 	IPHONESDK=/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk

--- a/Makefile
+++ b/Makefile
@@ -150,7 +150,7 @@ $(BUILD)/gltfpack: $(GLTFPACK_OBJECTS) $(LIBRARY)
 gltfpack.wasm: gltf/library.wasm
 
 gltf/library.wasm: $(LIBRARY_SOURCES) $(GLTFPACK_SOURCES)
-	$(WASMCC) $^ -o $@ -Os -DNDEBUG --target=wasm32-wasi --sysroot=$(WASIROOT) -nostartfiles -Wl,--no-entry -Wl,--export=pack -Wl,--export=malloc -Wl,--export=free -Wl,--export=__wasm_call_ctors -Wl,-s -Wl,--allow-undefined-file=gltf/wasistubs.txt
+	$(WASMCC) $^ -o $@ -Wall -Os -DNDEBUG --target=wasm32-wasi --sysroot=$(WASIROOT) -nostartfiles -Wl,--no-entry -Wl,--export=pack -Wl,--export=malloc -Wl,--export=free -Wl,--export=__wasm_call_ctors -Wl,-s -Wl,--allow-undefined-file=gltf/wasistubs.txt
 
 build/decoder_base.wasm: $(WASM_DECODER_SOURCES)
 	@mkdir -p build


### PR DESCRIPTION
Warnings as errors interfere with local development, especially Wunused;
for CMake we already switched to specifying werror separately as an
option in #490, and it's probably time to do this for Makefile as well.