### PR TITLE
gltfpack: Introduce artificial seam edges on UV flips

### DIFF
--- a/gltf/gltfpack.cpp
+++ b/gltf/gltfpack.cpp
@@ -409,6 +409,9 @@ static void process(cgltf_data* data, const char* input_path, const char* output
 	{
 		const Mesh& mesh = meshes[i];
 
+		if (mesh.type != cgltf_primitive_type_triangles)
+			continue;
+
 		if (settings.simplify_debug > 0)
 		{
 			Mesh kinds = {};

--- a/gltf/mesh.cpp
+++ b/gltf/mesh.cpp
@@ -896,7 +896,7 @@ static void simplifyMesh(Mesh& mesh, float threshold, float error, bool attribut
 		mesh.indices.swap(indices);
 	}
 
-	if (uvremap.size() && mesh.indices.size())
+	if (uvremap.size() && mesh.indices.size() && !debug)
 		meshopt_remapIndexBuffer(&mesh.indices[0], &mesh.indices[0], mesh.indices.size(), &uvremap[0]);
 }
 
@@ -1127,8 +1127,6 @@ void debugSimplify(const Mesh& source, Mesh& kinds, Mesh& loops, float ratio, fl
 	reindexMesh(mesh, quantize_tbn);
 	filterTriangles(mesh);
 
-	size_t vertex_count = mesh.streams[0].data.size();
-
 	simplifyMesh(mesh, ratio, error, attributes, /* aggressive= */ false, /* lock_borders= */ false, /* debug= */ true);
 
 	// color palette for display
@@ -1157,6 +1155,8 @@ void debugSimplify(const Mesh& source, Mesh& kinds, Mesh& loops, float ratio, fl
 			loops.streams.push_back(stream);
 		}
 	}
+
+	size_t vertex_count = mesh.streams[0].data.size();
 
 	// transform kind/loop data into lines & points
 	Stream colors = {cgltf_attribute_type_color};


### PR DESCRIPTION
When two triangles with reverse UV direction meet, an edge between them
needs to be a seam edge. This makes sure that UV does not degrade by
preventing the collapses that go across different UV directions.

Ideally this should be implemented inside meshopt library at some point,
but it requires a separate function and some way to make possibly-manifold
vertices "seam" which may run into issues with the seam handling logic.

So for now, pre-process the mesh by splitting vertices in gltfpack, and
remap triangles with negative UV area to use the newly created vertices.
The number of these vertices is generally low, so it only slightly limits
simplification.

For now we only do this when `-sv` is specified, as it requires analyzing
the attribute values.

Fixes #718 (for gltfpack. In the future I'd like to implement a full solution in the library but it will be tracked internally)