### PR TITLE
demo: Miscellaneous improvements to clustered simplification

### DIFF
--- a/demo/nanite.cpp
+++ b/demo/nanite.cpp
@@ -507,7 +507,12 @@ void nanite(const std::vector<Vertex>& vertices, const std::vector<unsigned int>
 				merged.insert(merged.end(), clusters[groups[i][j]].indices.begin(), clusters[groups[i][j]].indices.end());
 
 			if (dump && depth == atoi(dump))
+			{
+				for (size_t j = 0; j < groups[i].size(); ++j)
+					dumpObj("cluster", clusters[groups[i][j]].indices);
+
 				dumpObj("group", merged);
+			}
 
 			float error = 0.f;
 			std::vector<unsigned int> simplified = simplify(vertices, merged, kUseLocks ? &locks : NULL, kClusterSize * 2 * 3, &error);

--- a/demo/nanite.cpp
+++ b/demo/nanite.cpp
@@ -567,11 +567,16 @@ void nanite(const std::vector<Vertex>& vertices, const std::vector<unsigned int>
 		pending.insert(pending.end(), retry.begin(), retry.end());
 	}
 
+	size_t total_triangles = 0;
 	size_t lowest_triangles = 0;
 	for (size_t i = 0; i < clusters.size(); ++i)
+	{
+		total_triangles += clusters[i].indices.size() / 3;
 		if (clusters[i].parent.error == FLT_MAX)
 			lowest_triangles += clusters[i].indices.size() / 3;
+	}
 
+	printf("total: %d triangles in %d clusters\n", int(total_triangles), int(clusters.size()));
 	printf("lowest lod: %d triangles\n", int(lowest_triangles));
 
 	// for testing purposes, we can compute a DAG cut from a given viewpoint and dump it as an OBJ

--- a/demo/nanite.cpp
+++ b/demo/nanite.cpp
@@ -279,8 +279,7 @@ static std::vector<Cluster> clusterize(const std::vector<Vertex>& vertices, cons
 static std::vector<std::vector<int> > partitionMetis(const std::vector<Cluster>& clusters, const std::vector<int>& pending, const std::vector<unsigned int>& remap)
 {
 	std::vector<std::vector<int> > result;
-
-	std::map<std::pair<int, int>, std::vector<int> > edges;
+	std::vector<std::vector<int> > vertices(remap.size());
 
 	for (size_t i = 0; i < pending.size(); ++i)
 	{
@@ -288,10 +287,9 @@ static std::vector<std::vector<int> > partitionMetis(const std::vector<Cluster>&
 
 		for (size_t j = 0; j < cluster.indices.size(); ++j)
 		{
-			int v0 = remap[cluster.indices[j + 0]];
-			int v1 = remap[cluster.indices[j + (j % 3 == 2 ? -2 : 1)]];
+			int v = remap[cluster.indices[j]];
 
-			std::vector<int>& list = edges[std::make_pair(std::min(v0, v1), std::max(v0, v1))];
+			std::vector<int>& list = vertices[v];
 			if (list.empty() || list.back() != int(i))
 				list.push_back(int(i));
 		}
@@ -299,9 +297,9 @@ static std::vector<std::vector<int> > partitionMetis(const std::vector<Cluster>&
 
 	std::map<std::pair<int, int>, int> adjacency;
 
-	for (std::map<std::pair<int, int>, std::vector<int> >::iterator it = edges.begin(); it != edges.end(); ++it)
+	for (size_t v = 0; v < vertices.size(); ++v)
 	{
-		const std::vector<int>& list = it->second;
+		const std::vector<int>& list = vertices[v];
 
 		for (size_t i = 0; i < list.size(); ++i)
 			for (size_t j = i + 1; j < list.size(); ++j)


### PR DESCRIPTION
This change mainly reworks cluster boundary locking to use explicit lock flags and reworks DAG build a little bit to allow for customizable group size with more careful checks. In addition, partitioning code is now correctly taking into account vertices with the same position, which strengthens adjacency between neighboring clusters, and switches to vertex adjacency for simplicity.

The larger group size allows much more freedom, as METIS would more often generate at least partially connected groups with a larger size (I also wanted to investigate recursive partitioning instead of k-way partitioning but since the goal isn't really to maximize METIS quality this is probably good enough for now). Together with more precise boundary detection, we can now get cliffs.obj (2M triangles) all the way down to a single 3-cluster (383 triangle) group when using METIS=1 configuration:

![Screenshot from 2024-10-01 20-23-45](https://github.com/user-attachments/assets/2548e452-0394-4227-9c34-eef4be07d726)
![Screenshot from 2024-10-01 20-23-50](https://github.com/user-attachments/assets/92a5c9b4-f645-4fad-9c0d-ff7af2c0d236)

Using METIS=2 is actually worse here, as although it generates smaller final result (255 triangles), the tree is much deeper (depth 26 instead of depth 16) and the clusters are ~90% filled on average. UE5 targets a slightly more conservative cluster size (usually I get ~126 triangles per cluster there) which I assume allows METIS a little bit more headroom to make mistakes with suboptimal cluster splits during a recursive bisection, something to try another time.

Note that `meshopt_simplifyWithAttributes` will currently only lock a vertex if *all* copies of the vertex with the same position are locked; if only some of them are locked and some aren't, locking isn't guaranteed to happen because only one of the vertices will be used for reference. The ideal interface contract is not fully clear to me here (eg in presence of `meshopt_SimplifySparse` flag we can't look at *all* copies), but it would probably be better if it was enough to lock any copy referenced by the index buffer... this change does not address this as it's easy enough to lock all copies on the boundary simultaneously.

*This contribution is sponsored by Valve.*