### PR TITLE
vertexcodec: Implement enhanced delta encoding

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -95,7 +95,7 @@ jobs:
       - name: test
         run: find glTF-Sample-Assets -name '*.gltf' -or -name '*.glb' | xargs -P 2 -L 16 -d '\n' ./gltfpack -cc -test
       - name: pack
-        run: find glTF-Sample-Assets -name '*.gltf' | grep -v 'glTF-Draco' | xargs -P 2 -L 16 -d '\n' -I '{}' ./gltfpack -i '{}' -o '{}pack.gltf'
+        run: find glTF-Sample-Assets -name '*.gltf' | grep -v '\-Draco/' | xargs -P 2 -L 16 -d '\n' -I '{}' ./gltfpack -i '{}' -o '{}pack.gltf'
       - name: validate
         run: |
           curl -sL $VALIDATOR | tar xJ

--- a/demo/main.cpp
+++ b/demo/main.cpp
@@ -768,11 +768,12 @@ void encodeIndex(const Mesh& mesh, char desc)
 		    (result[i + 2] == mesh.indices[i + 0] && result[i + 0] == mesh.indices[i + 1] && result[i + 1] == mesh.indices[i + 2]));
 	}
 
-	printf("IdxCodec%c: %.1f bits/triangle (post-deflate %.1f bits/triangle); encode %.2f msec, decode %.2f msec (%.2f GB/s)\n",
+	printf("IdxCodec%c: %.1f bits/triangle (post-deflate %.1f bits/triangle); encode %.2f msec (%.3f GB/s), decode %.2f msec (%.2f GB/s)\n",
 	    desc,
 	    double(buffer.size() * 8) / double(mesh.indices.size() / 3),
 	    double(csize * 8) / double(mesh.indices.size() / 3),
 	    (middle - start) * 1000,
+	    (double(result.size() * 4) / (1 << 30)) / (middle - start),
 	    (end - middle) * 1000,
 	    (double(result.size() * 4) / (1 << 30)) / (end - middle));
 }
@@ -799,11 +800,12 @@ void encodeIndexSequence(const std::vector<unsigned int>& data, size_t vertex_co
 
 	assert(memcmp(&data[0], &result[0], data.size() * sizeof(unsigned int)) == 0);
 
-	printf("IdxCodec%c: %.1f bits/index (post-deflate %.1f bits/index); encode %.2f msec, decode %.2f msec (%.2f GB/s)\n",
+	printf("IdxCodec%c: %.1f bits/index (post-deflate %.1f bits/index); encode %.2f msec (%.3f GB/s), decode %.2f msec (%.2f GB/s)\n",
 	    desc,
 	    double(buffer.size() * 8) / double(data.size()),
 	    double(csize * 8) / double(data.size()),
 	    (middle - start) * 1000,
+	    (double(result.size() * 4) / (1 << 30)) / (middle - start),
 	    (end - middle) * 1000,
 	    (double(result.size() * 4) / (1 << 30)) / (end - middle));
 }
@@ -847,11 +849,12 @@ void encodeVertex(const Mesh& mesh, const char* pvn, bool validate = true)
 
 	size_t csize = compress(vbuf);
 
-	printf("VtxCodec%1s%s: %.1f bits/vertex (post-deflate %.1f bits/vertex); encode %.2f msec, decode %.2f msec (%.2f GB/s)\n", pvn,
+	printf("VtxCodec%1s%s: %.1f bits/vertex (post-deflate %.1f bits/vertex); encode %.2f msec (%.3f GB/s), decode %.2f msec (%.2f GB/s)\n", pvn,
 	    res == 0 && memcmp(&pv[0], &result[0], pv.size() * sizeof(PV)) == 0 ? "" : "!",
 	    double(vbuf.size() * 8) / double(mesh.vertices.size()),
 	    double(csize * 8) / double(mesh.vertices.size()),
 	    (middle - start) * 1000,
+	    (double(result.size() * sizeof(PV)) / (1 << 30)) / (middle - start),
 	    (end - middle) * 1000,
 	    (double(result.size() * sizeof(PV)) / (1 << 30)) / (end - middle));
 }

--- a/demo/tests.cpp
+++ b/demo/tests.cpp
@@ -504,6 +504,27 @@ static void decodeVertexLarge()
 	assert(memcmp(decoded, data, sizeof(data)) == 0);
 }
 
