### PR TITLE
simplify: Improve vertex_lock handling in presence of seams

### DIFF
--- a/src/simplifier.cpp
+++ b/src/simplifier.cpp
@@ -369,12 +369,7 @@ static void classifyVertices(unsigned char* result, unsigned int* loop, unsigned
 	{
 		if (remap[i] == i)
 		{
-			if (vertex_lock && vertex_lock[sparse_remap ? sparse_remap[i] : i])
-			{
-				// vertex is explicitly locked
-				result[i] = Kind_Locked;
-			}
-			else if (wedge[i] == i)
+			if (wedge[i] == i)
 			{
 				// no attribute seam, need to check if it's manifold
 				unsigned int openi = openinc[i], openo = openout[i];
@@ -436,6 +431,18 @@ static void classifyVertices(unsigned char* result, unsigned int* loop, unsigned
 
 			result[i] = result[remap[i]];
 		}
+	}
+
+	if (vertex_lock)
+	{
+		// vertex_lock may lock any wedge, not just the primary vertex, so we need to lock the primary vertex and relock any wedges
+		for (size_t i = 0; i < vertex_count; ++i)
+			if (vertex_lock[sparse_remap ? sparse_remap[i] : i])
+				result[remap[i]] = Kind_Locked;
+
+		for (size_t i = 0; i < vertex_count; ++i)
+			if (result[remap[i]] == Kind_Locked)
+				result[i] = Kind_Locked;
 	}
 
 	if (options & meshopt_SimplifyLockBorder)


### PR DESCRIPTION
In the previous implementation from #601, we would only read `vertex_lock`
data for the primary vertex (the vertex with the smallest index among those
with the same position). When using sparse mode, this would be the first
vertex referenced by the index buffer due to how the sparse remap works.

If the input locks were inconsistent between all copies, there could be
a situation where a vertex with the wrong index was asked to be locked,
and the vertex would still be not-locked and could move. When *not*
using sparse mode, this was particularly problematic as the flags would
be read from the vertex that might not be referenced by the index buffer
at all.

We now propagate the locked status into the primary vertex in a separate
pass; this requires re-locking the wedges in a separate pass, but all of
this is very quick especially when using sparse mode. Locking any vertex
copy is now thus sufficient to lock the vertex (when using sparse mode,
locking any copy referenced by the index buffer is sufficient; by design,
sparse mode ignores any data from vertices that aren't referenced by
the index buffer).

*This contribution is sponsored by Valve.*