### PR TITLE
vertexcodec: Implement support for compression levels

### DIFF
--- a/demo/main.cpp
+++ b/demo/main.cpp
@@ -824,7 +824,7 @@ void packVertex(const Mesh& mesh, const char* pvn)
 }
 
 template <typename PV>
-void encodeVertex(const Mesh& mesh, const char* pvn)
+void encodeVertex(const Mesh& mesh, const char* pvn, int level = 2)
 {
 	std::vector<PV> pv(mesh.vertices.size());
 	packMesh(pv, mesh.vertices);
@@ -835,7 +835,7 @@ void encodeVertex(const Mesh& mesh, const char* pvn)
 	double start = timestamp();
 
 	std::vector<unsigned char> vbuf(meshopt_encodeVertexBufferBound(mesh.vertices.size(), sizeof(PV)));
-	vbuf.resize(meshopt_encodeVertexBuffer(&vbuf[0], vbuf.size(), &pv[0], mesh.vertices.size(), sizeof(PV)));
+	vbuf.resize(meshopt_encodeVertexBufferLevel(&vbuf[0], vbuf.size(), &pv[0], mesh.vertices.size(), sizeof(PV), level));
 
 	double middle = timestamp();
 
@@ -1406,9 +1406,12 @@ void processDev(const char* path)
 	meshopt_optimizeVertexFetch(&copy.vertices[0], &copy.indices[0], copy.indices.size(), &copy.vertices[0], copy.vertices.size(), sizeof(Vertex));
 
 	meshopt_encodeVertexVersion(0);
-	encodeVertex<PackedVertex>(copy, "0");
+	encodeVertex<PackedVertex>(copy, "L");
 	meshopt_encodeVertexVersion(0xe);
-	encodeVertex<PackedVertex>(copy, "1");
+	encodeVertex<PackedVertex>(copy, "0", 0);
+	encodeVertex<PackedVertex>(copy, "1", 1);
+	encodeVertex<PackedVertex>(copy, "2", 2);
+	encodeVertex<PackedVertex>(copy, "3", 3);
 }
 
 void processNanite(const char* path)

--- a/demo/tests.cpp
+++ b/demo/tests.cpp
@@ -518,7 +518,7 @@ static void decodeVertexBitXor()
 	}
 
 	std::vector<unsigned char> buffer(meshopt_encodeVertexBufferBound(16, 16));
-	buffer.resize(meshopt_encodeVertexBuffer(&buffer[0], buffer.size(), data, 16, 16));
+	buffer.resize(meshopt_encodeVertexBufferLevel(&buffer[0], buffer.size(), data, 16, 16, 2));
 
 	unsigned int decoded[16 * 4];
 	assert(meshopt_decodeVertexBuffer(decoded, 16, 16, &buffer[0], buffer.size()) == 0);

--- a/demo/tests.cpp
+++ b/demo/tests.cpp
@@ -497,7 +497,7 @@ static void decodeVertexDeltas()
 	}
 
 	std::vector<unsigned char> buffer(meshopt_encodeVertexBufferBound(16, 8));
-	buffer.resize(meshopt_encodeVertexBuffer(&buffer[0], buffer.size(), data, 16, 8));
+	buffer.resize(meshopt_encodeVertexBufferLevel(&buffer[0], buffer.size(), data, 16, 8, 2));
 
 	unsigned short decoded[16 * 4];
 	assert(meshopt_decodeVertexBuffer(decoded, 16, 8, &buffer[0], buffer.size()) == 0);
@@ -513,12 +513,12 @@ static void decodeVertexBitXor()
 	{
 		data[i * 4 + 0] = unsigned(i << 0);
 		data[i * 4 + 1] = unsigned(i << 2);
-		data[i * 4 + 2] = unsigned(i << 17);
+		data[i * 4 + 2] = unsigned(i << 15);
 		data[i * 4 + 3] = unsigned(i << 28);
 	}
 
 	std::vector<unsigned char> buffer(meshopt_encodeVertexBufferBound(16, 16));
-	buffer.resize(meshopt_encodeVertexBufferLevel(&buffer[0], buffer.size(), data, 16, 16, 2));
+	buffer.resize(meshopt_encodeVertexBufferLevel(&buffer[0], buffer.size(), data, 16, 16, 3));
 
 	unsigned int decoded[16 * 4];
 	assert(meshopt_decodeVertexBuffer(decoded, 16, 16, &buffer[0], buffer.size()) == 0);

