### PR TITLE
vertexcodec: Initial implementation of experimental next version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,6 +88,10 @@ ifeq ($(config),coverage)
 	LDFLAGS+=-coverage
 endif
 
+ifeq ($(config),release-avx512)
+	CXXFLAGS+=-O3 -DNDEBUG -mavx512vl -mavx512vbmi -mavx512vbmi2
+endif
+
 ifeq ($(config),release-scalar)
 	CXXFLAGS+=-O3 -DNDEBUG -DMESHOPTIMIZER_NO_SIMD
 endif

--- a/demo/main.cpp
+++ b/demo/main.cpp
@@ -847,12 +847,56 @@ void encodeVertex(const Mesh& mesh, const char* pvn, bool validate = true)
 
 	size_t csize = compress(vbuf);
 
-	printf("VtxCodec%1s: %.1f bits/vertex (post-deflate %.1f bits/vertex); encode %.2f msec, decode %.2f msec (%.2f GB/s)\n", pvn,
+	printf("VtxCodec%1s%s: %.1f bits/vertex (post-deflate %.1f bits/vertex); encode %.2f msec, decode %.2f msec (%.2f GB/s)\n", pvn,
+	    res == 0 && memcmp(&pv[0], &result[0], pv.size() * sizeof(PV)) == 0 ? "" : "!",
 	    double(vbuf.size() * 8) / double(mesh.vertices.size()),
 	    double(csize * 8) / double(mesh.vertices.size()),
 	    (middle - start) * 1000,
 	    (end - middle) * 1000,
 	    (double(result.size() * sizeof(PV)) / (1 << 30)) / (end - middle));
+}
+
+template <typename PV>
+void benchmarkVertex(const Mesh& mesh, const char* pvn)
+{
+	std::vector<PV> pv(mesh.vertices.size());
+	packMesh(pv, mesh.vertices);
+
+	// allocate result outside of the timing loop to exclude memset() from decode timing
+	std::vector<PV> result(mesh.vertices.size());
+
+	std::vector<unsigned char> vbuf(meshopt_encodeVertexBufferBound(mesh.vertices.size(), sizeof(PV)));
+	vbuf.resize(meshopt_encodeVertexBuffer(&vbuf[0], vbuf.size(), &pv[0], mesh.vertices.size(), sizeof(PV)));
+
+	// warmup
+	meshopt_decodeVertexBuffer(&result[0], mesh.vertices.size(), sizeof(PV), &vbuf[0], vbuf.size());
+
+	for (int run = 0; run < 10; ++run)
+	{
+		double mint = 0;
+		double avgt = 0;
+		double vart = 0;
+
+		for (int i = 0; i < 100; ++i)
+		{
+			double start = timestamp();
+			meshopt_decodeVertexBuffer(&result[0], mesh.vertices.size(), sizeof(PV), &vbuf[0], vbuf.size());
+			double end = timestamp();
+
+			double time = end - start;
+
+			mint = (mint == 0 || time < mint) ? time : mint;
+
+			// Welford variance computation
+			double delta = time - avgt;
+			avgt += delta / (i + 1);
+			vart += delta * (time - avgt);
+		}
+
+		printf("VtxCodec%1s: decode best %.2f msec (%.2f GB/s); avg %.2f +- %.2f msec\n", pvn,
+		    mint * 1000, (double(result.size() * sizeof(PV)) / (1 << 30)) / mint,
+		    avgt * 1000, sqrt(vart / 100) * 1000);
+	}
 }
 
 void stripify(const Mesh& mesh, bool use_restart, char desc)
@@ -1405,6 +1449,11 @@ void processDev(const char* path)
 	encodeVertex<PackedVertex>(copy, "0");
 	meshopt_encodeVertexVersion(0xe);
 	encodeVertex<PackedVertex>(copy, "1", /* validate= */ false);
+	meshopt_encodeVertexVersion(0);
+
+	benchmarkVertex<PackedVertex>(copy, "0");
+	meshopt_encodeVertexVersion(0xe);
+	benchmarkVertex<PackedVertex>(copy, "1");
 }
 
 void processNanite(const char* path)

--- a/demo/tests.cpp
+++ b/demo/tests.cpp
@@ -1965,6 +1965,13 @@ void runTests()
 	decodeVertexLarge();
 	encodeVertexEmpty();
 
+	meshopt_encodeVertexVersion(0xe);
+	decodeVertexBitGroups();
+	decodeVertexBitGroupSentinels();
+	decodeVertexLarge();
+	encodeVertexEmpty();
+	meshopt_encodeVertexVersion(0);
+
 	decodeFilterOct8();
 	decodeFilterOct12();
 	decodeFilterQuat12();

