### PR TITLE
vertexcodec: Augment XOR delta encoding with rotation

### DIFF
--- a/demo/main.cpp
+++ b/demo/main.cpp
@@ -824,7 +824,7 @@ void packVertex(const Mesh& mesh, const char* pvn)
 }
 
 template <typename PV>
-void encodeVertex(const Mesh& mesh, const char* pvn, bool validate = true)
+void encodeVertex(const Mesh& mesh, const char* pvn)
 {
 	std::vector<PV> pv(mesh.vertices.size());
 	packMesh(pv, mesh.vertices);
@@ -840,17 +840,16 @@ void encodeVertex(const Mesh& mesh, const char* pvn, bool validate = true)
 	double middle = timestamp();
 
 	int res = meshopt_decodeVertexBuffer(&result[0], mesh.vertices.size(), sizeof(PV), &vbuf[0], vbuf.size());
-	assert(!validate || res == 0);
+	assert(res == 0);
 	(void)res;
 
 	double end = timestamp();
 
-	assert(!validate || memcmp(&pv[0], &result[0], pv.size() * sizeof(PV)) == 0);
+	assert(memcmp(&pv[0], &result[0], pv.size() * sizeof(PV)) == 0);
 
 	size_t csize = compress(vbuf);
 
-	printf("VtxCodec%1s%s: %.1f bits/vertex (post-deflate %.1f bits/vertex); encode %.2f msec (%.3f GB/s), decode %.2f msec (%.2f GB/s)\n", pvn,
-	    res == 0 && memcmp(&pv[0], &result[0], pv.size() * sizeof(PV)) == 0 ? "" : "!",
+	printf("VtxCodec%1s: %.1f bits/vertex (post-deflate %.1f bits/vertex); encode %.2f msec (%.3f GB/s), decode %.2f msec (%.2f GB/s)\n", pvn,
 	    double(vbuf.size() * 8) / double(mesh.vertices.size()),
 	    double(csize * 8) / double(mesh.vertices.size()),
 	    (middle - start) * 1000,
@@ -1409,7 +1408,7 @@ void processDev(const char* path)
 	meshopt_encodeVertexVersion(0);
 	encodeVertex<PackedVertex>(copy, "0");
 	meshopt_encodeVertexVersion(0xe);
-	encodeVertex<PackedVertex>(copy, "1", /* validate= */ false);
+	encodeVertex<PackedVertex>(copy, "1");
 }
 
 void processNanite(const char* path)

--- a/src/vertexcodec.cpp
+++ b/src/vertexcodec.cpp
@@ -164,7 +164,7 @@ inline unsigned int zigzag(unsigned int v)
 
 inline unsigned int rotate(unsigned int v, int r)
 {
-	return (v << r) | (v >> (32 - r));
+	return (v << r) | (v >> ((32 - r) & 31));
 }
 
 template <typename T>

--- a/src/vertexcodec.cpp
+++ b/src/vertexcodec.cpp
@@ -1745,16 +1745,13 @@ size_t meshopt_encodeVertexBuffer(unsigned char* buffer, size_t buffer_size, con
 		{
 			int channel = channels[k / 4];
 
-			const char* chname = ".";
-			chname = (channel == 0) ? "1" : chname;
-			chname = (channel == 1 && k % 2 == 0) ? "2" : chname;
-			chname = (channel == 2 && k % 4 == 0) ? "4" : chname;
-			chname = (channel == 3) ? "^" : chname;
-
-			printf(" | %s", chname);
+			if ((channel & 3) == 2 && k % 4 == 0)
+				printf(" | ^%2d", channel >> 3);
+			else
+				printf(" | %3s", channel == 0 ? "1" : (channel == 1 && k % 2 == 0 ? "2" : "."));
 		}
 
-		printf(" |\thdr [%5.1f%%] bitg [1 %4.1f%% 2 %4.1f%% 4 %4.1f%% 8 %4.1f%%]",
+		printf(" | hdr [%5.1f%%] bitg [1 %4.1f%% 2 %4.1f%% 4 %4.1f%% 8 %4.1f%%]",
 		    double(vsk.header) * total_kr * 100,
 		    double(vsk.bitg[1]) * total_kr * 100, double(vsk.bitg[2]) * total_kr * 100,
 		    double(vsk.bitg[4]) * total_kr * 100, double(vsk.bitg[8]) * total_kr * 100);
@@ -1763,13 +1760,13 @@ size_t meshopt_encodeVertexBuffer(unsigned char* buffer, size_t buffer_size, con
 
 		if (total_ctrl)
 		{
-			printf(" |\tctrl %3.0f%% %3.0f%% %3.0f%% %3.0f%%",
+			printf(" | ctrl %3.0f%% %3.0f%% %3.0f%% %3.0f%%",
 			    double(vsk.ctrl[0]) / double(total_ctrl) * 100, double(vsk.ctrl[1]) / double(total_ctrl) * 100,
 			    double(vsk.ctrl[2]) / double(total_ctrl) * 100, double(vsk.ctrl[3]) / double(total_ctrl) * 100);
 		}
 
 #if TRACE > 1
-		printf(" |\tbitc [%3.0f%% %3.0f%% %3.0f%% %3.0f%% %3.0f%% %3.0f%% %3.0f%% %3.0f%%]",
+		printf(" | bitc [%3.0f%% %3.0f%% %3.0f%% %3.0f%% %3.0f%% %3.0f%% %3.0f%% %3.0f%%]",
 		    double(vsk.bitc[0]) / double(vertex_count) * 100, double(vsk.bitc[1]) / double(vertex_count) * 100,
 		    double(vsk.bitc[2]) / double(vertex_count) * 100, double(vsk.bitc[3]) / double(vertex_count) * 100,
 		    double(vsk.bitc[4]) / double(vertex_count) * 100, double(vsk.bitc[5]) / double(vertex_count) * 100,

--- a/src/vertexcodec.cpp
+++ b/src/vertexcodec.cpp
@@ -370,7 +370,7 @@ static void encodeDeltas1(unsigned char* buffer, const unsigned char* vertex_dat
 		for (size_t j = 1; j < sizeof(T); ++j)
 			v |= vertex_data[i * vertex_size + k0 + j] << (j * 8);
 
-		T d = Xor ? rotate(v ^ p, rot) : zigzag(T(v - p));
+		T d = Xor ? T(rotate(v ^ p, rot)) : zigzag(T(v - p));
 
 		buffer[i] = (unsigned char)(d >> ks);
 		p = v;
@@ -689,7 +689,7 @@ static void decodeDeltas1(const unsigned char* buffer, unsigned char* transposed
 			for (size_t j = 1; j < sizeof(T); ++j)
 				v |= buffer[i + vertex_count * j] << (8 * j);
 
-			v = Xor ? rotate(v, rot) ^ p : unzigzag(v) + p;
+			v = Xor ? T(rotate(v, rot)) ^ p : unzigzag(v) + p;
 
 			for (size_t j = 0; j < sizeof(T); ++j)
 				transposed[vertex_offset + j] = (unsigned char)(v >> (j * 8));


### PR DESCRIPTION
This can be useful to align the bits better in certain cases. However,
rotates come with a set of questions: what's the granularity? which
delta modes do they work in? how much do they cost to decode?

Ideally perhaps we would do fully orthogonal rotates. However, rotates
can be done as a filter step; as such, from the decoder perspective it's
best to focus on rotate applications that are minimal.

When combined with SUB deltas, rotates must be done after deltas get
recombined. This makes them expensive, as this step is ~scalarized. When
using XOR deltas, rotates can be done before or after undelta; that
makes them cheaper and aligns XOR decoding with other delta forms, as
the cost is similar to unzigzag.

Conceptually, there's also some value in this split: SUB deltas assume
integer-like values and bit propagation from MSB to LSB, so bit
alignment is expected; for arbitrary bitpacked data, SUB deltas end up
crossing packing thresholds so they are not optimal.

With XOR deltas, we could still choose to encode 8-bit or 16-bit
rotates. However, since SIMD ISAs commonly lack per-lane rotates, 16-bit
rotates require fixing both halves to do the same rotation which is not
really better than a 32-bit rotate; 8-bit rotates could be done before
transposition but require 12 bits (3x4) of extra channel encoding, 4x more
time to encode, are not much stronger vs a single 32-bit rotate that neatly
fits into existing channel encoding.

This change makes encoding substantially slower; however, future PRs are
expected to improve this as well as introduce support for compression
levels.

*This contribution is sponsored by Valve.*