+static void decodeVertexSmall()
+{
+	unsigned char data[13 * 4];
+
+	// this tests 0/2/4/8 bit groups in one stream
+	for (size_t i = 0; i < 13; ++i)
+	{
+		data[i * 4 + 0] = 0;
+		data[i * 4 + 1] = (unsigned char)(i * 1);
+		data[i * 4 + 2] = (unsigned char)(i * 2);
+		data[i * 4 + 3] = (unsigned char)(i * 8);
+	}
+
+	std::vector<unsigned char> buffer(meshopt_encodeVertexBufferBound(13, 4));
+	buffer.resize(meshopt_encodeVertexBuffer(&buffer[0], buffer.size(), data, 13, 4));
+
+	unsigned char decoded[13 * 4];
+	assert(meshopt_decodeVertexBuffer(decoded, 13, 4, &buffer[0], buffer.size()) == 0);
+	assert(memcmp(decoded, data, sizeof(data)) == 0);
+}
+
 static void encodeVertexEmpty()
 {
 	std::vector<unsigned char> buffer(meshopt_encodeVertexBufferBound(0, 16));
@@ -1960,15 +1981,18 @@ void runTests()
 	decodeVertexMemorySafe();
 	decodeVertexRejectExtraBytes();
 	decodeVertexRejectMalformedHeaders();
+
 	decodeVertexBitGroups();
 	decodeVertexBitGroupSentinels();
 	decodeVertexLarge();
+	decodeVertexSmall();
 	encodeVertexEmpty();
 
 	meshopt_encodeVertexVersion(0xe);
 	decodeVertexBitGroups();
 	decodeVertexBitGroupSentinels();
 	decodeVertexLarge();
+	decodeVertexSmall();
 	encodeVertexEmpty();
 	meshopt_encodeVertexVersion(0);
 

--- a/src/vertexcodec.cpp
+++ b/src/vertexcodec.cpp
@@ -433,13 +433,18 @@ static int estimateChannel(const unsigned char* vertex_data, size_t vertex_count
 	for (size_t i = 0; i < vertex_count; i += kVertexBlockMaxSize)
 	{
 		size_t block_size = i + kVertexBlockMaxSize < vertex_count ? kVertexBlockMaxSize : vertex_count - i;
+		size_t block_size_aligned = (block_size + kByteGroupSize - 1) & ~(kByteGroupSize - 1);
+
+		// we sometimes encode elements we didn't fill when rounding to kByteGroupSize
+		memset(block, 0, block_size_aligned);
 
 		for (int channel = 0; channel < max_channel; ++channel)
 		{
 			for (size_t j = 0; j < 4; ++j)
 			{
 				encodeDeltas(block, vertex_data + i * vertex_size, block_size, vertex_size, last_vertex, k + j, channel);
-				sizes[channel] += encodeBytesMeasure(block, block_size, bits);
+
+				sizes[channel] += encodeBytesMeasure(block, block_size_aligned, bits);
 			}
 		}
 	}

--- a/src/vertexcodec.cpp
+++ b/src/vertexcodec.cpp
@@ -1824,6 +1824,19 @@ size_t meshopt_encodeVertexBuffer(unsigned char* buffer, size_t buffer_size, con
 		size_t total_k = vsk.header + vsk.bitg[1] + vsk.bitg[2] + vsk.bitg[4] + vsk.bitg[8];
 		double total_kr = total_k ? 1.0 / double(total_k) : 0;
 
+		if (version != 0)
+		{
+			int channel = channels[k / 4];
+
+			const char* chname = ".";
+			chname = (channel == 0) ? "1" : chname;
+			chname = (channel == 1 && k % 2 == 0) ? "2" : chname;
+			chname = (channel == 2 && k % 4 == 0) ? "4" : chname;
+			chname = (channel == 3) ? "^" : chname;
+
+			printf(" | %s", chname);
+		}
+
 		printf(" |\thdr [%5.1f%%] bitg [1 %4.1f%% 2 %4.1f%% 4 %4.1f%% 8 %4.1f%%]",
 		    double(vsk.header) * total_kr * 100,
 		    double(vsk.bitg[1]) * total_kr * 100, double(vsk.bitg[2]) * total_kr * 100,
@@ -1843,6 +1856,7 @@ size_t meshopt_encodeVertexBuffer(unsigned char* buffer, size_t buffer_size, con
 		    double(vsk.bitc[2]) / double(vertex_count) * 100, double(vsk.bitc[3]) / double(vertex_count) * 100,
 		    double(vsk.bitc[4]) / double(vertex_count) * 100, double(vsk.bitc[5]) / double(vertex_count) * 100,
 		    double(vsk.bitc[6]) / double(vertex_count) * 100, double(vsk.bitc[7]) / double(vertex_count) * 100);
+
 		printf("\n");
 	}
 #endif

--- a/src/vertexcodec.cpp
+++ b/src/vertexcodec.cpp
@@ -165,7 +165,7 @@ inline unsigned int zigzag32(unsigned int v)
 template <typename T>
 inline T unzigzag(T v)
 {
-	return -(v & 1) ^ (v >> 1);
+	return (0 - (v & 1)) ^ (v >> 1);
 }
 
 #if TRACE
@@ -659,18 +659,14 @@ static void decodeDeltas1(const unsigned char* buffer, unsigned char* transposed
 		size_t vertex_offset = k;
 
 		T p = last_vertex[0];
-		if (sizeof(T) > 1)
-			p |= last_vertex[1] << 8;
-		if (sizeof(T) > 2)
-			p |= (last_vertex[2] << 16) | (last_vertex[3] << 24);
+		for (size_t j = 1; j < sizeof(T); ++j)
+			p |= last_vertex[j] << (8 * j);
 
 		for (size_t i = 0; i < vertex_count; ++i)
 		{
 			T v = buffer[i];
-			if (sizeof(T) > 1)
-				v |= buffer[i + vertex_count] << 8;
-			if (sizeof(T) > 2)
-				v |= (buffer[i + vertex_count * 2] << 16) | (buffer[i + vertex_count * 3] << 24);
+			for (size_t j = 1; j < sizeof(T); ++j)
+				v |= buffer[i + vertex_count * j] << (8 * j);
 
 			v = Xor ? v ^ p : unzigzag(v) + p;
 
@@ -1796,7 +1792,7 @@ size_t meshopt_encodeVertexBuffer(unsigned char* buffer, size_t buffer_size, con
 	unsigned char channels[64] = {};
 	if (version != 0)
 		for (size_t k = 0; k < vertex_size; k += 4)
-			channels[k / 4] = estimateChannel(vertex_data, vertex_count, vertex_size, k, kEncodeMaxChannel);
+			channels[k / 4] = (unsigned char)estimateChannel(vertex_data, vertex_count, vertex_size, k, kEncodeMaxChannel);
 
 	size_t vertex_block_size = getVertexBlockSize(vertex_size);
 

--- a/tools/codectest.cpp
+++ b/tools/codectest.cpp
@@ -133,7 +133,12 @@ void testFile(const char* path, Stats* stats = 0)
 	size_t namel = name1 ? name1 - name0 : strlen(name0);
 	namel = namel > 25 ? 25 : namel;
 
+#if TRACE
+	printf("%.*s: %s\n", int(namel), name0, path);
+#else
 	printf("%25.*s:", int(namel), name0);
+#endif
+
 	testFile(file, vcnt, vsz, stats);
 	printf("\n");
 


### PR DESCRIPTION
When using new format we can now select between byte and halfword
deltas, or switch to xor without zigzag encoding (which is
width-invariant).

Different types of deltas are optimal for different content; 2-byte
deltas provide the most value, whereas 4-byte and XOR deltas are more
experimental. This PR initially contained support for 4-byte deltas as well,
but it was increasing complexity without providing value so it was removed.
Xor deltas could be used to optimize for decoding performance when they
don't change the ratio.

The delta encoding is stored as a channel type for every 4 bytes of the
vertex;for now we only need to encode a 2-bit value, but we reserve a full
byte for simplicity - this may change in the future to accommodate rotates.

While varying the channel data per vertex block may be helpful, it
increases the block overhead and switching encodings for adjacent blocks
penalizes efficiency of LZ compressors. As such, we will only work with
a single encoding across the entire data stream for every channel.

To select the delta encoding, we try to encode deltas in all possible ways
and count the estimated number of bytes using a specific control mode.
This is not technically optimal as it ignores other subtleties of byte group
encoding, but ends up close to optimal in terms of efficiency. This also
significantly slows down encoding process, but that can be fixed once we
settle on the delta types we need to support.

With this, we're up to >5% gains overall, with no loss of decoding performance:
> 143 files: raw v1/v0 -5.24%, lz4 v1/v0 -4.21%, zstd v1/v0 -2.76%

With just 1/2 byte deltas, we get:
> 143 files: raw v1/v0 -5.20%, lz4 v1/v0 -4.21%, zstd v1/v0 -2.75%

As before, all of these changes are to an experimental version that has absolutely
no guarantees of bitstream compatibility until it gets renumbered to 1.

*This contribution is sponsored by Valve.*