--- a/src/meshoptimizer.h
+++ b/src/meshoptimizer.h
@@ -279,8 +279,9 @@ MESHOPTIMIZER_API size_t meshopt_encodeVertexBufferBound(size_t vertex_count, si
 
 /**
  * Experimental: Vertex buffer encoder
- * Encodes vertex data just like meshopt_encodeVertexBuffer, but allows to specify compression level.
+ * Encodes vertex data just like meshopt_encodeVertexBuffer, but allows to override compression level.
  * For compression level to take effect, the vertex encoding version must be set to 1 via meshopt_encodeVertexVersion.
+ * The default compression level implied by meshopt_encodeVertexBuffer is 2.
  *
  * level should be in the range [0, 3] with 0 being the fastest and 3 being the slowest and producing the best compression ratio.
  */

--- a/src/meshoptimizer.h
+++ b/src/meshoptimizer.h
@@ -278,6 +278,15 @@ MESHOPTIMIZER_API size_t meshopt_encodeVertexBuffer(unsigned char* buffer, size_
 MESHOPTIMIZER_API size_t meshopt_encodeVertexBufferBound(size_t vertex_count, size_t vertex_size);
 
 /**
+ * Experimental: Vertex buffer encoder
+ * Encodes vertex data just like meshopt_encodeVertexBuffer, but allows to specify compression level.
+ * For compression level to take effect, the vertex encoding version must be set to 1 via meshopt_encodeVertexVersion.
+ *
+ * level should be in the range [0, 3] with 0 being the fastest and 3 being the slowest and producing the best compression ratio.
+ */
+MESHOPTIMIZER_API size_t meshopt_encodeVertexBufferLevel(unsigned char* buffer, size_t buffer_size, const void* vertices, size_t vertex_count, size_t vertex_size, int level);
+
+/**
  * Set vertex encoder format version
  * version must specify the data format version to encode; valid values are 0 (decodable by all library versions)
  */

--- a/src/vertexcodec.cpp
+++ b/src/vertexcodec.cpp
@@ -974,27 +974,15 @@ inline const unsigned char* decodeBytesGroupSimd(const unsigned char* data, unsi
 #endif
 
 #ifdef SIMD_AVX
-static const __m128i decodeBytesGroupConfig[2][8] = {
-    {
-        _mm_setzero_si128(),
-        _mm_set1_epi8(3),
-        _mm_set1_epi8(15),
-        _mm_setzero_si128(),
-        _mm_setzero_si128(),
-        _mm_set1_epi8(1),
-        _mm_set1_epi8(3),
-        _mm_set1_epi8(15),
-    },
-    {
-        _mm_setzero_si128(),
-        _mm_setr_epi8(6, 4, 2, 0, 14, 12, 10, 8, 22, 20, 18, 16, 30, 28, 26, 24),
-        _mm_setr_epi8(4, 0, 12, 8, 20, 16, 28, 24, 36, 32, 44, 40, 52, 48, 60, 56),
-        _mm_setzero_si128(),
-        _mm_setzero_si128(),
-        _mm_setr_epi8(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15),
-        _mm_setr_epi8(6, 4, 2, 0, 14, 12, 10, 8, 22, 20, 18, 16, 30, 28, 26, 24),
-        _mm_setr_epi8(4, 0, 12, 8, 20, 16, 28, 24, 36, 32, 44, 40, 52, 48, 60, 56),
-    },
+static const __m128i kDecodeBytesGroupConfig[8][2] = {
+    {_mm_setzero_si128(), _mm_setzero_si128()},
+    {_mm_set1_epi8(3), _mm_setr_epi8(6, 4, 2, 0, 14, 12, 10, 8, 22, 20, 18, 16, 30, 28, 26, 24)},
+    {_mm_set1_epi8(15), _mm_setr_epi8(4, 0, 12, 8, 20, 16, 28, 24, 36, 32, 44, 40, 52, 48, 60, 56)},
+    {_mm_setzero_si128(), _mm_setzero_si128()},
+    {_mm_setzero_si128(), _mm_setzero_si128()},
+    {_mm_set1_epi8(1), _mm_setr_epi8(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)},
+    {_mm_set1_epi8(3), _mm_setr_epi8(6, 4, 2, 0, 14, 12, 10, 8, 22, 20, 18, 16, 30, 28, 26, 24)},
+    {_mm_set1_epi8(15), _mm_setr_epi8(4, 0, 12, 8, 20, 16, 28, 24, 36, 32, 44, 40, 52, 48, 60, 56)},
 };
 
 SIMD_TARGET
@@ -1023,8 +1011,8 @@ inline const unsigned char* decodeBytesGroupSimd(const unsigned char* data, unsi
 		__m128i selb = _mm_loadl_epi64(reinterpret_cast<const __m128i*>(data));
 		__m128i rest = _mm_loadu_si128(reinterpret_cast<const __m128i*>(skip));
 
-		__m128i sent = decodeBytesGroupConfig[0][hbits];
-		__m128i ctrl = decodeBytesGroupConfig[1][hbits];
+		__m128i sent = kDecodeBytesGroupConfig[hbits][0];
+		__m128i ctrl = kDecodeBytesGroupConfig[hbits][1];
 
 		__m128i selw = _mm_shuffle_epi32(selb, 0x44);
 		__m128i sel = _mm_and_si128(sent, _mm_multishift_epi64_epi8(ctrl, selw));

--- a/src/vertexcodec.cpp
+++ b/src/vertexcodec.cpp
@@ -1637,6 +1637,7 @@ size_t meshopt_encodeVertexBufferLevel(unsigned char* buffer, size_t buffer_size
 
 	assert(vertex_size > 0 && vertex_size <= 256);
 	assert(vertex_size % 4 == 0);
+	assert(level >= 0 && level <= 9); // only a subset of this range is used right now
 
 #if TRACE
 	memset(vertexstats, 0, sizeof(vertexstats));

--- a/src/vertexcodec.cpp
+++ b/src/vertexcodec.cpp
@@ -147,24 +147,15 @@ static size_t getVertexBlockSize(size_t vertex_size)
 	return (result < kVertexBlockMaxSize) ? result : kVertexBlockMaxSize;
 }
 
-inline unsigned char zigzag(unsigned char v)
-{
-	return ((signed char)(v) >> 7) ^ (v << 1);
-}
-
-inline unsigned short zigzag(unsigned short v)
-{
-	return ((signed short)(v) >> 15) ^ (v << 1);
-}
-
-inline unsigned int zigzag(unsigned int v)
-{
-	return ((signed int)(v) >> 31) ^ (v << 1);
-}
-
 inline unsigned int rotate(unsigned int v, int r)
 {
 	return (v << r) | (v >> ((32 - r) & 31));
+}
+
+template <typename T>
+inline T zigzag(T v)
+{
+	return (0 - (v >> (sizeof(T) * 8 - 1))) ^ (v << 1);
 }
 
 template <typename T>

--- a/src/vertexcodec.cpp
+++ b/src/vertexcodec.cpp
@@ -408,6 +408,7 @@ static int estimateRotate(const unsigned char* vertex_data, size_t vertex_count,
 	{
 		unsigned int bitg = 0;
 
+		// calculate bit consistency mask for the group
 		for (size_t j = 0; j < group_size && i + j < vertex_count; ++j)
 		{
 			unsigned int v = vertex[0] | (vertex[1] << 8) | (vertex[2] << 16) | (vertex[3] << 24);
@@ -417,6 +418,10 @@ static int estimateRotate(const unsigned char* vertex_data, size_t vertex_count,
 			last = v;
 			vertex += vertex_size;
 		}
+
+		// ignore trivial groups for performance
+		if (bitg == 0 || bitg == ~0u)
+			continue;
 
 		for (int j = 0; j < 8; ++j)
 		{

--- a/src/vertexcodec.cpp
+++ b/src/vertexcodec.cpp
@@ -428,7 +428,7 @@ static int estimateRotate(const unsigned char* vertex_data, size_t vertex_count,
 		{
 			unsigned int bitr = rotate(bitg, j);
 
-			sizes[j] += estimateBits(bitr >> 0) + estimateBits(bitr >> 8) + estimateBits(bitr >> 16) + estimateBits(bitr >> 24);
+			sizes[j] += estimateBits((unsigned char)(bitr >> 0)) + estimateBits((unsigned char)(bitr >> 8)) + estimateBits((unsigned char)(bitr >> 16)) + estimateBits((unsigned char)(bitr >> 24));
 		}
 	}
 


### PR DESCRIPTION
While individual components of the encoder can always be optimized
further, to ensure that control over encode time/size tradeoff is still
present, meshopt_encodeVertexBufferLevel can now choose compression
level. For v0 all levels are equivalent; for v1, currently:

- level 0 is closest to v0 and picks a single bitgroup layout (while
  still supporting zero channels as these are fast to reject)
- level 1 picks the best bitgroup layout but only uses byte deltas
- level 2 selects 1- or 2- byte deltas per channel, without XOR/rot
- level 3 selects XOR/rot per channel

These may change as performance characteristics of the encoder change.

This PR also significantly optimizes all levels in subsequent commits.
The initial numbers after the first commit were:

> v0: 0.585 GB/s
> v1 level 0: 0.548 GB/s
> v1 level 1: 0.398 GB/s
> v1 level 2: 0.217 GB/s
> v1 level 3: 0.060 GB/s

The new numbers are:

> v0 encode: 0.778 GB/s
> v1 level 0: 0.722 GB/s
> v1 level 1: 0.591 GB/s
> v1 level 2: 0.482 GB/s
> v1 level 3: 0.386 GB/s

For now level 2 is the default; while it is currently ~20% slower to encode vs what v0 used to encode at, using level 1 as a baseline would disable wider deltas and realistically almost 500 MB/s of encoding speed is likely sufficient. Applications that need slightly more gains for complex bitpacked data could choose level 2; applications that need streaming encoding can choose levels 1 or 0.

*This contribution is sponsored by Valve.*