### PR TITLE
vertexcodec: Initial implementation of experimental decoders

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,6 +88,14 @@ ifeq ($(config),coverage)
 	LDFLAGS+=-coverage
 endif
 
+ifeq ($(config),release-avx)
+	CXXFLAGS+=-O3 -DNDEBUG -mavx
+endif
+
+ifeq ($(config),release-avx512)
+	CXXFLAGS+=-O3 -DNDEBUG -mavx512vl -mavx512vbmi -mavx512vbmi2
+endif
+
 ifeq ($(config),release-scalar)
 	CXXFLAGS+=-O3 -DNDEBUG -DMESHOPTIMIZER_NO_SIMD
 endif

--- a/js/benchmark.js
+++ b/js/benchmark.js
@@ -16,11 +16,15 @@ var tests = {
 		var N = 1024 * 1024;
 		var data = new Uint8Array(N * 16);
 
-		for (var i = 0; i < N * 16; i += 4) {
-			data[i + 0] = 0;
-			data[i + 1] = (i % 16) * 1;
-			data[i + 2] = (i % 16) * 2;
-			data[i + 3] = (i % 16) * 8;
+		var lcg = 1;
+
+		for (var i = 0; i < N * 16; ++i) {
+			// mindstd_rand
+			lcg = (lcg * 48271) % 2147483647;
+
+			var k = i % 16;
+			if (k <= 8) data[i] = lcg & ((1 << k) - 1);
+			else data[i] = i & ((1 << (k - 8)) - 1);
 		}
 
 		var decoded = new Uint8Array(N * 16);

--- a/src/vertexcodec.cpp
+++ b/src/vertexcodec.cpp
@@ -781,8 +781,8 @@ static const unsigned char* decodeBytesGroupSimdX(const unsigned char* data, uns
 		unsigned char mask1 = data[1];
 
 		// bit reverse
-		unsigned char mask0r = ((mask0 * 0x80200802ULL) & 0x0884422110ULL) * 0x0101010101ULL >> 32;
-		unsigned char mask1r = ((mask1 * 0x80200802ULL) & 0x0884422110ULL) * 0x0101010101ULL >> 32;
+		unsigned char mask0r = (unsigned char)(((mask0 * 0x80200802ULL) & 0x0884422110ULL) * 0x0101010101ULL >> 32);
+		unsigned char mask1r = (unsigned char)(((mask1 * 0x80200802ULL) & 0x0884422110ULL) * 0x0101010101ULL >> 32);
 
 		__m128i shuf = decodeShuffleMask(mask0r, mask1r);
 
@@ -880,7 +880,7 @@ static const unsigned char* decodeBytesGroupSimdX(const unsigned char* data, uns
 		__m128i rest = _mm_loadu_si128(reinterpret_cast<const __m128i*>(data + 12));
 
 		// 4 groups with 4 6-bit values in each 3 bytes => 4 groups with 4 6-bit values in each 4 bytes
-		__m128i sel4 = _mm_shuffle_epi8(sel6, _mm_setr_epi8(2, 1, 0, 0xff, 5, 4, 3, 0xff, 8, 7, 6, 0xff, 11, 10, 9, 0xff));
+		__m128i sel4 = _mm_shuffle_epi8(sel6, _mm_setr_epi8(2, 1, 0, -128, 5, 4, 3, -127, 8, 7, 6, -128, 11, 10, 9, -128));
 
 		// sel4 = 0x00 [6 2] [4 4] [2 6]
 		__m128i sel0 = _mm_srli_epi32(sel4, 18); // 0 0 0 0X
@@ -988,7 +988,7 @@ static const __m128i decodeBytesGroupConfigX[6][3] = {
     {_mm_setzero_si128(), _mm_setzero_si128(), _mm_setzero_si128()},                                                                                                             // 3
     {_mm_setr_epi8(0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7), _mm_set1_epi8(15), _mm_setr_epi8(4, 0, 12, 8, 20, 16, 28, 24, 36, 32, 44, 40, 52, 48, 60, 56)},              // 4
     {_mm_setzero_si128(), _mm_setzero_si128(), _mm_setzero_si128()},                                                                                                             // 5
-    {_mm_setr_epi8(5, 4, 3, 2, 1, 0, 0xff, 0xff, 11, 10, 9, 8, 7, 6, 0xff, 0xff), _mm_set1_epi8(63), _mm_setr_epi8(42, 36, 30, 24, 18, 12, 6, 0, 42, 36, 30, 24, 18, 12, 6, 0)}, // 6
+    {_mm_setr_epi8(5, 4, 3, 2, 1, 0, -128, -128, 11, 10, 9, 8, 7, 6, -128, -128), _mm_set1_epi8(63), _mm_setr_epi8(42, 36, 30, 24, 18, 12, 6, 0, 42, 36, 30, 24, 18, 12, 6, 0)}, // 6
 };
 
 static const unsigned char* decodeBytesGroupSimdX(const unsigned char* data, unsigned char* buffer, int bits)
@@ -1190,8 +1190,8 @@ static const unsigned char* decodeBytesGroupSimdX(const unsigned char* data, uns
 		unsigned char mask1 = data[1];
 
 		// bit reverse
-		unsigned char mask0r = ((mask0 * 0x80200802ULL) & 0x0884422110ULL) * 0x0101010101ULL >> 32;
-		unsigned char mask1r = ((mask1 * 0x80200802ULL) & 0x0884422110ULL) * 0x0101010101ULL >> 32;
+		unsigned char mask0r = (unsigned char)(((mask0 * 0x80200802ULL) & 0x0884422110ULL) * 0x0101010101ULL >> 32);
+		unsigned char mask1r = (unsigned char)(((mask1 * 0x80200802ULL) & 0x0884422110ULL) * 0x0101010101ULL >> 32);
 
 		uint8x8_t rest0 = vld1_u8(data + 2);
 		uint8x8_t rest1 = vld1_u8(data + 2 + kDecodeBytesGroupCount[mask0]);
@@ -1455,8 +1455,8 @@ static const unsigned char* decodeBytesGroupSimdX(const unsigned char* data, uns
 		unsigned char mask1 = data[1];
 
 		// bit reverse
-		unsigned char mask0r = ((mask0 * 0x80200802ULL) & 0x0884422110ULL) * 0x0101010101ULL >> 32;
-		unsigned char mask1r = ((mask1 * 0x80200802ULL) & 0x0884422110ULL) * 0x0101010101ULL >> 32;
+		unsigned char mask0r = (unsigned char)(((mask0 * 0x80200802ULL) & 0x0884422110ULL) * 0x0101010101ULL >> 32);
+		unsigned char mask1r = (unsigned char)(((mask1 * 0x80200802ULL) & 0x0884422110ULL) * 0x0101010101ULL >> 32);
 
 		v128_t shuf = decodeShuffleMask(mask0r, mask1r);
 

--- a/src/vertexcodec.cpp
+++ b/src/vertexcodec.cpp
@@ -148,7 +148,7 @@ struct Stats
 {
 	size_t size;
 	size_t header;  // bytes for header
-	size_t bitg[4]; // bytes for bit groups
+	size_t bitg[9]; // bytes for bit groups
 	size_t bitc[8]; // bit consistency: how many bits are shared between all bytes in a group
 };
 
@@ -278,7 +278,7 @@ static unsigned char* encodeBytes(unsigned char* data, unsigned char* data_end, 
 		data = next;
 
 #if TRACE
-		bytestats->bitg[bitslog2] += best_size;
+		bytestats->bitg[best_bits] += best_size;
 #endif
 	}
 
@@ -1222,11 +1222,12 @@ size_t meshopt_encodeVertexBuffer(unsigned char* buffer, size_t buffer_size, con
 
 		printf("%2d: %7d bytes [%4.1f%%] %.1f bpv", int(k), int(vsk.size), double(vsk.size) / double(total_size) * 100, double(vsk.size) / double(vertex_count) * 8);
 
-		size_t total_k = vsk.header + vsk.bitg[0] + vsk.bitg[1] + vsk.bitg[2] + vsk.bitg[3];
+		size_t total_k = vsk.header + vsk.bitg[1] + vsk.bitg[2] + vsk.bitg[4] + vsk.bitg[6] + vsk.bitg[8];
 
-		printf(" |\thdr [%5.1f%%] bitg 1-3 [%4.1f%% %4.1f%% %4.1f%%]",
+		printf(" |\thdr [%5.1f%%] bitg [1 %4.1f%% 2 %4.1f%% 4 %4.1f%% 6 %4.1f%% 8 %4.1f%%]",
 		    double(vsk.header) / double(total_k) * 100, double(vsk.bitg[1]) / double(total_k) * 100,
-		    double(vsk.bitg[2]) / double(total_k) * 100, double(vsk.bitg[3]) / double(total_k) * 100);
+		    double(vsk.bitg[2]) / double(total_k) * 100, double(vsk.bitg[4]) / double(total_k) * 100,
+		    double(vsk.bitg[6]) / double(total_k) * 100, double(vsk.bitg[8]) / double(total_k) * 100);
 
 		printf(" |\tbitc [%3.0f%% %3.0f%% %3.0f%% %3.0f%% %3.0f%% %3.0f%% %3.0f%% %3.0f%%]",
 		    double(vsk.bitc[0]) / double(vertex_count) * 100, double(vsk.bitc[1]) / double(vertex_count) * 100,

--- a/src/vertexcodec.cpp
+++ b/src/vertexcodec.cpp
@@ -124,8 +124,8 @@ const size_t kTailMaxSize = 32;
 static const int kBitsV0[4] = {0, 2, 4, 8};
 static const int kBitsV1[3][4] = {
     {0, 2, 4, 8},
-    {0, 1, 2, 8},
-    {2, 4, 6, 8},
+    {0, 1, 2, 4},
+    {1, 4, 6, 8},
 };
 
 static size_t getVertexBlockSize(size_t vertex_size)

--- a/src/vertexcodec.cpp
+++ b/src/vertexcodec.cpp
@@ -1291,7 +1291,7 @@ static const unsigned char* decodeBytesGroupSimdX(const unsigned char* data, uns
 		uint8x16_t sel4b = vcombine_u8(sel4l, sel4h);
 #endif
 
-		uint32x4_t sel4 = vreinterpretq_u8_u32(sel4b);
+		uint32x4_t sel4 = vreinterpretq_u32_u8(sel4b);
 
 		// sel4 = 0x00 [6 2] [4 4] [2 6]
 		uint32x4_t sel0 = vshrq_n_u32(sel4, 18); // 0 0 0 0X

--- a/src/vertexcodec.cpp
+++ b/src/vertexcodec.cpp
@@ -60,6 +60,15 @@
 #define SIMD_LATENCYOPT
 #endif
 
+// In switch dispatch, marking default case as unreachable allows to remove redundant bounds checks
+#if defined(__GNUC__)
+#define SIMD_UNREACHABLE() __builtin_unreachable()
+#elif defined(__MSC_VER)
+#define SIMD_UNREACHABLE() __assume(0)
+#else
+#define SIMD_UNREACHABLE() assert(0)
+#endif
+
 #endif // !MESHOPTIMIZER_NO_SIMD
 
 #ifdef SIMD_SSE
@@ -745,7 +754,7 @@ static const unsigned char* decodeBytesGroupSimd(const unsigned char* data, unsi
 	}
 
 	default:
-		assert(!"Unexpected bit length"); // unreachable since bitslog2 is a 2-bit value
+		SIMD_UNREACHABLE();
 		return data;
 	}
 }
@@ -908,7 +917,7 @@ static const unsigned char* decodeBytesGroupSimdX(const unsigned char* data, uns
 	}
 
 	default:
-		assert(!"Unexpected bit length"); // unreachable
+		SIMD_UNREACHABLE();
 		return data;
 	}
 }
@@ -967,7 +976,7 @@ static const unsigned char* decodeBytesGroupSimd(const unsigned char* data, unsi
 	}
 
 	default:
-		assert(!"Unexpected bit length"); // unreachable since bitslog2 is a 2-bit value
+		SIMD_UNREACHABLE();
 		return data;
 	}
 }
@@ -1030,7 +1039,7 @@ static const unsigned char* decodeBytesGroupSimdX(const unsigned char* data, uns
 	}
 
 	default:
-		assert(!"Unexpected bit length"); // unreachable since bitslog2 is a 2-bit value
+		SIMD_UNREACHABLE();
 		return data;
 	}
 }
@@ -1156,7 +1165,7 @@ static const unsigned char* decodeBytesGroupSimd(const unsigned char* data, unsi
 	}
 
 	default:
-		assert(!"Unexpected bit length"); // unreachable since bitslog2 is a 2-bit value
+		SIMD_UNREACHABLE();
 		return data;
 	}
 }
