### PR TITLE
js: Fix vertex_lock support for simplifyWithAttributes

### DIFF
--- a/js/meshopt_simplifier.js
+++ b/js/meshopt_simplifier.js
@@ -278,7 +278,8 @@ var MeshoptSimplifier = (function () {
 			assert(vertex_attributes instanceof Float32Array);
 			assert(vertex_attributes.length % vertex_attributes_stride == 0);
 			assert(vertex_attributes_stride >= 0);
-			assert(vertex_lock == null || vertex_lock.length == vertex_positions.length);
+			assert(vertex_lock == null || vertex_lock instanceof Uint8Array);
+			assert(vertex_lock == null || vertex_lock.length == vertex_positions.length / vertex_positions_stride);
 			assert(target_index_count >= 0 && target_index_count <= indices.length);
 			assert(target_index_count % 3 == 0);
 			assert(target_error >= 0);

--- a/js/meshopt_simplifier.module.d.ts
+++ b/js/meshopt_simplifier.module.d.ts
@@ -27,7 +27,7 @@ export const MeshoptSimplifier: {
 		vertex_attributes: Float32Array,
 		vertex_attributes_stride: number,
 		attribute_weights: number[],
-		vertex_lock: boolean[] | null,
+		vertex_lock: Uint8Array | null,
 		target_index_count: number,
 		target_error: number,
 		flags?: Flags[]

--- a/js/meshopt_simplifier.module.js
+++ b/js/meshopt_simplifier.module.js
@@ -277,7 +277,8 @@ var MeshoptSimplifier = (function () {
 			assert(vertex_attributes instanceof Float32Array);
 			assert(vertex_attributes.length % vertex_attributes_stride == 0);
 			assert(vertex_attributes_stride >= 0);
-			assert(vertex_lock == null || vertex_lock.length == vertex_positions.length);
+			assert(vertex_lock == null || vertex_lock instanceof Uint8Array);
+			assert(vertex_lock == null || vertex_lock.length == vertex_positions.length / vertex_positions_stride);
 			assert(target_index_count >= 0 && target_index_count <= indices.length);
 			assert(target_index_count % 3 == 0);
 			assert(target_error >= 0);

--- a/js/meshopt_simplifier.test.js
+++ b/js/meshopt_simplifier.test.js
@@ -114,6 +114,23 @@ var tests = {
 		assert.deepEqual(res[0], expected);
 	},
 
+	simplifyLockFlags: function () {
+		// 0
+		// 1 2
+		// 3 4 5
+		var indices = new Uint32Array([0, 2, 1, 1, 2, 3, 3, 2, 4, 2, 5, 4]);
+
+		var positions = new Float32Array([0, 2, 0, 0, 1, 0, 1, 1, 0, 0, 0, 0, 1, 0, 0, 2, 0, 0]);
+		var locks = new Uint8Array([1, 1, 1, 1, 0, 1]); // only vertex 4 can move
+
+		var res = simplifier.simplifyWithAttributes(indices, positions, 3, new Float32Array(), 1, [], locks, 3, 0.01);
+
+		var expected = new Uint32Array([0, 2, 1, 1, 2, 3, 2, 5, 3]);
+
+		assert.deepEqual(res[0], expected);
+		assert.equal(res[1], 0); // error
+	},
+
 	getScale: function () {
 		var positions = new Float32Array([0, 0, 0, 1, 0, 0, 0, 2, 0, 0, 0, 3]);
 


### PR DESCRIPTION
This code never worked if an actual array was passed in as it required an element per float instead of an element per vertex.

Since we need to change this anyway, change the interface to accept Uint8Array instead of a boolean array. This is more consistent with other parameters and allows an upgrade path if the C interface changes from "lock flags" to just "flags".