### PR TITLE
gltfpack: Allow per-texture-class control for texture scaling

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -100,7 +100,7 @@ jobs:
           curl -sL $VALIDATOR | tar xJ
           find glTF-Sample-Assets -name '*.gltfpack.gltf' | xargs -P 2 -L 1 -d '\n' ./gltf_validator -r -a
         env:
-          VALIDATOR: https://github.com/KhronosGroup/glTF-Validator/releases/download/2.0.0-dev.3.8/gltf_validator-2.0.0-dev.3.8-linux64.tar.xz
+          VALIDATOR: https://github.com/KhronosGroup/glTF-Validator/releases/download/2.0.0-dev.3.10/gltf_validator-2.0.0-dev.3.10-linux64.tar.xz
 
   gltfpack-js:
     runs-on: ubuntu-latest
@@ -173,7 +173,7 @@ jobs:
           ./gltfpack -test glTF-Sample-Assets/Models/BoxTextured/glTF/BoxTextured.gltf -vpf -vtf -c
           ./gltfpack -test glTF-Sample-Assets/Models/BoxTextured/glTF/BoxTextured.gltf -vpf -vtf -cc
           ./gltfpack -test glTF-Sample-Assets/Models/BoxTextured/glTF/BoxTextured.gltf -tc
-          ./gltfpack -test glTF-Sample-Assets/Models/BoxTextured/glTF/BoxTextured.gltf -tc -tq color 10 -tu normal,attrib
+          ./gltfpack -test glTF-Sample-Assets/Models/BoxTextured/glTF/BoxTextured.gltf -tc -tq color 10 -tu normal,attrib -ts attrib 0.5
           ./gltfpack -test glTF-Sample-Assets/Models/BoxTextured/glTF/BoxTextured.gltf -tr
           ./gltfpack -test glTF-Sample-Assets/Models/BoxTextured/glTF/BoxTextured.gltf -tc -ts 0.5 -tl 64
           ./gltfpack -test glTF-Sample-Assets/Models/CesiumMan/glTF/CesiumMan.gltf -tu -ts 0.6 -tp

--- a/gltf/basisenc.cpp
+++ b/gltf/basisenc.cpp
@@ -114,7 +114,7 @@ static const char* prepareEncode(basisu::basis_compressor_params& params, const 
 	if (!getDimensions(img_data, mime_type.c_str(), width, height))
 		return "error parsing image header";
 
-	adjustDimensions(width, height, settings);
+	adjustDimensions(width, height, settings.texture_scale[info.kind], settings.texture_limit, settings.texture_pow2);
 
 	temp_input = temp_prefix + mimeExtension(mime_type.c_str());
 	temp_output = temp_prefix + ".ktx2";

--- a/gltf/gltfpack.cpp
+++ b/gltf/gltfpack.cpp
@@ -1201,9 +1201,13 @@ Settings defaults()
 	settings.mesh_dedup = true;
 	settings.simplify_ratio = 1.f;
 	settings.simplify_error = 1e-2f;
-	settings.texture_scale = 1.f;
+
 	for (int kind = 0; kind < TextureKind__Count; ++kind)
+	{
+		settings.texture_mode[kind] = TextureMode_Raw;
+		settings.texture_scale[kind] = 1.f;
 		settings.texture_quality[kind] = 8;
+	}
 
 	return settings;
 }