--- a/js/benchmark.js
+++ b/js/benchmark.js
@@ -16,11 +16,15 @@ var tests = {
 		var N = 1024 * 1024;
 		var data = new Uint8Array(N * 16);
 
-		for (var i = 0; i < N * 16; i += 4) {
-			data[i + 0] = 0;
-			data[i + 1] = (i % 16) * 1;
-			data[i + 2] = (i % 16) * 2;
-			data[i + 3] = (i % 16) * 8;
+		var lcg = 1;
+
+		for (var i = 0; i < N * 16; ++i) {
+			// mindstd_rand
+			lcg = (lcg * 48271) % 2147483647;
+
+			var k = i % 16;
+			if (k <= 8) data[i] = lcg & ((1 << k) - 1);
+			else data[i] = i & ((1 << (k - 8)) - 1);
 		}
 
 		var decoded = new Uint8Array(N * 16);

--- a/src/vertexcodec.cpp
+++ b/src/vertexcodec.cpp
@@ -827,13 +827,13 @@ inline const unsigned char* decodeBytesGroupSimd(const unsigned char* data, unsi
 		return data;
 	}
 
-	case 1:
-	case 2:
-	case 5:
+	case 5: // 1-bit
+	case 1: // 2-bit
 	case 6:
+	case 2: // 4-bit
 	case 7:
 	{
-		const unsigned char* skip = data + (hbits < 3 ? (hbits << 2) : (1 << (hbits - 4)));
+		const unsigned char* skip = data + (2 << (hbits < 3 ? hbits : hbits - 5));
 
 		__m128i selb = _mm_loadl_epi64(reinterpret_cast<const __m128i*>(data));
 		__m128i rest = _mm_loadu_si128(reinterpret_cast<const __m128i*>(skip));

--- a/src/vertexcodec.cpp
+++ b/src/vertexcodec.cpp
@@ -151,7 +151,7 @@ struct Stats
 {
 	size_t size;
 	size_t header;  // bytes for header
-	size_t bitg[4]; // bytes for bit groups
+	size_t bitg[9]; // bytes for bit groups
 	size_t bitc[8]; // bit consistency: how many bits are shared between all bytes in a group
 };
 
@@ -284,7 +284,7 @@ static unsigned char* encodeBytes(unsigned char* data, unsigned char* data_end, 
 		last_bits = best_bits;
 
 #if TRACE
-		bytestats->bitg[bitslog2] += best_size;
+		bytestats->bitg[best_bits] += best_size;
 #endif
 	}
 
@@ -1333,11 +1333,12 @@ size_t meshopt_encodeVertexBuffer(unsigned char* buffer, size_t buffer_size, con
 
 		printf("%2d: %7d bytes [%4.1f%%] %.1f bpv", int(k), int(vsk.size), double(vsk.size) / double(total_size) * 100, double(vsk.size) / double(vertex_count) * 8);
 
-		size_t total_k = vsk.header + vsk.bitg[0] + vsk.bitg[1] + vsk.bitg[2] + vsk.bitg[3];
+		size_t total_k = vsk.header + vsk.bitg[1] + vsk.bitg[2] + vsk.bitg[4] + vsk.bitg[8];
 
-		printf(" |\thdr [%5.1f%%] bitg 1-3 [%4.1f%% %4.1f%% %4.1f%%]",
-		    double(vsk.header) / double(total_k) * 100, double(vsk.bitg[1]) / double(total_k) * 100,
-		    double(vsk.bitg[2]) / double(total_k) * 100, double(vsk.bitg[3]) / double(total_k) * 100);
+		printf(" |\thdr [%5.1f%%] bitg [1 %4.1f%% 2 %4.1f%% 4 %4.1f%% %4.1f%%]",
+		    double(vsk.header) / double(total_k) * 100,
+		    double(vsk.bitg[1]) / double(total_k) * 100, double(vsk.bitg[2]) / double(total_k) * 100,
+		    double(vsk.bitg[4]) / double(total_k) * 100, double(vsk.bitg[8]) / double(total_k) * 100);
 
 		printf(" |\tbitc [%3.0f%% %3.0f%% %3.0f%% %3.0f%% %3.0f%% %3.0f%% %3.0f%% %3.0f%%]",
 		    double(vsk.bitc[0]) / double(vertex_count) * 100, double(vsk.bitc[1]) / double(vertex_count) * 100,

--- a/src/vertexcodec.cpp
+++ b/src/vertexcodec.cpp
@@ -646,7 +646,7 @@ static bool gDecodeBytesGroupInitialized = decodeBytesGroupBuildTables();
 
 #ifdef SIMD_SSE
 SIMD_TARGET
-static __m128i decodeShuffleMask(unsigned char mask0, unsigned char mask1)
+inline __m128i decodeShuffleMask(unsigned char mask0, unsigned char mask1)
 {
 	__m128i sm0 = _mm_loadl_epi64(reinterpret_cast<const __m128i*>(&kDecodeBytesGroupShuffle[mask0]));
 	__m128i sm1 = _mm_loadl_epi64(reinterpret_cast<const __m128i*>(&kDecodeBytesGroupShuffle[mask1]));
@@ -812,7 +812,8 @@ static const __m128i decodeBytesGroupConfig[2][8] = {
     },
 };
 
-static const unsigned char* decodeBytesGroupSimd(const unsigned char* data, unsigned char* buffer, int hbits)
+SIMD_TARGET
+inline const unsigned char* decodeBytesGroupSimd(const unsigned char* data, unsigned char* buffer, int hbits)
 {
 	switch (hbits)
 	{
@@ -869,7 +870,8 @@ static const unsigned char* decodeBytesGroupSimd(const unsigned char* data, unsi
 #endif
 
 #ifdef SIMD_NEON
-static uint8x16_t shuffleBytes(unsigned char mask0, unsigned char mask1, uint8x8_t rest0, uint8x8_t rest1)
+SIMD_TARGET
+inline uint8x16_t shuffleBytes(unsigned char mask0, unsigned char mask1, uint8x8_t rest0, uint8x8_t rest1)
 {
 	uint8x8_t sm0 = vld1_u8(kDecodeBytesGroupShuffle[mask0]);
 	uint8x8_t sm1 = vld1_u8(kDecodeBytesGroupShuffle[mask1]);
@@ -880,7 +882,8 @@ static uint8x16_t shuffleBytes(unsigned char mask0, unsigned char mask1, uint8x8
 	return vcombine_u8(r0, r1);
 }
 
-static void neonMoveMask(uint8x16_t mask, unsigned char& mask0, unsigned char& mask1)
+SIMD_TARGET
+inline void neonMoveMask(uint8x16_t mask, unsigned char& mask0, unsigned char& mask1)
 {
 	// magic constant found using z3 SMT assuming mask has 8 groups of 0xff or 0x00
 	const uint64_t magic = 0x000103070f1f3f80ull;
@@ -891,7 +894,8 @@ static void neonMoveMask(uint8x16_t mask, unsigned char& mask0, unsigned char& m
 	mask1 = uint8_t((vgetq_lane_u64(mask2, 1) * magic) >> 56);
 }
 
-static const unsigned char* decodeBytesGroupSimd(const unsigned char* data, unsigned char* buffer, int hbits)
+SIMD_TARGET
+inline const unsigned char* decodeBytesGroupSimd(const unsigned char* data, unsigned char* buffer, int hbits)
 {
 	switch (hbits)
 	{
@@ -1012,7 +1016,7 @@ static const unsigned char* decodeBytesGroupSimd(const unsigned char* data, unsi
 
 #ifdef SIMD_WASM
 SIMD_TARGET
-static v128_t decodeShuffleMask(unsigned char mask0, unsigned char mask1)
+inline v128_t decodeShuffleMask(unsigned char mask0, unsigned char mask1)
 {
 	v128_t sm0 = wasm_v128_load(&kDecodeBytesGroupShuffle[mask0]);
 	v128_t sm1 = wasm_v128_load(&kDecodeBytesGroupShuffle[mask1]);
@@ -1026,7 +1030,7 @@ static v128_t decodeShuffleMask(unsigned char mask0, unsigned char mask1)
 }
 
 SIMD_TARGET
-static void wasmMoveMask(v128_t mask, unsigned char& mask0, unsigned char& mask1)
+inline void wasmMoveMask(v128_t mask, unsigned char& mask0, unsigned char& mask1)
 {
 	// magic constant found using z3 SMT assuming mask has 8 groups of 0xff or 0x00
 	const uint64_t magic = 0x000103070f1f3f80ull;
@@ -1036,7 +1040,7 @@ static void wasmMoveMask(v128_t mask, unsigned char& mask0, unsigned char& mask1
 }
 
 SIMD_TARGET
-static const unsigned char* decodeBytesGroupSimd(const unsigned char* data, unsigned char* buffer, int hbits)
+inline const unsigned char* decodeBytesGroupSimd(const unsigned char* data, unsigned char* buffer, int hbits)
 {
 	switch (hbits)
 	{
@@ -1132,7 +1136,7 @@ static const unsigned char* decodeBytesGroupSimd(const unsigned char* data, unsi
 
 #if defined(SIMD_SSE) || defined(SIMD_AVX)
 SIMD_TARGET
-static void transpose8(__m128i& x0, __m128i& x1, __m128i& x2, __m128i& x3)
+inline void transpose8(__m128i& x0, __m128i& x1, __m128i& x2, __m128i& x3)
 {
 	__m128i t0 = _mm_unpacklo_epi8(x0, x1);
 	__m128i t1 = _mm_unpackhi_epi8(x0, x1);
@@ -1146,7 +1150,7 @@ static void transpose8(__m128i& x0, __m128i& x1, __m128i& x2, __m128i& x3)
 }
 
 SIMD_TARGET
-static __m128i unzigzag8(__m128i v)
+inline __m128i unzigzag8(__m128i v)
 {
 	__m128i xl = _mm_sub_epi8(_mm_setzero_si128(), _mm_and_si128(v, _mm_set1_epi8(1)));
 	__m128i xr = _mm_and_si128(_mm_srli_epi16(v, 1), _mm_set1_epi8(127));
@@ -1156,7 +1160,8 @@ static __m128i unzigzag8(__m128i v)
 #endif
 
 #ifdef SIMD_NEON
-static void transpose8(uint8x16_t& x0, uint8x16_t& x1, uint8x16_t& x2, uint8x16_t& x3)
+SIMD_TARGET
+inline void transpose8(uint8x16_t& x0, uint8x16_t& x1, uint8x16_t& x2, uint8x16_t& x3)
 {
 	uint8x16x2_t t01 = vzipq_u8(x0, x1);
 	uint8x16x2_t t23 = vzipq_u8(x2, x3);
@@ -1170,7 +1175,8 @@ static void transpose8(uint8x16_t& x0, uint8x16_t& x1, uint8x16_t& x2, uint8x16_
 	x3 = vreinterpretq_u8_u16(x23.val[1]);
 }
 
-static uint8x16_t unzigzag8(uint8x16_t v)
+SIMD_TARGET
+inline uint8x16_t unzigzag8(uint8x16_t v)
 {
 	uint8x16_t xl = vreinterpretq_u8_s8(vnegq_s8(vreinterpretq_s8_u8(vandq_u8(v, vdupq_n_u8(1)))));
 	uint8x16_t xr = vshrq_n_u8(v, 1);
@@ -1181,7 +1187,7 @@ static uint8x16_t unzigzag8(uint8x16_t v)
 
 #ifdef SIMD_WASM
 SIMD_TARGET
-static void transpose8(v128_t& x0, v128_t& x1, v128_t& x2, v128_t& x3)
+inline void transpose8(v128_t& x0, v128_t& x1, v128_t& x2, v128_t& x3)
 {
 	v128_t t0 = wasmx_unpacklo_v8x16(x0, x1);
 	v128_t t1 = wasmx_unpackhi_v8x16(x0, x1);
@@ -1195,7 +1201,7 @@ static void transpose8(v128_t& x0, v128_t& x1, v128_t& x2, v128_t& x3)
 }
 
 SIMD_TARGET
-static v128_t unzigzag8(v128_t v)
+inline v128_t unzigzag8(v128_t v)
 {
 	v128_t xl = wasm_i8x16_neg(wasm_v128_and(v, wasm_i8x16_splat(1)));
 	v128_t xr = wasm_u8x16_shr(v, 1);

--- a/src/vertexcodec.cpp
+++ b/src/vertexcodec.cpp
@@ -63,10 +63,10 @@
 // In switch dispatch, marking default case as unreachable allows to remove redundant bounds checks
 #if defined(__GNUC__)
 #define SIMD_UNREACHABLE() __builtin_unreachable()
-#elif defined(__MSC_VER)
-#define SIMD_UNREACHABLE() __assume(0)
+#elif defined(_MSC_VER)
+#define SIMD_UNREACHABLE() __assume(false)
 #else
-#define SIMD_UNREACHABLE() assert(0)
+#define SIMD_UNREACHABLE() assert(!"Unreachable")
 #endif
 
 #endif // !MESHOPTIMIZER_NO_SIMD
@@ -783,7 +783,6 @@ inline const unsigned char* decodeBytesGroupSimd(const unsigned char* data, unsi
 
 	default:
 		SIMD_UNREACHABLE();
-		return data;
 	}
 }
 #endif
@@ -864,7 +863,6 @@ inline const unsigned char* decodeBytesGroupSimd(const unsigned char* data, unsi
 
 	default:
 		SIMD_UNREACHABLE();
-		return data;
 	}
 }
 #endif
@@ -1129,7 +1127,6 @@ inline const unsigned char* decodeBytesGroupSimd(const unsigned char* data, unsi
 
 	default:
 		SIMD_UNREACHABLE();
-		return data;
 	}
 }
 #endif

--- a/src/vertexcodec.cpp
+++ b/src/vertexcodec.cpp
@@ -123,6 +123,7 @@ const size_t kTailMaxSize = 32;
 
 static const int kBitsV0[4] = {0, 2, 4, 8};
 static const int kBitsV1[3][4] = {
+    // first entry must be 0/2/4/8 to match v0
     {0, 2, 4, 8},
     {0, 1, 2, 8},
     {2, 4, 6, 8},
@@ -338,13 +339,11 @@ static unsigned char* encodeVertexBlock(unsigned char* data, unsigned char* data
 	// we sometimes encode elements we didn't fill when rounding to kByteGroupSize
 	memset(buffer, 0, sizeof(buffer));
 
-	unsigned char* control = data;
-
 	size_t control_size = version == 0 ? 0 : vertex_size / 4;
-
 	if (size_t(data_end - data) < control_size)
 		return NULL;
 
+	unsigned char* control = data;
 	data += control_size;
 
 	memset(control, 0, control_size);
@@ -486,18 +485,16 @@ static const unsigned char* decodeBytesGroup(const unsigned char* data, unsigned
 #undef NEXT
 }
 
-static const unsigned char* decodeBytes(const unsigned char* data, const unsigned char* data_end, unsigned char* buffer, size_t buffer_size)
+static const unsigned char* decodeBytes(const unsigned char* data, const unsigned char* data_end, unsigned char* buffer, size_t buffer_size, const int* bits)
 {
 	assert(buffer_size % kByteGroupSize == 0);
 
-	const unsigned char* header = data;
-
 	// round number of groups to 4 to get number of header bytes
 	size_t header_size = (buffer_size / kByteGroupSize + 3) / 4;
-
 	if (size_t(data_end - data) < header_size)
 		return NULL;
 
+	const unsigned char* header = data;
 	data += header_size;
 
 	for (size_t i = 0; i < buffer_size; i += kByteGroupSize)
@@ -507,9 +504,10 @@ static const unsigned char* decodeBytes(const unsigned char* data, const unsigne
 
 		size_t header_offset = i / kByteGroupSize;
 
-		int bitslog2 = (header[header_offset / 4] >> ((header_offset % 4) * 2)) & 3;
+		int bitsk = (header[header_offset / 4] >> ((header_offset % 4) * 2)) & 3;
+		(void)bits;
 
-		data = decodeBytesGroup(data, buffer + i, bitslog2);
+		data = decodeBytesGroup(data, buffer + i, bitsk);
 	}
 
 	return data;
@@ -532,7 +530,7 @@ static void decodeDeltas1(const unsigned char* buffer, unsigned char* transposed
 	}
 }
 
-static const unsigned char* decodeVertexBlock(const unsigned char* data, const unsigned char* data_end, unsigned char* vertex_data, size_t vertex_count, size_t vertex_size, unsigned char last_vertex[256])
+static const unsigned char* decodeVertexBlock(const unsigned char* data, const unsigned char* data_end, unsigned char* vertex_data, size_t vertex_count, size_t vertex_size, unsigned char last_vertex[256], int version)
 {
 	assert(vertex_count > 0 && vertex_count <= kVertexBlockMaxSize);
 
@@ -542,11 +540,32 @@ static const unsigned char* decodeVertexBlock(const unsigned char* data, const u
 	size_t vertex_count_aligned = (vertex_count + kByteGroupSize - 1) & ~(kByteGroupSize - 1);
 	assert(vertex_count <= vertex_count_aligned);
 
+	size_t control_size = version == 0 ? 0 : vertex_size / 4;
+	if (size_t(data_end - data) < control_size)
+		return NULL;
+
+	const unsigned char* control = data;
+	data += control_size;
+
 	for (size_t k = 0; k < vertex_size; ++k)
 	{
-		data = decodeBytes(data, data_end, buffer, vertex_count_aligned);
-		if (!data)
-			return NULL;
+		int ctrl = version == 0 ? 0 : (control[k / 4] >> ((k % 4) * 2)) & 3;
+
+		if (ctrl == 3)
+		{
+			// literal encoding
+			if (size_t(data_end - data) < vertex_count)
+				return NULL;
+
+			memcpy(buffer, data, vertex_count);
+			data += vertex_count;
+		}
+		else
+		{
+			data = decodeBytes(data, data_end, buffer, vertex_count_aligned, kBitsV1[ctrl]);
+			if (!data)
+				return NULL;
+		}
 
 		decodeDeltas1(buffer, transposed + k, vertex_count, vertex_size, last_vertex[k]);
 	}
@@ -1078,14 +1097,12 @@ static const unsigned char* decodeBytesSimd(const unsigned char* data, const uns
 	assert(buffer_size % kByteGroupSize == 0);
 	assert(kByteGroupSize == 16);
 
-	const unsigned char* header = data;
-
 	// round number of groups to 4 to get number of header bytes
 	size_t header_size = (buffer_size / kByteGroupSize + 3) / 4;
-
 	if (size_t(data_end - data) < header_size)
 		return NULL;
 
+	const unsigned char* header = data;
 	data += header_size;
 
 	size_t i = 0;
@@ -1194,9 +1211,12 @@ static void decodeDeltas4Simd(const unsigned char* buffer, unsigned char* transp
 }
 
 SIMD_TARGET
-static const unsigned char* decodeVertexBlockSimd(const unsigned char* data, const unsigned char* data_end, unsigned char* vertex_data, size_t vertex_count, size_t vertex_size, unsigned char last_vertex[256])
+static const unsigned char* decodeVertexBlockSimd(const unsigned char* data, const unsigned char* data_end, unsigned char* vertex_data, size_t vertex_count, size_t vertex_size, unsigned char last_vertex[256], int version)
 {
 	assert(vertex_count > 0 && vertex_count <= kVertexBlockMaxSize);
+	assert(version == 0);
+
+	(void)version;
 
 	unsigned char buffer[kVertexBlockMaxSize * 4];
 	unsigned char transposed[kVertexBlockSizeBytes];
@@ -1364,7 +1384,7 @@ int meshopt_decodeVertexBuffer(void* destination, size_t vertex_count, size_t ve
 	assert(vertex_size > 0 && vertex_size <= 256);
 	assert(vertex_size % 4 == 0);
 
-	const unsigned char* (*decode)(const unsigned char*, const unsigned char*, unsigned char*, size_t, size_t, unsigned char[256]) = NULL;
+	const unsigned char* (*decode)(const unsigned char*, const unsigned char*, unsigned char*, size_t, size_t, unsigned char[256], int) = NULL;
 
 #if defined(SIMD_SSE) && defined(SIMD_FALLBACK)
 	decode = (cpuid & (1 << 9)) ? decodeVertexBlockSimd : decodeVertexBlock;
@@ -1407,7 +1427,7 @@ int meshopt_decodeVertexBuffer(void* destination, size_t vertex_count, size_t ve
 	{
 		size_t block_size = (vertex_offset + vertex_block_size < vertex_count) ? vertex_block_size : vertex_count - vertex_offset;
 
-		data = decode(data, data_end, vertex_data + vertex_offset * vertex_size, block_size, vertex_size, last_vertex);
+		data = decode(data, data_end, vertex_data + vertex_offset * vertex_size, block_size, vertex_size, last_vertex, version);
 		if (!data)
 			return -2;
 

--- a/src/vertexcodec.cpp
+++ b/src/vertexcodec.cpp
@@ -127,7 +127,7 @@ static int gEncodeVertexVersion = 0;
 const size_t kVertexBlockSizeBytes = 8192;
 const size_t kVertexBlockMaxSize = 256;
 const size_t kByteGroupSize = 16;
-const size_t kByteGroupDecodeLimit = 28; // bit group 6: 12 bytes of bit data, 16 bytes of sentinel data (for invalid streams)
+const size_t kByteGroupDecodeLimit = 24;
 const size_t kTailMaxSize = 32;
 
 static const int kBitsV0[4] = {0, 2, 4, 8};
@@ -1353,17 +1353,17 @@ static const unsigned char* decodeVertexBlockSimd(const unsigned char* data, con
 
 			if (ctrl == 3)
 			{
-				// literal encoding
-				if (size_t(data_end - data) < vertex_count)
+				// literal encoding; safe to over-copy due to tail
+				if (size_t(data_end - data) < vertex_count_aligned)
 					return NULL;
 
-				memcpy(buffer + j * vertex_count_aligned, data, vertex_count);
+				memcpy(buffer + j * vertex_count_aligned, data, vertex_count_aligned);
 				data += vertex_count;
 			}
 			else if (ctrl == 2)
 			{
 				// zero encoding
-				memset(buffer + j * vertex_count_aligned, 0, vertex_count);
+				memset(buffer + j * vertex_count_aligned, 0, vertex_count_aligned);
 			}
 			else
 			{

--- a/src/vertexcodec.cpp
+++ b/src/vertexcodec.cpp
@@ -60,6 +60,15 @@
 #define SIMD_LATENCYOPT
 #endif
 
+// In switch dispatch, marking default case as unreachable allows to remove redundant bounds checks
+#if defined(__GNUC__)
+#define SIMD_UNREACHABLE() __builtin_unreachable()
+#elif defined(__MSC_VER)
+#define SIMD_UNREACHABLE() __assume(0)
+#else
+#define SIMD_UNREACHABLE() assert(0)
+#endif
+
 #endif // !MESHOPTIMIZER_NO_SIMD
 
 #ifdef SIMD_SSE
@@ -744,7 +753,7 @@ static const unsigned char* decodeBytesGroupSimd(const unsigned char* data, unsi
 	}
 
 	default:
-		assert(!"Unexpected bit length"); // unreachable since bitslog2 is a 2-bit value
+		SIMD_UNREACHABLE();
 		return data;
 	}
 }
@@ -803,7 +812,7 @@ static const unsigned char* decodeBytesGroupSimd(const unsigned char* data, unsi
 	}
 
 	default:
-		assert(!"Unexpected bit length"); // unreachable since bitslog2 is a 2-bit value
+		SIMD_UNREACHABLE();
 		return data;
 	}
 }
@@ -926,7 +935,7 @@ static const unsigned char* decodeBytesGroupSimd(const unsigned char* data, unsi
 	}
 
 	default:
-		assert(!"Unexpected bit length"); // unreachable since bitslog2 is a 2-bit value
+		SIMD_UNREACHABLE();
 		return data;
 	}
 }
@@ -1026,7 +1035,7 @@ static const unsigned char* decodeBytesGroupSimd(const unsigned char* data, unsi
 	}
 
 	default:
-		assert(!"Unexpected bit length"); // unreachable since bitslog2 is a 2-bit value
+		SIMD_UNREACHABLE();
 		return data;
 	}
 }

--- a/src/vertexcodec.cpp
+++ b/src/vertexcodec.cpp
@@ -764,8 +764,8 @@ inline const unsigned char* decodeBytesGroupSimd(const unsigned char* data, unsi
 		unsigned char mask1 = data[1];
 
 		// bit reverse
-		unsigned char mask0r = ((mask0 * 0x80200802ULL) & 0x0884422110ULL) * 0x0101010101ULL >> 32;
-		unsigned char mask1r = ((mask1 * 0x80200802ULL) & 0x0884422110ULL) * 0x0101010101ULL >> 32;
+		unsigned char mask0r = (unsigned char)(((mask0 * 0x80200802ULL) & 0x0884422110ULL) * 0x0101010101ULL >> 32);
+		unsigned char mask1r = (unsigned char)(((mask1 * 0x80200802ULL) & 0x0884422110ULL) * 0x0101010101ULL >> 32);
 
 		__m128i shuf = decodeShuffleMask(mask0r, mask1r);
 
@@ -989,8 +989,8 @@ static const unsigned char* decodeBytesGroupSimd(const unsigned char* data, unsi
 		unsigned char mask1 = data[1];
 
 		// bit reverse
-		unsigned char mask0r = ((mask0 * 0x80200802ULL) & 0x0884422110ULL) * 0x0101010101ULL >> 32;
-		unsigned char mask1r = ((mask1 * 0x80200802ULL) & 0x0884422110ULL) * 0x0101010101ULL >> 32;
+		unsigned char mask0r = (unsigned char)(((mask0 * 0x80200802ULL) & 0x0884422110ULL) * 0x0101010101ULL >> 32);
+		unsigned char mask1r = (unsigned char)(((mask1 * 0x80200802ULL) & 0x0884422110ULL) * 0x0101010101ULL >> 32);
 
 		uint8x8_t rest0 = vld1_u8(data + 2);
 		uint8x8_t rest1 = vld1_u8(data + 2 + kDecodeBytesGroupCount[mask0]);
@@ -1114,8 +1114,8 @@ static const unsigned char* decodeBytesGroupSimd(const unsigned char* data, unsi
 		unsigned char mask1 = data[1];
 
 		// bit reverse
-		unsigned char mask0r = ((mask0 * 0x80200802ULL) & 0x0884422110ULL) * 0x0101010101ULL >> 32;
-		unsigned char mask1r = ((mask1 * 0x80200802ULL) & 0x0884422110ULL) * 0x0101010101ULL >> 32;
+		unsigned char mask0r = (unsigned char)(((mask0 * 0x80200802ULL) & 0x0884422110ULL) * 0x0101010101ULL >> 32);
+		unsigned char mask1r = (unsigned char)(((mask1 * 0x80200802ULL) & 0x0884422110ULL) * 0x0101010101ULL >> 32);
 
 		v128_t shuf = decodeShuffleMask(mask0r, mask1r);
 

--- a/src/vertexcodec.cpp
+++ b/src/vertexcodec.cpp
@@ -167,9 +167,9 @@ static bool encodeBytesGroupZero(const unsigned char* buffer)
 
 static size_t encodeBytesGroupMeasure(const unsigned char* buffer, int bits)
 {
-	assert(bits >= 1 && bits <= 8);
+	assert(bits >= 0 && bits <= 8);
 
-	if (bits == 1)
+	if (bits == 0)
 		return encodeBytesGroupZero(buffer) ? 0 : size_t(-1);
 
 	if (bits == 8)
@@ -187,9 +187,10 @@ static size_t encodeBytesGroupMeasure(const unsigned char* buffer, int bits)
 
 static unsigned char* encodeBytesGroup(unsigned char* data, const unsigned char* buffer, int bits)
 {
-	assert(bits >= 1 && bits <= 8);
+	assert(bits >= 0 && bits <= 8);
+	assert(kByteGroupSize % 8 == 0);
 
-	if (bits == 1)
+	if (bits == 0)
 		return data;
 
 	if (bits == 8)
@@ -231,7 +232,7 @@ static unsigned char* encodeBytesGroup(unsigned char* data, const unsigned char*
 	return data;
 }
 
-static unsigned char* encodeBytes(unsigned char* data, unsigned char* data_end, const unsigned char* buffer, size_t buffer_size)
+static unsigned char* encodeBytes(unsigned char* data, unsigned char* data_end, const unsigned char* buffer, size_t buffer_size, const int bits[4])
 {
 	assert(buffer_size % kByteGroupSize == 0);
 
@@ -252,27 +253,24 @@ static unsigned char* encodeBytes(unsigned char* data, unsigned char* data_end, 
 		if (size_t(data_end - data) < kByteGroupDecodeLimit)
 			return NULL;
 
-		int best_bits = 8;
-		size_t best_size = encodeBytesGroupMeasure(buffer + i, 8);
+		int best_bitk = 3;
+		size_t best_size = encodeBytesGroupMeasure(buffer + i, bits[best_bitk]);
 
-		for (int bits = 1; bits < 8; bits *= 2)
+		for (int bitk = 0; bitk < 3; ++bitk)
 		{
-			size_t size = encodeBytesGroupMeasure(buffer + i, bits);
+			size_t size = encodeBytesGroupMeasure(buffer + i, bits[bitk]);
 
 			if (size < best_size)
 			{
-				best_bits = bits;
+				best_bitk = bitk;
 				best_size = size;
 			}
 		}
 
-		int bitslog2 = (best_bits == 1) ? 0 : (best_bits == 2 ? 1 : (best_bits == 4 ? 2 : 3));
-		assert((1 << bitslog2) == best_bits);
-
 		size_t header_offset = i / kByteGroupSize;
+		header[header_offset / 4] |= best_bitk << ((header_offset % 4) * 2);
 
-		header[header_offset / 4] |= bitslog2 << ((header_offset % 4) * 2);
-
+		int best_bits = bits[best_bitk];
 		unsigned char* next = encodeBytesGroup(data, buffer + i, best_bits);
 
 		assert(data + best_size == next);
@@ -332,7 +330,9 @@ static unsigned char* encodeVertexBlock(unsigned char* data, unsigned char* data
 		}
 #endif
 
-		data = encodeBytes(data, data_end, buffer, (vertex_count + kByteGroupSize - 1) & ~(kByteGroupSize - 1));
+		static const int kBitsV0[4] = {0, 2, 4, 8};
+
+		data = encodeBytes(data, data_end, buffer, (vertex_count + kByteGroupSize - 1) & ~(kByteGroupSize - 1), kBitsV0);
 		if (!data)
 			return NULL;
 

--- a/src/vertexcodec.cpp
+++ b/src/vertexcodec.cpp
@@ -1250,7 +1250,8 @@ size_t meshopt_encodeVertexBufferBound(size_t vertex_count, size_t vertex_size)
 
 void meshopt_encodeVertexVersion(int version)
 {
-	assert(unsigned(version) <= 0);
+	// note: this version is experimental and the binary format is not finalized; this should not be used in production!
+	assert(unsigned(version) <= 0 || version == 0xe);
 
 	meshopt::gEncodeVertexVersion = version;
 }
@@ -1291,7 +1292,7 @@ int meshopt_decodeVertexBuffer(void* destination, size_t vertex_count, size_t ve
 		return -1;
 
 	int version = data_header & 0x0f;
-	if (version > 0)
+	if (version > 0 && version != 0xe)
 		return -1;
 
 	unsigned char last_vertex[256];

--- a/tools/codectest.cpp
+++ b/tools/codectest.cpp
@@ -4,11 +4,139 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 
 #ifdef _WIN32
 #include <fcntl.h>
 #include <io.h>
 #endif
+
+size_t measure(const char* cmd, const std::vector<unsigned char>& data)
+{
+	FILE* file = fopen("/tmp/codectest.in", "wb");
+	if (!file)
+		return 0;
+	fwrite(data.data(), data.size(), 1, file);
+	fclose(file);
+
+	char actualcmd[1024];
+	snprintf(actualcmd, sizeof(actualcmd), cmd, "/tmp/codectest.in", "/tmp/codectest.out");
+
+	int rc = system(actualcmd);
+	if (rc)
+		return 0;
+
+	file = fopen("/tmp/codectest.out", "rb");
+	if (!file)
+		return 0;
+	fseek(file, 0, SEEK_END);
+	long result = ftell(file);
+	fclose(file);
+
+	return result;
+}
+
+size_t measure_lz4(const std::vector<unsigned char>& data)
+{
+	return measure("lz4 -f -q %s %s", data);
+}
+
+size_t measure_zstd(const std::vector<unsigned char>& data)
+{
+	return measure("zstd -f -q %s -o %s", data);
+}
+
+struct Stats
+{
+	bool testz;
+	double v10_raw;
+	double v10_lz4;
+	double v10_zstd;
+	double count;
+};
+
+void testFile(FILE* file, size_t count, size_t stride, Stats* stats = 0)
+{
+	std::vector<unsigned char> input;
+	unsigned char buffer[4096];
+	size_t bytes_read;
+
+	while ((bytes_read = fread(buffer, 1, sizeof(buffer), file)) > 0)
+		input.insert(input.end(), buffer, buffer + bytes_read);
+
+	std::vector<unsigned char> decoded(count * stride);
+	int res = meshopt_decodeVertexBuffer(&decoded[0], count, stride, &input[0], input.size());
+	if (res != 0 && input.size() == decoded.size())
+	{
+		// some files are not encoded; encode them with v1 to let the rest of the flow proceed as is
+		memcpy(decoded.data(), input.data(), decoded.size());
+		input.resize(meshopt_encodeVertexBufferBound(count, stride));
+		input.resize(meshopt_encodeVertexBuffer(input.data(), input.size(), decoded.data(), count, stride));
+	}
+
+	std::vector<unsigned char> output(meshopt_encodeVertexBufferBound(count, stride));
+	output.resize(meshopt_encodeVertexBuffer(output.data(), output.size(), decoded.data(), count, stride));
+
+	printf(" raw %zu KB\t", decoded.size() / 1024);
+	printf(" v0 %.2f", double(input.size()) / double(decoded.size()));
+	printf(" v1 %.2f", double(output.size()) / double(decoded.size()));
+	printf(" v1/v0 %+.1f%%", double(output.size()) / double(input.size()) * 100 - 100);
+
+	if (stats)
+	{
+		stats->v10_raw += double(output.size()) / double(input.size()) - 1;
+		stats->count++;
+	}
+
+	if (stats && stats->testz)
+	{
+		size_t decoded_lz4 = measure_lz4(decoded);
+		size_t input_lz4 = measure_lz4(input);
+		size_t output_lz4 = measure_lz4(output);
+		size_t decoded_zstd = measure_zstd(decoded);
+		size_t input_zstd = measure_zstd(input);
+		size_t output_zstd = measure_zstd(output);
+
+		printf("\tlz4 %.2f:", double(decoded_lz4) / double(decoded.size()));
+		printf(" v0 %.2f", double(input_lz4) / double(decoded.size()));
+		printf(" v1 %.2f", double(output_lz4) / double(decoded.size()));
+		printf(" v1/v0 %+.1f%%", double(output_lz4) / double(input_lz4) * 100 - 100);
+
+		printf("\tzstd %.2f:", double(decoded_zstd) / double(decoded.size()));
+		printf(" v0 %.2f", double(input_zstd) / double(decoded.size()));
+		printf(" v1 %.2f", double(output_zstd) / double(decoded.size()));
+		printf(" v1/v0 %+.1f%%", double(output_zstd) / double(input_zstd) * 100 - 100);
+
+		stats->v10_lz4 += double(output_lz4) / double(input_lz4) - 1;
+		stats->v10_zstd += double(output_zstd) / double(input_zstd) - 1;
+	}
+}
+
+void testFile(const char* path, Stats* stats = 0)
+{
+	FILE* file = fopen(path, "rb");
+	if (!file)
+		return;
+
+	const char* name = strrchr(path, '/');
+	name = name ? name + 1 : path;
+
+	int vcnt, vsz;
+	int sr = sscanf(name, "v%d_s%d_", &vcnt, &vsz);
+	assert(sr == 2);
+	(void)sr;
+
+	const char* name0 = strchr(strchr(name, '_') + 1, '_') + 1;
+	const char* name1 = strstr(name0, "_R");
+	size_t namel = name1 ? name1 - name0 : strlen(name0);
+	namel = namel > 25 ? 25 : namel;
+
+	printf("%25.*s:", int(namel), name0);
+	testFile(file, vcnt, vsz, stats);
+	printf("\n");
+
+	fclose(file);
+}
 
 int main(int argc, char** argv)
 {
@@ -16,6 +144,18 @@ int main(int argc, char** argv)
 	_setmode(_fileno(stdin), _O_BINARY);
 	_setmode(_fileno(stdout), _O_BINARY);
 #endif
+
+	if (argc > 1 && (strcmp(argv[1], "-test") == 0 || strcmp(argv[1], "-testz") == 0))
+	{
+		Stats stats = {};
+		stats.testz = strcmp(argv[1], "-testz") == 0;
+		for (int i = 2; i < argc; ++i)
+			testFile(argv[i], &stats);
+		printf("---\n");
+		printf("%d files: raw v1/v0 %+.2f%%, lz4 v1/v0 %+.2f%%, zstd v1/v0 %+.2f%%\n",
+		    int(stats.count), stats.v10_raw / stats.count * 100, stats.v10_lz4 / stats.count * 100, stats.v10_zstd / stats.count * 100);
+		return 0;
+	}
 
 	if (argc < 2 || argc > 3 || atoi(argv[1]) <= 0)
 	{

--- a/tools/codectest.cpp
+++ b/tools/codectest.cpp
@@ -75,7 +75,9 @@ void testFile(FILE* file, size_t count, size_t stride, Stats* stats = 0)
 	}
 
 	std::vector<unsigned char> output(meshopt_encodeVertexBufferBound(count, stride));
+	meshopt_encodeVertexVersion(0xe);
 	output.resize(meshopt_encodeVertexBuffer(output.data(), output.size(), decoded.data(), count, stride));
+	meshopt_encodeVertexVersion(0);
 
 	printf(" raw %zu KB\t", decoded.size() / 1024);
 	printf(" v0 %.2f", double(input.size()) / double(decoded.size()));


### PR DESCRIPTION
This PR prototypes initial support for the next vertex codec version.

The change introduces version 0xe; this version has zero compatibility guarantees, and will be in the state of flux wrt bitstream format until it is finalized as version 1. The goals for the next version are to retain comparable decoding performance to v0 -- currently v0 decodes around 4.5 GB/s on Zen 4 (7950X), around 3.5 GB/s on M2 (base) -- and to increase compression ratio, targeting up to ~10% relative improvement on average for a set of geometry data. This will make the decoder more complicated and larger, but hopefully not dramatically so. Some performance loss is probably unavoidable, hopefully it can be kept at ~5% or so.

In this PR the initial infrastructure (version selection, enhanced codectest harness) is setup, and byte group encoding is expanded to support a palette of bit counts, adding support for 1-bit and 6-bit groups as well as literal byte blocks. This results in aggregate improvements as follows on the test set (~half of this is glTF data, ~half is proprietary engine data).

> 143 files: raw v1/v0 -4.83%, lz4 v1/v0 -3.37%, zstd v1/v0 -0.79%

~It's not certain yet that the decoding performance can be maintained with this expansion due to some issues around codegen with compilers, but that will be investigated separately. To get to the target compression ratio improvements, more changes will be necessary but they will be orthogonal to byte group encoding enhancements which this PR will focus on.~

Unfortunately, introduction of 6-bit groups significantly penalized decoding performance across the board; while they are useful on some data, to maintain excellent performance the approach had to be adjusted: only 1-bit groups are added for byte group encoding, but control bits are enhanced to support zero channels as well as literal channels within a block. This as well as rebalanced dispatch structure allows to maintain excellent decoding performance, but results in slightly less significant ratio wins unless zstd is used:

> 143 files: raw v1/v0 -3.70%, lz4 v1/v0 -2.43%, zstd v1/v0 -0.81%

... that said, decoding performance is actually often *better*, and on just game ready engine data the wins are still decent, and actually better post-zstd:

> 64 files: raw v1/v0 -4.06%, lz4 v1/v0 -2.99%, zstd v1/v0 -1.12%

Further tweaks may be possible to get more performance out of the new dispatch structure, especially for `gcc` which leaves a bounds check for switch table even though it's provably unnecessary.

*This contribution is sponsored by Valve.*