### PR TITLE
gltfpack: Accelerate deduplication pass for scenes with a lot of primitives

### DIFF
--- a/gltf/gltfpack.cpp
+++ b/gltf/gltfpack.cpp
@@ -2,7 +2,7 @@
 #include "gltfpack.h"
 
 #include <algorithm>
-#include <map>
+#include <unordered_map>
 
 #include <locale.h>
 #include <stdint.h>
@@ -329,6 +329,18 @@ static bool isExtensionSupported(const ExtensionInfo* extensions, size_t count, 
 	return false;
 }
 
+namespace std
+{
+template <>
+struct hash<std::pair<uint64_t, uint64_t> >
+{
+	size_t operator()(const std::pair<uint64_t, uint64_t>& x) const
+	{
+		return std::hash<uint64_t>()(x.first ^ x.second);
+	}
+};
+} // namespace std
+
 static void process(cgltf_data* data, const char* input_path, const char* output_path, const char* report_path, std::vector<Mesh>& meshes, std::vector<Animation>& animations, const Settings& settings, std::string& json, std::string& bin, std::string& fallback, size_t& fallback_size)
 {
 	if (settings.verbose)
@@ -565,7 +577,7 @@ static void process(cgltf_data* data, const char* input_path, const char* output
 		ext_texture_transform = ext_texture_transform || mi.uses_texture_transform;
 	}
 
-	std::map<std::pair<uint64_t, uint64_t>, std::pair<size_t, size_t> > primitive_cache;
+	std::unordered_map<std::pair<uint64_t, uint64_t>, std::pair<size_t, size_t> > primitive_cache;
 
 	for (size_t i = 0; i < meshes.size(); ++i)
 	{

--- a/gltf/mesh.cpp
+++ b/gltf/mesh.cpp
@@ -780,7 +780,7 @@ static void simplifyMesh(Mesh& mesh, float threshold, float error, bool attribut
 
 	size_t vertex_count = mesh.streams[0].data.size();
 
-	size_t target_index_count = size_t(double(mesh.indices.size() / 3) * threshold) * 3;
+	size_t target_index_count = size_t(double(size_t(mesh.indices.size() / 3)) * threshold) * 3;
 	float target_error = error;
 	float target_error_aggressive = 1e-1f;
 

--- a/gltf/mesh.cpp
+++ b/gltf/mesh.cpp
@@ -408,6 +408,16 @@ void dedupMeshes(std::vector<Mesh>& meshes)
 			mesh.instances.clear();
 		}
 	}
+
+	for (size_t i = 0; i < meshes.size(); ++i)
+	{
+		Mesh& target = meshes[i];
+		if (target.nodes.size() <= 1)
+			continue;
+
+		std::sort(target.nodes.begin(), target.nodes.end());
+		target.nodes.erase(std::unique(target.nodes.begin(), target.nodes.end()), target.nodes.end());
+	}
 }
 
 void mergeMeshInstances(Mesh& mesh)

--- a/gltf/mesh.cpp
+++ b/gltf/mesh.cpp
@@ -2,6 +2,7 @@
 #include "gltfpack.h"
 
 #include <algorithm>
+#include <unordered_map>
 
 #include <math.h>
 #include <stdint.h>
@@ -355,14 +356,24 @@ static bool canDedupMesh(const Mesh& mesh)
 
 void dedupMeshes(std::vector<Mesh>& meshes)
 {
+	std::unordered_map<uint64_t, int> hashes;
+
 	for (size_t i = 0; i < meshes.size(); ++i)
-		hashMesh(meshes[i]);
+	{
+		Mesh& mesh = meshes[i];
+
+		hashMesh(mesh);
+		hashes[mesh.geometry_hash[0] ^ mesh.geometry_hash[1]]++;
+	}
 
 	for (size_t i = 0; i < meshes.size(); ++i)
 	{
 		Mesh& target = meshes[i];
 
 		if (!canDedupMesh(target))
+			continue;
+
+		if (hashes[target.geometry_hash[0] ^ target.geometry_hash[1]] <= 1)
 			continue;
 
 		for (size_t j = i + 1; j < meshes.size(); ++j)


### PR DESCRIPTION
While on most scenes our strategy performs reasonably well, and we
already have some potential N^2 processing elsewhere, there are cases
where the existing N^2 algorithms in the pipeline are actually
semi-linear, because mesh merging lazily and effectively aggregates most
meshes; since deduplication is the first pass, it may actually be
quadratic in the face of a scene with a lot of meshes.

A simple fix is to track the number of occurences of each hash and only
search for duplicates for meshes where this value is >1. We could of
course implement more involved tracking but for now this works just
fine.

We also now prune the node list to avoid accidental duplicate attachments,
as it confuses the logic downstream in the pipeline.