@@ -1420,7 +1424,18 @@ int main(int argc, char** argv)
 		}
 		else if (strcmp(arg, "-ts") == 0 && i + 1 < argc && isdigit(argv[i + 1][0]))
 		{
-			settings.texture_scale = clamp(float(atof(argv[++i])), 0.f, 1.f);
+			float scale = clamp(float(atof(argv[++i])), 0.f, 1.f);
+			for (int kind = 0; kind < TextureKind__Count; ++kind)
+				settings.texture_scale[kind] = scale;
+		}
+		else if (strcmp(arg, "-ts") == 0 && i + 2 < argc && isalpha(argv[i + 1][0]) && isdigit(argv[i + 2][0]))
+		{
+			unsigned int mask = textureMask(argv[++i]);
+			float scale = clamp(float(atof(argv[++i])), 0.f, 1.f);
+
+			for (int kind = 0; kind < TextureKind__Count; ++kind)
+				if (mask & (1 << kind))
+					settings.texture_scale[kind] = scale;
 		}
 		else if (strcmp(arg, "-tl") == 0 && i + 1 < argc && isdigit(argv[i + 1][0]))
 		{
@@ -1550,6 +1565,7 @@ int main(int argc, char** argv)
 			fprintf(stderr, "\t-tc C: use ETC1S when encoding textures of class C\n");
 			fprintf(stderr, "\t-tu C: use UASTC when encoding textures of class C\n");
 			fprintf(stderr, "\t-tq C N: set texture encoding quality for class C\n");
+			fprintf(stderr, "\t-ts C R: scale texture dimensions for class C\n");
 			fprintf(stderr, "\t... where C is a comma-separated list (no spaces) with valid values color,normal,attrib\n");
 			fprintf(stderr, "\nSimplification:\n");
 			fprintf(stderr, "\t-si R: simplify meshes targeting triangle/point count ratio R (default: 1; R should be between 0 and 1)\n");
@@ -1615,7 +1631,7 @@ int main(int argc, char** argv)
 		return 1;
 	}
 
-	if (settings.texture_scale < 1 && !settings.texture_ktx2)
+	if (settings.texture_scale[TextureKind_Generic] < 1 && !settings.texture_ktx2)
 	{
 		fprintf(stderr, "Option -ts is only supported when -tc is set as well\n");
 		return 1;

--- a/gltf/gltfpack.cpp
+++ b/gltf/gltfpack.cpp
@@ -1259,6 +1259,7 @@ int main(int argc, char** argv)
 	const char* report = NULL;
 	bool help = false;
 	bool test = false;
+	bool require_ktx2 = false;
 
 	std::vector<const char*> testinputs;
 
@@ -1409,12 +1410,16 @@ int main(int argc, char** argv)
 		}
 		else if (strcmp(arg, "-tq") == 0 && i + 1 < argc && isdigit(argv[i + 1][0]))
 		{
+			require_ktx2 = true;
+
 			int quality = clamp(atoi(argv[++i]), 1, 10);
 			for (int kind = 0; kind < TextureKind__Count; ++kind)
 				settings.texture_quality[kind] = quality;
 		}
 		else if (strcmp(arg, "-tq") == 0 && i + 2 < argc && isalpha(argv[i + 1][0]) && isdigit(argv[i + 2][0]))
 		{
+			require_ktx2 = true;
+
 			unsigned int mask = textureMask(argv[++i]);
 			int quality = clamp(atoi(argv[++i]), 1, 10);
 
@@ -1424,12 +1429,16 @@ int main(int argc, char** argv)
 		}
 		else if (strcmp(arg, "-ts") == 0 && i + 1 < argc && isdigit(argv[i + 1][0]))
 		{
+			require_ktx2 = true;
+
 			float scale = clamp(float(atof(argv[++i])), 0.f, 1.f);
 			for (int kind = 0; kind < TextureKind__Count; ++kind)
 				settings.texture_scale[kind] = scale;
 		}
 		else if (strcmp(arg, "-ts") == 0 && i + 2 < argc && isalpha(argv[i + 1][0]) && isdigit(argv[i + 2][0]))
 		{
+			require_ktx2 = true;
+
 			unsigned int mask = textureMask(argv[++i]);
 			float scale = clamp(float(atof(argv[++i])), 0.f, 1.f);
 
@@ -1439,14 +1448,20 @@ int main(int argc, char** argv)
 		}
 		else if (strcmp(arg, "-tl") == 0 && i + 1 < argc && isdigit(argv[i + 1][0]))
 		{
+			require_ktx2 = true;
+
 			settings.texture_limit = atoi(argv[++i]);
 		}
 		else if (strcmp(arg, "-tp") == 0)
 		{
+			require_ktx2 = true;
+
 			settings.texture_pow2 = true;
 		}
 		else if (strcmp(arg, "-tfy") == 0)
 		{
+			require_ktx2 = true;
+
 			settings.texture_flipy = true;
 		}
 		else if (strcmp(arg, "-tr") == 0)