@@ -1319,7 +1328,7 @@ static const unsigned char* decodeBytesGroupSimdX(const unsigned char* data, uns
 	}
 
 	default:
-		assert(!"Unexpected bit length"); // unreachable since bitslog2 is a 2-bit value
+		SIMD_UNREACHABLE();
 		return data;
 	}
 }
@@ -1419,7 +1428,7 @@ static const unsigned char* decodeBytesGroupSimd(const unsigned char* data, unsi
 	}
 
 	default:
-		assert(!"Unexpected bit length"); // unreachable since bitslog2 is a 2-bit value
+		SIMD_UNREACHABLE();
 		return data;
 	}
 }
@@ -1547,7 +1556,7 @@ static const unsigned char* decodeBytesGroupSimdX(const unsigned char* data, uns
 	}
 
 	default:
-		assert(!"Unexpected bit length"); // unreachable since bitslog2 is a 2-bit value
+		SIMD_UNREACHABLE();
 		return data;
 	}
 }

--- a/src/vertexcodec.cpp
+++ b/src/vertexcodec.cpp
@@ -305,18 +305,12 @@ static size_t encodeBytesMeasure(const unsigned char* buffer, size_t buffer_size
 
 	for (size_t i = 0; i < buffer_size; i += kByteGroupSize)
 	{
-		int best_bitk = 3;
-		size_t best_size = encodeBytesGroupMeasure(buffer + i, bits[best_bitk]);
+		size_t best_size = size_t(-1);
 
-		for (int bitk = 0; bitk < 3; ++bitk)
+		for (int bitk = 0; bitk < 4; ++bitk)
 		{
 			size_t size = encodeBytesGroupMeasure(buffer + i, bits[bitk]);
-
-			if (size < best_size)
-			{
-				best_bitk = bitk;
-				best_size = size;
-			}
+			best_size = (size < best_size) ? size : best_size;
 		}
 
 		result += best_size;
@@ -383,10 +377,10 @@ static unsigned char* encodeVertexBlock(unsigned char* data, unsigned char* data
 
 		if (version == 0xe)
 		{
-			int best_ctrl = 0;
-			size_t best_bytes = encodeBytesMeasure(buffer, vertex_count_aligned, kBitsV1[0]);
+			int best_ctrl = 3; // literal encoding
+			size_t best_bytes = vertex_count;
 
-			for (int i = 1; i <= 2; ++i)
+			for (int i = 0; i <= 2; ++i)
 			{
 				size_t est_bytes = encodeBytesMeasure(buffer, vertex_count_aligned, kBitsV1[i]);
 
@@ -399,12 +393,24 @@ static unsigned char* encodeVertexBlock(unsigned char* data, unsigned char* data
 
 			control[k / 4] |= best_ctrl << ((k % 4) * 2);
 
-			unsigned char* next = encodeBytes(data, data_end, buffer, vertex_count_aligned, kBitsV1[best_ctrl]);
-			if (!next)
-				return NULL;
+			if (best_ctrl == 3)
+			{
+				// literal encoding
+				if (size_t(data_end - data) < vertex_count)
+					return NULL;
 
-			assert(data + best_bytes == next);
-			data = next;
+				memcpy(data, buffer, vertex_count);
+				data += vertex_count;
+			}
+			else
+			{
+				unsigned char* next = encodeBytes(data, data_end, buffer, vertex_count_aligned, kBitsV1[best_ctrl]);
+				if (!next)
+					return NULL;
+
+				assert(data + best_bytes == next);
+				data = next;
+			}
 		}
 		else
 		{

--- a/src/vertexcodec.cpp
+++ b/src/vertexcodec.cpp
@@ -118,8 +118,15 @@ static int gEncodeVertexVersion = 0;
 const size_t kVertexBlockSizeBytes = 8192;
 const size_t kVertexBlockMaxSize = 256;
 const size_t kByteGroupSize = 16;
-const size_t kByteGroupDecodeLimit = 24;
+const size_t kByteGroupDecodeLimit = 28; // bit group 6: 12 bytes of bit data, 16 bytes of sentinel data (for invalid streams)
 const size_t kTailMaxSize = 32;
+
+static const int kBitsV0[4] = {0, 2, 4, 8};
+static const int kBitsV1[3][4] = {
+    {0, 2, 4, 8},
+    {0, 1, 2, 8},
+    {2, 4, 6, 8},
+};
 
 static size_t getVertexBlockSize(size_t vertex_size)
 {
@@ -286,15 +293,61 @@ static unsigned char* encodeBytes(unsigned char* data, unsigned char* data_end, 
 	return data;
 }
 
-static unsigned char* encodeVertexBlock(unsigned char* data, unsigned char* data_end, const unsigned char* vertex_data, size_t vertex_count, size_t vertex_size, unsigned char last_vertex[256])
+static size_t encodeBytesMeasure(const unsigned char* buffer, size_t buffer_size, const int bits[4])
+{
+	assert(buffer_size % kByteGroupSize == 0);
+
+	size_t result = 0;
+
+	// round number of groups to 4 to get number of header bytes
+	size_t header_size = (buffer_size / kByteGroupSize + 3) / 4;
+	result += header_size;
+
+	for (size_t i = 0; i < buffer_size; i += kByteGroupSize)
+	{
+		int best_bitk = 3;
+		size_t best_size = encodeBytesGroupMeasure(buffer + i, bits[best_bitk]);
+
+		for (int bitk = 0; bitk < 3; ++bitk)
+		{
+			size_t size = encodeBytesGroupMeasure(buffer + i, bits[bitk]);
+
+			if (size < best_size)
+			{
+				best_bitk = bitk;
+				best_size = size;
+			}
+		}
+
+		result += best_size;
+	}
+
+	return result;
+}
+
+static unsigned char* encodeVertexBlock(unsigned char* data, unsigned char* data_end, const unsigned char* vertex_data, size_t vertex_count, size_t vertex_size, unsigned char last_vertex[256], int version)
 {
 	assert(vertex_count > 0 && vertex_count <= kVertexBlockMaxSize);
+	assert(vertex_size % 4 == 0);
 
 	unsigned char buffer[kVertexBlockMaxSize];
 	assert(sizeof(buffer) % kByteGroupSize == 0);
 
+	size_t vertex_count_aligned = (vertex_count + kByteGroupSize - 1) & ~(kByteGroupSize - 1);
+
 	// we sometimes encode elements we didn't fill when rounding to kByteGroupSize
 	memset(buffer, 0, sizeof(buffer));
+
+	unsigned char* control = data;
+
+	size_t control_size = version == 0 ? 0 : vertex_size / 4;
+
+	if (size_t(data_end - data) < control_size)
+		return NULL;
+
+	data += control_size;
+
+	memset(control, 0, control_size);
 
 	for (size_t k = 0; k < vertex_size; ++k)
 	{
@@ -328,11 +381,37 @@ static unsigned char* encodeVertexBlock(unsigned char* data, unsigned char* data
 		}
 #endif
 
-		static const int kBitsV0[4] = {0, 2, 4, 8};
+		if (version == 0xe)
+		{
+			int best_ctrl = 0;
+			size_t best_bytes = encodeBytesMeasure(buffer, vertex_count_aligned, kBitsV1[0]);
 
-		data = encodeBytes(data, data_end, buffer, (vertex_count + kByteGroupSize - 1) & ~(kByteGroupSize - 1), kBitsV0);
-		if (!data)
-			return NULL;
+			for (int i = 1; i <= 2; ++i)
+			{
+				size_t est_bytes = encodeBytesMeasure(buffer, vertex_count_aligned, kBitsV1[i]);
+
+				if (est_bytes < best_bytes)
+				{
+					best_ctrl = i;
+					best_bytes = est_bytes;
+				}
+			}
+
+			control[k / 4] |= best_ctrl << ((k % 4) * 2);
+
+			unsigned char* next = encodeBytes(data, data_end, buffer, vertex_count_aligned, kBitsV1[best_ctrl]);
+			if (!next)
+				return NULL;
+
+			assert(data + best_bytes == next);
+			data = next;
+		}
+		else
+		{
+			data = encodeBytes(data, data_end, buffer, vertex_count_aligned, kBitsV0);
+			if (!data)
+				return NULL;
+		}
 
 #if TRACE
 		bytestats = NULL;
@@ -999,7 +1078,7 @@ static const unsigned char* decodeBytesSimd(const unsigned char* data, const uns
 
 	size_t i = 0;
 
-	// fast-path: process 4 groups at a time, do a shared bounds check - each group reads <=24b
+	// fast-path: process 4 groups at a time, do a shared bounds check
 	for (; i + kByteGroupSize * 4 <= buffer_size && size_t(data_end - data) >= kByteGroupDecodeLimit * 4; i += kByteGroupSize * 4)
 	{
 		size_t header_offset = i / kByteGroupSize;
@@ -1187,7 +1266,7 @@ size_t meshopt_encodeVertexBuffer(unsigned char* buffer, size_t buffer_size, con
 	{
 		size_t block_size = (vertex_offset + vertex_block_size < vertex_count) ? vertex_block_size : vertex_count - vertex_offset;
 
-		data = encodeVertexBlock(data, data_end, vertex_data + vertex_offset * vertex_size, block_size, vertex_size, last_vertex);
+		data = encodeVertexBlock(data, data_end, vertex_data + vertex_offset * vertex_size, block_size, vertex_size, last_vertex, version);
 		if (!data)
 			return 0;
 
@@ -1250,12 +1329,13 @@ size_t meshopt_encodeVertexBufferBound(size_t vertex_count, size_t vertex_size)
 	size_t vertex_block_size = getVertexBlockSize(vertex_size);
 	size_t vertex_block_count = (vertex_count + vertex_block_size - 1) / vertex_block_size;
 
+	size_t vertex_block_control_size = vertex_size / 4;
 	size_t vertex_block_header_size = (vertex_block_size / kByteGroupSize + 3) / 4;
 	size_t vertex_block_data_size = vertex_block_size;
 
 	size_t tail_size = vertex_size < kTailMaxSize ? kTailMaxSize : vertex_size;
 
-	return 1 + vertex_block_count * vertex_size * (vertex_block_header_size + vertex_block_data_size) + tail_size;
+	return 1 + vertex_block_count * vertex_size * (vertex_block_control_size + vertex_block_header_size + vertex_block_data_size) + tail_size;
 }
 
 void meshopt_encodeVertexVersion(int version)

--- a/src/vertexcodec.cpp
+++ b/src/vertexcodec.cpp
@@ -253,6 +253,8 @@ static unsigned char* encodeBytes(unsigned char* data, unsigned char* data_end, 
 
 	memset(header, 0, header_size);
 
+	int last_bits = -1;
+
 	for (size_t i = 0; i < buffer_size; i += kByteGroupSize)
 	{
 		if (size_t(data_end - data) < kByteGroupDecodeLimit)
@@ -265,7 +267,8 @@ static unsigned char* encodeBytes(unsigned char* data, unsigned char* data_end, 
 		{
 			size_t size = encodeBytesGroupMeasure(buffer + i, bits[bitk]);
 
-			if (size < best_size)
+			// favor consistent bit selection across groups, but never replace literals
+			if (size < best_size || (size == best_size && bits[bitk] == last_bits && bits[best_bitk] != 8))
 			{
 				best_bitk = bitk;
 				best_size = size;
@@ -280,6 +283,7 @@ static unsigned char* encodeBytes(unsigned char* data, unsigned char* data_end, 
 
 		assert(data + best_size == next);
 		data = next;
+		last_bits = best_bits;
 
 #if TRACE
 		bytestats->bitg[best_bits] += best_size;

--- a/src/vertexcodec.cpp
+++ b/src/vertexcodec.cpp
@@ -1250,7 +1250,8 @@ size_t meshopt_encodeVertexBufferBound(size_t vertex_count, size_t vertex_size)
 
 void meshopt_encodeVertexVersion(int version)
 {
-	assert(unsigned(version) <= 0);
+	// note: this version is experimental and the binary format is not finalized; this should not be used in production!
+	assert(unsigned(version) <= 0 || version == 0xe);
 
 	meshopt::gEncodeVertexVersion = version;
 }
@@ -1291,7 +1292,7 @@ int meshopt_decodeVertexBuffer(void* destination, size_t vertex_count, size_t ve
 		return -1;
 
 	int version = data_header & 0x0f;
-	if (version > 0)
+	if (version > 0 && version != 0xe)
 		return -1;
 
 	unsigned char last_vertex[256];

--- a/tools/codectest.cpp
+++ b/tools/codectest.cpp
@@ -4,11 +4,139 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 
 #ifdef _WIN32
 #include <fcntl.h>
 #include <io.h>
 #endif
+
+size_t measure(const char* cmd, const std::vector<unsigned char>& data)
+{
+	FILE* file = fopen("/tmp/codectest.in", "wb");
+	if (!file)
+		return 0;
+	fwrite(data.data(), data.size(), 1, file);
+	fclose(file);
+
+	char actualcmd[1024];
+	snprintf(actualcmd, sizeof(actualcmd), cmd, "/tmp/codectest.in", "/tmp/codectest.out");
+
+	int rc = system(actualcmd);
+	if (rc)
+		return 0;
+
+	file = fopen("/tmp/codectest.out", "rb");
+	if (!file)
+		return 0;
+	fseek(file, 0, SEEK_END);
+	long result = ftell(file);
+	fclose(file);
+
+	return result;
+}
+
+size_t measure_lz4(const std::vector<unsigned char>& data)
+{
+	return measure("lz4 -f -q %s %s", data);
+}
+
+size_t measure_zstd(const std::vector<unsigned char>& data)
+{
+	return measure("zstd -f -q %s -o %s", data);
+}
+
+struct Stats
+{
+	bool testz;
+	double v10_raw;
+	double v10_lz4;
+	double v10_zstd;
+	double count;
+};
+
+void testFile(FILE* file, size_t count, size_t stride, Stats* stats = 0)
+{
+	std::vector<unsigned char> input;
+	unsigned char buffer[4096];
+	size_t bytes_read;
+
+	while ((bytes_read = fread(buffer, 1, sizeof(buffer), file)) > 0)
+		input.insert(input.end(), buffer, buffer + bytes_read);
+
+	std::vector<unsigned char> decoded(count * stride);
+	int res = meshopt_decodeVertexBuffer(&decoded[0], count, stride, &input[0], input.size());
+	if (res != 0 && input.size() == decoded.size())
+	{
+		// some files are not encoded; encode them with v1 to let the rest of the flow proceed as is
+		memcpy(decoded.data(), input.data(), decoded.size());
+		input.resize(meshopt_encodeVertexBufferBound(count, stride));
+		input.resize(meshopt_encodeVertexBuffer(input.data(), input.size(), decoded.data(), count, stride));
+	}
+
+	std::vector<unsigned char> output(meshopt_encodeVertexBufferBound(count, stride));
+	output.resize(meshopt_encodeVertexBuffer(output.data(), output.size(), decoded.data(), count, stride));
+
+	printf(" raw %zu KB\t", decoded.size() / 1024);
+	printf(" v0 %.2f", double(input.size()) / double(decoded.size()));
+	printf(" v1 %.2f", double(output.size()) / double(decoded.size()));
+	printf(" v1/v0 %+.1f%%", double(output.size()) / double(input.size()) * 100 - 100);
+
+	if (stats)
+	{
+		stats->v10_raw += double(output.size()) / double(input.size()) - 1;
+		stats->count++;
+	}
+
+	if (stats && stats->testz)
+	{
+		size_t decoded_lz4 = measure_lz4(decoded);
+		size_t input_lz4 = measure_lz4(input);
+		size_t output_lz4 = measure_lz4(output);
+		size_t decoded_zstd = measure_zstd(decoded);
+		size_t input_zstd = measure_zstd(input);
+		size_t output_zstd = measure_zstd(output);
+
+		printf("\tlz4 %.2f:", double(decoded_lz4) / double(decoded.size()));
+		printf(" v0 %.2f", double(input_lz4) / double(decoded.size()));
+		printf(" v1 %.2f", double(output_lz4) / double(decoded.size()));
+		printf(" v1/v0 %+.1f%%", double(output_lz4) / double(input_lz4) * 100 - 100);
+
+		printf("\tzstd %.2f:", double(decoded_zstd) / double(decoded.size()));
+		printf(" v0 %.2f", double(input_zstd) / double(decoded.size()));
+		printf(" v1 %.2f", double(output_zstd) / double(decoded.size()));
+		printf(" v1/v0 %+.1f%%", double(output_zstd) / double(input_zstd) * 100 - 100);
+
+		stats->v10_lz4 += double(output_lz4) / double(input_lz4) - 1;
+		stats->v10_zstd += double(output_zstd) / double(input_zstd) - 1;
+	}
+}
+
+void testFile(const char* path, Stats* stats = 0)
+{
+	FILE* file = fopen(path, "rb");
+	if (!file)
+		return;
+
+	const char* name = strrchr(path, '/');
+	name = name ? name + 1 : path;
+
+	int vcnt, vsz;
+	int sr = sscanf(name, "v%d_s%d_", &vcnt, &vsz);
+	assert(sr == 2);
+	(void)sr;
+
+	const char* name0 = strchr(strchr(name, '_') + 1, '_') + 1;
+	const char* name1 = strstr(name0, "_R");
+	size_t namel = name1 ? name1 - name0 : strlen(name0);
+	namel = namel > 25 ? 25 : namel;
+
+	printf("%25.*s:", int(namel), name0);
+	testFile(file, vcnt, vsz, stats);
+	printf("\n");
+
+	fclose(file);
+}
 
 int main(int argc, char** argv)
 {
@@ -16,6 +144,18 @@ int main(int argc, char** argv)
 	_setmode(_fileno(stdin), _O_BINARY);
 	_setmode(_fileno(stdout), _O_BINARY);
 #endif
+
+	if (argc > 1 && (strcmp(argv[1], "-test") == 0 || strcmp(argv[1], "-testz") == 0))
+	{
+		Stats stats = {};
+		stats.testz = strcmp(argv[1], "-testz") == 0;
+		for (int i = 2; i < argc; ++i)
+			testFile(argv[i], &stats);
+		printf("---\n");
+		printf("%d files: raw v1/v0 %+.1f%%, lz4 v1/v0 %+.1f%%, zstd v1/v0 %+.1f%%\n",
+		    int(stats.count), stats.v10_raw / stats.count * 100, stats.v10_lz4 / stats.count * 100, stats.v10_zstd / stats.count * 100);
+		return 0;
+	}
 
 	if (argc < 2 || argc > 3 || atoi(argv[1]) <= 0)
 	{

--- a/tools/codectest.cpp
+++ b/tools/codectest.cpp
@@ -154,7 +154,7 @@ int main(int argc, char** argv)
 		for (int i = 2; i < argc; ++i)
 			testFile(argv[i], &stats);
 		printf("---\n");
-		printf("%d files: raw v1/v0 %+.1f%%, lz4 v1/v0 %+.1f%%, zstd v1/v0 %+.1f%%\n",
+		printf("%d files: raw v1/v0 %+.2f%%, lz4 v1/v0 %+.2f%%, zstd v1/v0 %+.2f%%\n",
 		    int(stats.count), stats.v10_raw / stats.count * 100, stats.v10_lz4 / stats.count * 100, stats.v10_zstd / stats.count * 100);
 		return 0;
 	}

--- a/tools/codectest.cpp
+++ b/tools/codectest.cpp
@@ -75,7 +75,9 @@ void testFile(FILE* file, size_t count, size_t stride, Stats* stats = 0)
 	}
 
 	std::vector<unsigned char> output(meshopt_encodeVertexBufferBound(count, stride));
+	meshopt_encodeVertexVersion(0xe);
 	output.resize(meshopt_encodeVertexBuffer(output.data(), output.size(), decoded.data(), count, stride));
+	meshopt_encodeVertexVersion(0);
 
 	printf(" raw %zu KB\t", decoded.size() / 1024);
 	printf(" v0 %.2f", double(input.size()) / double(decoded.size()));


### PR DESCRIPTION
This PR prototypes initial support for the next vertex codec version.

The change introduces version 0xe; this version has zero compatibility guarantees, and will be in the state of flux wrt bitstream format until it is finalized as version 1. The goals for the next version are to retain comparable decoding performance to v0 -- currently v0 decodes around 4.5 GB/s on Zen 4 (7950X), around 3.5 GB/s on M2 (base) -- and to increase compression ratio, targeting up to ~10% relative improvement on average for a set of geometry data. This will make the decoder more complicated and larger, but hopefully not dramatically so. Some performance loss is probably unavoidable, hopefully it can be kept at ~5% or so.

In this PR the initial infrastructure (version selection, enhanced codectest harness) is setup, and byte group encoding is expanded to support a palette of bit counts, adding support for 1-bit and 6-bit groups as well as literal byte blocks. This results in aggregate improvements as follows on the test set (~half of this is glTF data, ~half is proprietary engine data).

    143 files: raw v1/v0 -4.83%, lz4 v1/v0 -3.37%, zstd v1/v0 -0.79%

It's not certain yet that the decoding performance can be maintained with this expansion due to some issues around codegen with compilers, but that will be investigated separately. To get to the target compression ratio improvements, more changes will be necessary but they will be orthogonal to byte group encoding enhancements.

*This contribution is sponsored by Valve.*