### PR TITLE
Add Ubuntu ARM runner for build CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,13 @@ jobs:
   unix:
     strategy:
       matrix:
-        os: [{ name: ubuntu, version: ubuntu-latest }, { name: macos-intel, version: macos-13 }, { name: macos-arm, version: macos-14 }]
+        os:
+          [
+            { name: ubuntu, version: ubuntu-latest },
+            { name: ubuntu-arm, version: ubuntu-24.04-arm },
+            { name: macos-intel, version: macos-13 },
+            { name: macos-arm, version: macos-14 },
+          ]
     name: ${{matrix.os.name}}
     runs-on: ${{matrix.os.version}}
     env:

--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -24,7 +24,7 @@ jobs:
           dry-run: false
           language: c++
       - name: Upload Crash
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: failure() && steps.build.outcome == 'success'
         with:
           name: artifacts


### PR DESCRIPTION
This should be available as of today: https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/

Coincidentally this also would have prevented #833 (not that this option existed until today!)