### PR TITLE
demo: Streamline METIS integration in clustered simplification demo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,11 +35,6 @@ ifdef BASISU
     endif
 endif
 
-ifdef METIS
-    $(DEMO_OBJECTS): CXXFLAGS+=-DMETIS
-    $(DEMO): LDFLAGS+=-lmetis
-endif
-
 WASI_SDK?=/opt/wasi-sdk
 WASMCC?=$(WASI_SDK)/bin/clang++
 WASIROOT?=$(WASI_SDK)/share/wasi-sysroot

--- a/demo/nanite.cpp
+++ b/demo/nanite.cpp
@@ -167,7 +167,7 @@ static void clusterizeMetisRec(std::vector<Cluster>& result, const std::vector<u
 				adjncy.push_back(triadj[i * 3 + j]);
 			}
 
-		xadj[i + 1] = adjncy.size();
+		xadj[i + 1] = int(adjncy.size());
 	}
 
 	int options[METIS_NOPTIONS];
@@ -265,7 +265,7 @@ static std::vector<Cluster> clusterizeMetis(const std::vector<Vertex>& vertices,
 		std::vector<std::vector<int> > trilist(vertices.size());
 
 		for (size_t i = 0; i < indices.size(); ++i)
-			trilist[shadowib[i]].push_back(i / 3);
+			trilist[shadowib[i]].push_back(int(i / 3));
 
 		std::vector<int> xadj(indices.size() / 3 + 1);
 		std::vector<int> adjncy;
@@ -301,7 +301,7 @@ static std::vector<Cluster> clusterizeMetis(const std::vector<Vertex>& vertices,
 				}
 			}
 
-			xadj[i + 1] = adjncy.size();
+			xadj[i + 1] = int(adjncy.size());
 		}
 
 		int options[METIS_NOPTIONS];
@@ -438,7 +438,7 @@ static std::vector<std::vector<int> > partitionMetis(const std::vector<Cluster>&
 				adjwgt.push_back(it->second);
 			}
 
-		xadj[i + 1] = adjncy.size();
+		xadj[i + 1] = int(adjncy.size());
 	}
 
 	int options[METIS_NOPTIONS];

--- a/demo/nanite.cpp
+++ b/demo/nanite.cpp
@@ -164,7 +164,10 @@ static void clusterizeMetisRec(std::vector<Cluster>& result, const std::vector<u
 	{
 		for (int j = 0; j < 3; ++j)
 			if (triadj[i * 3 + j] != -1)
+			{
+				assert(triadj[i * 3 + j] != int(i));
 				adjncy.push_back(triadj[i * 3 + j]);
+			}
 
 		xadj[i + 1] = adjncy.size();
 	}
@@ -244,9 +247,9 @@ static std::vector<Cluster> clusterizeMetis(const std::vector<Vertex>& vertices,
 		std::map<std::pair<unsigned int, unsigned int>, unsigned int>::iterator obc = edges.find(std::make_pair(v2, v1));
 		std::map<std::pair<unsigned int, unsigned int>, unsigned int>::iterator oca = edges.find(std::make_pair(v0, v2));
 
-		triadj[i + 0] = oab != edges.end() ? int(oab->second) : -1;
-		triadj[i + 1] = obc != edges.end() ? int(obc->second) : -1;
-		triadj[i + 2] = oca != edges.end() ? int(oca->second) : -1;
+		triadj[i + 0] = oab != edges.end() && oab->second != i / 3 ? int(oab->second) : -1;
+		triadj[i + 1] = obc != edges.end() && obc->second != i / 3 ? int(obc->second) : -1;
+		triadj[i + 2] = oca != edges.end() && oca->second != i / 3 ? int(oca->second) : -1;
 	}
 
 	if (kRecMetis)
@@ -271,6 +274,7 @@ static std::vector<Cluster> clusterizeMetis(const std::vector<Vertex>& vertices,
 			for (int j = 0; j < 3; ++j)
 				if (triadj[i * 3 + j] != -1)
 				{
+					assert(triadj[i * 3 + j] != int(i));
 					adjncy.push_back(triadj[i * 3 + j]);
 					adjwgt.push_back(1);
 				}

--- a/demo/nanite.cpp
+++ b/demo/nanite.cpp
@@ -627,7 +627,9 @@ void nanite(const std::vector<Vertex>& vertices, const std::vector<unsigned int>
 				dumpObj("group", merged);
 			}
 
-			size_t target_size = ((groups[i].size() + 1) / 2) * kClusterSize * 3;
+			// aim to reduce group size in half
+			size_t target_size = (merged.size() / 3) / 2 * 3;
+
 			float error = 0.f;
 			std::vector<unsigned int> simplified = simplify(vertices, merged, kUseLocks ? &locks : NULL, target_size, &error);
 			if (simplified.size() > merged.size() * 0.85f || simplified.size() / (kClusterSize * 3) >= merged.size() / (kClusterSize * 3))


### PR DESCRIPTION
While the higher level goal for the demo is to get to a point where METIS is not necessary, this requires ability to carefully evaluate the DAG quality between modes, and a solid baseline. This change fixes a few issues around the latter when METIS is used, specifically:

- Instead of a build-time configuration, we link to METIS dynamically; this makes it easier to work on this code as switching modes never requires a rebuild
- As an extra option, mostly-non-recursive clusterization is added; this is similar to what Bevy added recently, and uses a single partitioning call to get all clusters, and then splits occasional outlier clusters that are larger than the limit. To reduce the splits METIS is instructed to produce smaller clusters - even with a small slop, occasionally much larger clusters occur in the output.
- Minor tweaks around simplification targets / thresholds / ufactor that change the DAG a bit but are probably not critical
- Most importantly, cluster partitioning is now using `METIS_PartGraphRecursive` instead of `METIS_PartGraphKway`. This significantly improves quality of partitions regardless of whether meshopt or METIS is used to produce triangle clusters. The improvement is large enough that the need for retry queue doesn't appear to exist anymore, but it's easy to keep it around so for now it's still available behind an option.

The non-recursive METIS triangle clusterization seems better than the recursive variant, but because there isn't an easy way to compare DAG quality across different variants, for now we keep the old code around. With the last fix, neither meshopt nor either METIS variant produces any stuck clusters on intermediate levels of DAG (on cliffs, kitten, bunny assets - obviously stuck clusters are possible in theory!) - this does not mean that the clusterization is of the same quality, it just means that our existing metrics (tri/cl and stuck clusters) are insufficiently granular to tell the difference. This will be improved in a future PR.

> Note: no further changes are planned to METIS specific code in this demo; these will just help to develop and refine future meshopt algorithms.

*This contribution is sponsored by Valve.*