@@ -1619,33 +1634,15 @@ int main(int argc, char** argv)
 		return 1;
 	}
 
-	if (settings.texture_limit && !settings.texture_ktx2)
-	{
-		fprintf(stderr, "Option -tl is only supported when -tc is set as well\n");
-		return 1;
-	}
-
 	if (settings.texture_pow2 && (settings.texture_limit & (settings.texture_limit - 1)) != 0)
 	{
 		fprintf(stderr, "Option -tp requires the limit specified via -tl to be a power of 2\n");
 		return 1;
 	}
 
-	if (settings.texture_scale[TextureKind_Generic] < 1 && !settings.texture_ktx2)
+	if (require_ktx2 && !settings.texture_ktx2)
 	{
-		fprintf(stderr, "Option -ts is only supported when -tc is set as well\n");
-		return 1;
-	}
-
-	if (settings.texture_pow2 && !settings.texture_ktx2)
-	{
-		fprintf(stderr, "Option -tp is only supported when -tc is set as well\n");
-		return 1;
-	}
-
-	if (settings.texture_flipy && !settings.texture_ktx2)
-	{
-		fprintf(stderr, "Option -tfy is only supported when -tc is set as well\n");
+		fprintf(stderr, "Texture processing is only supported when texture compression is enabled via -tc/-tu\n");
 		return 1;
 	}
 

--- a/gltf/gltfpack.h
+++ b/gltf/gltfpack.h
@@ -153,7 +153,7 @@ struct Settings
 
 	bool texture_pow2;
 	bool texture_flipy;
-	float texture_scale;
+	float texture_scale[TextureKind__Count];
 	int texture_limit;
 
 	TextureMode texture_mode[TextureKind__Count];
@@ -338,7 +338,7 @@ void optimizeMaterials(cgltf_data* data, const char* input_path, std::vector<Ima
 bool readImage(const cgltf_image& image, const char* input_path, std::string& data, std::string& mime_type);
 bool hasAlpha(const std::string& data, const char* mime_type);
 bool getDimensions(const std::string& data, const char* mime_type, int& width, int& height);
-void adjustDimensions(int& width, int& height, const Settings& settings);
+void adjustDimensions(int& width, int& height, float scale, int limit, bool pow2);
 const char* mimeExtension(const char* mime_type);
 
 #ifdef WITH_BASISU

--- a/gltf/image.cpp
+++ b/gltf/image.cpp
@@ -344,21 +344,21 @@ static int roundBlock(int value, bool pow2)
 	return (value + 3) & ~3;
 }
 
-void adjustDimensions(int& width, int& height, const Settings& settings)
+void adjustDimensions(int& width, int& height, float scale, int limit, bool pow2)
 {
-	width = int(width * settings.texture_scale);
-	height = int(height * settings.texture_scale);
+	width = int(width * scale);
+	height = int(height * scale);
 
-	if (settings.texture_limit && (width > settings.texture_limit || height > settings.texture_limit))
+	if (limit && (width > limit || height > limit))
 	{
-		float limit_scale = float(settings.texture_limit) / float(width > height ? width : height);
+		float limit_scale = float(limit) / float(width > height ? width : height);
 
 		width = int(width * limit_scale);
 		height = int(height * limit_scale);
 	}
 
-	width = roundBlock(width, settings.texture_pow2);
-	height = roundBlock(height, settings.texture_pow2);
+	width = roundBlock(width, pow2);
+	height = roundBlock(height, pow2);
 }
 
 const char* mimeExtension(const char* mime_type)


### PR DESCRIPTION
While we expose an ability to specify texture compression settings for each texture class separately, there's a significant quality and size gap between ETC1S and UASTC that doesn't have any middle-ground options.

In some cases, downscaling an UASTC texture looks much better than a full-resolution ETC1S; however, when ETC1S provides sufficient quality, this can in turn reduce the quality visibly.

This change makes it possible to adjust the tradeoff with more granularity by specifying texture scaling per-class; for example,

	gltfpack -tu -tc color -ts attrib 0.75

... will use ETC1S for color textures at full resolution, UASTC for other textures (normal maps and attribute textures), but will further downscale attribute textures (roughness, etc.) to 0.75 x 0.75 of the original resolution (which is around 2x smaller).

