### PR TITLE
simplifier: Evaluate attribute error for both edges for seam collapses

### DIFF
--- a/src/simplifier.cpp
+++ b/src/simplifier.cpp
@@ -1055,11 +1055,15 @@ static void rankEdgeCollapses(Collapse* collapses, size_t collapse_count, const 
 			// note: seam edges need to aggregate attribute errors between primary and secondary edges, as attribute quadrics are separate
 			if (vertex_kind[i0] == Kind_Seam)
 			{
+				// for seam collapses we need to find the seam pair; this is a bit tricky since we need to rely on edge loops as target vertex may be locked (and thus have more than two wedges)
 				unsigned int s0 = wedge[i0];
 				unsigned int s1 = loop[i0] == i1 ? loopback[s0] : loop[s0];
 
 				assert(s0 != i0 && wedge[s0] == i0);
 				assert(s1 != ~0u && remap[s1] == remap[i1]);
+
+				// note: this should never happen due to the assertion above, but when disabled if we ever hit this case we'll get a memory safety issue; for now play it safe
+				s1 = (s1 != ~0u) ? s1 : wedge[i1];
 
 				float se = quadricError(attribute_quadrics[s0], &attribute_gradients[s0 * attribute_count], attribute_count, vertex_positions[s1], &vertex_attributes[s1 * attribute_count]);
 
@@ -1220,7 +1224,7 @@ static size_t performEdgeCollapses(unsigned int* collapse_remap, unsigned char* 
 		}
 		else if (kind == Kind_Seam)
 		{
-			// for seam collapses we need to move the seam pair together; this is a bit tricky to compute since we need to rely on edge loops as target vertex may be locked (and thus have more than two wedges)
+			// for seam collapses we need to move the seam pair together; this is a bit tricky since we need to rely on edge loops as target vertex may be locked (and thus have more than two wedges)
 			unsigned int s0 = wedge[i0];
 			unsigned int s1 = loop[i0] == i1 ? loopback[s0] : loop[s0];
 			assert(s0 != i0 && wedge[s0] == i0);

--- a/src/simplifier.cpp
+++ b/src/simplifier.cpp
@@ -1041,7 +1041,7 @@ static void rankEdgeCollapses(Collapse* collapses, size_t collapse_count, const 
 		unsigned int j1 = c.bidi ? i0 : i1;
 
 		float ei = quadricError(vertex_quadrics[remap[i0]], vertex_positions[i1]);
-		float ej = quadricError(vertex_quadrics[remap[j0]], vertex_positions[j1]);
+		float ej = c.bidi ? quadricError(vertex_quadrics[remap[j0]], vertex_positions[j1]) : FLT_MAX;
 
 #if TRACE >= 3
 		float di = ei, dj = ej;
@@ -1050,7 +1050,7 @@ static void rankEdgeCollapses(Collapse* collapses, size_t collapse_count, const 
 		if (attribute_count)
 		{
 			ei += quadricError(attribute_quadrics[i0], &attribute_gradients[i0 * attribute_count], attribute_count, vertex_positions[i1], &vertex_attributes[i1 * attribute_count]);
-			ej += quadricError(attribute_quadrics[j0], &attribute_gradients[j0 * attribute_count], attribute_count, vertex_positions[j1], &vertex_attributes[j1 * attribute_count]);
+			ej += c.bidi ? quadricError(attribute_quadrics[j0], &attribute_gradients[j0 * attribute_count], attribute_count, vertex_positions[j1], &vertex_attributes[j1 * attribute_count]) : 0;
 
 			// note: seam edges need to aggregate attribute errors between primary and secondary edges, as attribute quadrics are separate
 			if (vertex_kind[i0] == Kind_Seam)
@@ -1065,10 +1065,8 @@ static void rankEdgeCollapses(Collapse* collapses, size_t collapse_count, const 
 				// note: this should never happen due to the assertion above, but when disabled if we ever hit this case we'll get a memory safety issue; for now play it safe
 				s1 = (s1 != ~0u) ? s1 : wedge[i1];
 
-				float se = quadricError(attribute_quadrics[s0], &attribute_gradients[s0 * attribute_count], attribute_count, vertex_positions[s1], &vertex_attributes[s1 * attribute_count]);
-
-				ei += se;
-				ej += c.bidi ? quadricError(attribute_quadrics[s1], &attribute_gradients[s1 * attribute_count], attribute_count, vertex_positions[s0], &vertex_attributes[s0 * attribute_count]) : se;
+				ei += quadricError(attribute_quadrics[s0], &attribute_gradients[s0 * attribute_count], attribute_count, vertex_positions[s1], &vertex_attributes[s1 * attribute_count]);
+				ej += c.bidi ? quadricError(attribute_quadrics[s1], &attribute_gradients[s1 * attribute_count], attribute_count, vertex_positions[s0], &vertex_attributes[s0 * attribute_count]) : 0;
 			}
 		}
 

--- a/src/simplifier.cpp
+++ b/src/simplifier.cpp
@@ -1049,10 +1049,10 @@ static void rankEdgeCollapses(Collapse* collapses, size_t collapse_count, const 
 
 		if (attribute_count)
 		{
-			float ai = quadricError(attribute_quadrics[i0], &attribute_gradients[i0 * attribute_count], attribute_count, vertex_positions[i1], &vertex_attributes[i1 * attribute_count]);
-			float aj = quadricError(attribute_quadrics[j0], &attribute_gradients[j0 * attribute_count], attribute_count, vertex_positions[j1], &vertex_attributes[j1 * attribute_count]);
+			ei += quadricError(attribute_quadrics[i0], &attribute_gradients[i0 * attribute_count], attribute_count, vertex_positions[i1], &vertex_attributes[i1 * attribute_count]);
+			ej += quadricError(attribute_quadrics[j0], &attribute_gradients[j0 * attribute_count], attribute_count, vertex_positions[j1], &vertex_attributes[j1 * attribute_count]);
 
-			// note: seam edges use a maximum of attribute errors between primary and secondary edges, which is necessary to avoid collapses introducing hidden errors
+			// note: seam edges need to aggregate attribute errors between primary and secondary edges, as attribute quadrics are separate
 			if (vertex_kind[i0] == Kind_Seam)
 			{
 				unsigned int s0 = wedge[i0];
@@ -1061,15 +1061,11 @@ static void rankEdgeCollapses(Collapse* collapses, size_t collapse_count, const 
 				assert(s0 != i0 && wedge[s0] == i0);
 				assert(s1 != ~0u && remap[s1] == remap[i1]);
 
-				float si = quadricError(attribute_quadrics[s0], &attribute_gradients[s0 * attribute_count], attribute_count, vertex_positions[s1], &vertex_attributes[s1 * attribute_count]);
-				float sj = c.bidi ? quadricError(attribute_quadrics[s1], &attribute_gradients[s1 * attribute_count], attribute_count, vertex_positions[s0], &vertex_attributes[s0 * attribute_count]) : si;
+				float se = quadricError(attribute_quadrics[s0], &attribute_gradients[s0 * attribute_count], attribute_count, vertex_positions[s1], &vertex_attributes[s1 * attribute_count]);
 
-				ai = ai < si ? si : ai;
-				aj = aj < sj ? sj : aj;
+				ei += se;
+				ej += c.bidi ? quadricError(attribute_quadrics[s1], &attribute_gradients[s1 * attribute_count], attribute_count, vertex_positions[s0], &vertex_attributes[s0 * attribute_count]) : se;
 			}
-
-			ei += ai;
-			ej += aj;
 		}
 
 		// pick edge direction with minimal error

--- a/tools/simplifyfuzz.cpp
+++ b/tools/simplifyfuzz.cpp
@@ -35,5 +35,8 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* buffer, size_t size)
 	meshopt_simplify(res, ib, indices, vb[0], 100, sizeof(float) * 4, 0, FLT_MAX, meshopt_SimplifySparse, NULL);
 	meshopt_simplify(res, ib, indices, vb[0], 100, sizeof(float) * 4, 0, FLT_MAX, meshopt_SimplifyPrune, NULL);
 
+	float aw = 1;
+	meshopt_simplifyWithAttributes(res, ib, indices, vb[0], 100, sizeof(float) * 4, vb[0] + 3, sizeof(float) * 4, &aw, 1, NULL, 0, FLT_MAX, 0, NULL);
+
 	return 0;
 }


### PR DESCRIPTION
When collapsing seam->seam or seam->locked edges, we were assuming that the attribute error on both the primary edge and the seam pair is about the same. There are cases when this is not true; that leads to the collapse with an ostensibly low error significantly changing attribute appearance.

To evaluate the error, we need to use the same logic as we use during perform() to discover the seam pair, and use the accumulated error of the two for the attribute component. The earlier notes in the comments suggested max/avg would be appropriate, but accumulation is actually correct: each error is weighted in proportion to the adjacent triangle areas, and if the seam didn't exist at all, these errors would be naturally accumulated through quadrics accumulation. So even on seams where the edges align in their respective attribute deviation, this change improves the "fairness" of seam collapses as it comes to attribute errors.

This fixes issues like this with normal shading on Bistro (LOD selection exaggerated to a ~16px threshold):

before|after
--|--
![image](https://github.com/user-attachments/assets/bfb60c5e-7ba1-4e0c-830d-076dc8a93b2d) | ![image](https://github.com/user-attachments/assets/97aa834c-5759-40f3-91a6-0f1944de93f3)

Since we evaluate slightly more edges now, this makes simplification of complex models a little slower; on models with few seams, like Buddha, this is neutral on performance; on Bistro it's ~2% slower. This performance delta is mitigated  by skipping reverse evaluations for unidirectional edges, as it doesn't look like this is actually helpful - the reduction in branch misprediction is not worth the extra ALU cost.

*This contribution is sponsored by Valve.*