### PR TITLE
demo: Improve boundsError to take camera parameters into account

### DIFF
--- a/demo/main.cpp
+++ b/demo/main.cpp
@@ -197,7 +197,7 @@ void dumpObj(const std::vector<Vertex>& vertices, const std::vector<unsigned int
 	{
 		unsigned int a = indices[i], b = indices[i + 1], c = indices[i + 2];
 
-		fprintf(stderr, "f %d %d %d\n", a + 1, b + 1, c + 1);
+		fprintf(stderr, "f %d//%d %d//%d %d//%d\n", a + 1, a + 1, b + 1, b + 1, c + 1, c + 1);
 	}
 }
 
@@ -209,7 +209,7 @@ void dumpObj(const char* section, const std::vector<unsigned int>& indices)
 	{
 		unsigned int a = indices[j], b = indices[j + 1], c = indices[j + 2];
 
-		fprintf(stderr, "f %d %d %d\n", a + 1, b + 1, c + 1);
+		fprintf(stderr, "f %d//%d %d//%d %d//%d\n", a + 1, a + 1, b + 1, b + 1, c + 1, c + 1);
 	}
 }
 

--- a/demo/nanite.cpp
+++ b/demo/nanite.cpp
@@ -53,6 +53,7 @@ struct Cluster
 const size_t kClusterSize = 128;
 const size_t kGroupSize = 8;
 const bool kUseLocks = true;
+const bool kUseNormals = true;
 
 static LODBounds bounds(const std::vector<Vertex>& vertices, const std::vector<unsigned int>& indices, float error)
 {
@@ -430,7 +431,10 @@ static std::vector<unsigned int> simplify(const std::vector<Vertex>& vertices, c
 
 	std::vector<unsigned int> lod(indices.size());
 	unsigned int options = meshopt_SimplifySparse | meshopt_SimplifyErrorAbsolute;
-	if (locks)
+	float normal_weights[3] = {0.5f, 0.5f, 0.5f};
+	if (kUseNormals)
+		lod.resize(meshopt_simplifyWithAttributes(&lod[0], &indices[0], indices.size(), &vertices[0].px, vertices.size(), sizeof(Vertex), &vertices[0].nx, sizeof(Vertex), normal_weights, 3, locks ? &(*locks)[0] : NULL, target_count, FLT_MAX, options, error));
+	else if (locks)
 		lod.resize(meshopt_simplifyWithAttributes(&lod[0], &indices[0], indices.size(), &vertices[0].px, vertices.size(), sizeof(Vertex), NULL, 0, NULL, 0, &(*locks)[0], target_count, FLT_MAX, options, error));
 	else
 		lod.resize(meshopt_simplify(&lod[0], &indices[0], indices.size(), &vertices[0].px, vertices.size(), sizeof(Vertex), target_count, FLT_MAX, options | meshopt_SimplifyLockBorder, error));


### PR DESCRIPTION
While boundsError is an approximation and the precise version would compute the projected sphere bounds taking into account perspective distortion and near plane clipping, our simpler variant can work as well and is invariant to camera rotation which is a nice property in certain cases; for example in VR you might want to compute LOD based on a "third" eye, a center camera, so that the geometry is in sync between two eyes.

Our boundsError implementation was mostly serviceable but did not depend on camera field of view and had some potential issues with monotonicity for cases where the camera position was inside the sphere.

We now clip the distance to znear and properly scale it so that the result is a normalized screen space error (0..1, multiply by screen height to get pixels). This ensures that if the bounds.error is 0, boundsError will return 0 even if the camera is inside, which should ensure proper cluster selection for extreme closeups.

*This contribution is sponsored by Valve.*