### PR TITLE
vertexcodec: Additional latency optimizations for delta decoding

### DIFF
--- a/src/vertexcodec.cpp
+++ b/src/vertexcodec.cpp
@@ -1351,21 +1351,6 @@ inline uint8x16_t rotate32(uint8x16_t v, int r)
 }
 
 template <int Channel>
-SIMD_TARGET inline uint8x16_t undelta(uint8x16_t a, uint8x16_t b)
-{
-	return Channel == 0 ? vaddq_u8(a, b) : (Channel == 1 ? vreinterpretq_u8_u16(vaddq_u16(vreinterpretq_u16_u8(a), vreinterpretq_u16_u8(b))) : veorq_u8(a, b));
-}
-
-template <int Channel>
-SIMD_TARGET inline uint8x16_t undelta4(uint8x16_t v)
-{
-	uint8x16_t zero = vdupq_n_u8(0);
-	v = undelta<Channel>(v, vextq_u8(zero, v, 12));
-	v = undelta<Channel>(v, vextq_u8(zero, v, 8));
-	return v;
-}
-
-template <int Channel>
 SIMD_TARGET inline uint8x8_t rebase(uint8x8_t npi, uint8x16_t r0, uint8x16_t r1, uint8x16_t r2, uint8x16_t r3)
 {
 	switch (Channel)
@@ -1498,7 +1483,6 @@ decodeDeltas4Simd(const unsigned char* buffer, unsigned char* transposed, size_t
 #define GRP4(i) t0 = vget_low_u8(r##i), t1 = vreinterpret_u8_u32(vdup_lane_u32(vreinterpret_u32_u8(t0), 1)), t2 = vget_high_u8(r##i), t3 = vreinterpret_u8_u32(vdup_lane_u32(vreinterpret_u32_u8(t2), 1))
 #define FIXD(i) t##i = pi = Channel == 0 ? vadd_u8(pi, t##i) : (Channel == 1 ? vreinterpret_u8_u16(vadd_u16(vreinterpret_u16_u8(pi), vreinterpret_u16_u8(t##i))) : veor_u8(pi, t##i))
 #define SAVE(i) vst1_lane_u32(reinterpret_cast<uint32_t*>(savep), vreinterpret_u32_u8(t##i), 0), savep += vertex_size
-#define STOR(i, l) vst1q_lane_u32(reinterpret_cast<uint32_t*>(savep), vreinterpretq_u32_u8(r##i), l), savep += vertex_size
 #endif
 
 #ifdef SIMD_WASM
@@ -1525,25 +1509,6 @@ decodeDeltas4Simd(const unsigned char* buffer, unsigned char* transposed, size_t
 
 		transpose8(r0, r1, r2, r3);
 
-#if defined(SIMD_NEON) && 0
-		UNZR(0), UNZR(1), UNZR(2), UNZR(3);
-
-		r0 = undelta4<Channel>(r0);
-		r1 = undelta4<Channel>(r1);
-		r2 = undelta4<Channel>(r2);
-		r3 = undelta4<Channel>(r3);
-
-		r0 = undelta<Channel>(r0, vdupq_lane_u32(vreinterpret_u32_u8(pi), 0));
-		r1 = undelta<Channel>(r1, vdupq_laneq_u32(vreinterpretq_u32_u8(r0), 3));
-		r2 = undelta<Channel>(r2, vdupq_laneq_u32(vreinterpretq_u32_u8(r1), 3));
-		r3 = undelta<Channel>(r3, vdupq_laneq_u32(vreinterpretq_u32_u8(r2), 3));
-		pi = vdup_lane_u32(vget_high_u8(r3), 1);
-
-		STOR(0, 0), STOR(0, 1), STOR(0, 2), STOR(0, 3);
-		STOR(1, 0), STOR(1, 1), STOR(1, 2), STOR(1, 3);
-		STOR(2, 0), STOR(2, 1), STOR(2, 2), STOR(2, 3);
-		STOR(3, 0), STOR(3, 1), STOR(3, 2), STOR(3, 3);
-#else
 		TEMP t0, t1, t2, t3;
 		TEMP npi = pi;
 
@@ -1573,8 +1538,6 @@ decodeDeltas4Simd(const unsigned char* buffer, unsigned char* transposed, size_t
 		(void)npi;
 #endif
 
-#endif
-
 #undef UNZR
 #undef TEMP
 #undef PREP
@@ -1582,7 +1545,6 @@ decodeDeltas4Simd(const unsigned char* buffer, unsigned char* transposed, size_t
 #undef GRP4
 #undef FIXD
 #undef SAVE
-#undef STOR
 	}
 }
 

--- a/src/vertexcodec.cpp
+++ b/src/vertexcodec.cpp
@@ -1532,7 +1532,8 @@ decodeDeltas4Simd(const unsigned char* buffer, unsigned char* transposed, size_t
 		FIXD(0), FIXD(1), FIXD(2), FIXD(3);
 		SAVE(0), SAVE(1), SAVE(2), SAVE(3);
 
-#if defined(SIMD_NEON)
+#if defined(SIMD_LATENCYOPT) && defined(SIMD_NEON) && defined(__APPLE__)
+		// instead of relying on accumulated pi, recompute it from scratch from r0..r3; this shortens dependency between loop iterations
 		pi = rebase<Channel>(npi, r0, r1, r2, r3);
 #else
 		(void)npi;


### PR DESCRIPTION
The second half of the delta decoding loop relies on 16 serialized instructions that
incrementally compute 4 prefix sums and store the results. On Apple CPUs, this is a critical
path of the loop: subsequent iterations depend on updated value of `pi`, and this restricts
throughput.

While this could be worked around by doing parallel prefix sum computations (for each
of the 4 channels individually), that only really works for byte groups. A partial parallel
prefix sum that computes prefix sums in groups of 4 values and then adjusts them with
serial accumulation was implemented in the first commit in this PR; that makes full decoding
~20% faster on Apple M2.

Unfortunately, that approach does not translate to any other CPU - it's slower on Zen 3 and
Graviton 2 - and requires a completely separate implementation. Thus, this change switches
to a different method in a later commit, which recomputes `pi` from individual elements - this
is easier to do than a full prefix sum, since we only need to perform 4 parallel reductions (for
bytes) and that can be done fairly efficiently.

On Apple M2, this is even faster than the original method, resulting in up to 25% faster decoding,
`codecbench` reports 3.85 GB/s => 4.89 GB/s. The impact on just delta decoding is much stronger,
`decodeDeltas4Simd` gets ~1.7x faster.

This change does not translate to wins on other CPUs either (~2% regression on Zen 3, ~3%
regression on Graviton 2), but it is easier to maintain alongside other code. So for now we only
enable this on Apple CPUs to ensure this is a net positive.

(also a more minor optimization was committed separately in https://github.com/zeux/meshoptimizer/commit/abcfe76a0cd8dbeb2bc94c59bcb9ba8ac526ff58)

*This contribution is sponsored by Valve.*