### PR TITLE
clusterizer: Improve performance and memory use of meshlet builder

### DIFF
--- a/demo/tests.cpp
+++ b/demo/tests.cpp
@@ -1040,6 +1040,28 @@ static void clusterBoundsDegenerate()
 	assert(bounds2.center[2] - bounds2.radius <= 0 && bounds2.center[2] + bounds2.radius >= 1);
 }
 
+static void meshletsSparse()
+{
+	const float vbd[16 * 3] = {};
+	const unsigned int ibd[6] = {0, 7, 15, 15, 7, 3};
+
+	meshopt_Meshlet ml[1];
+	unsigned int mv[4];
+	unsigned char mt[8];
+	size_t mc = meshopt_buildMeshlets(ml, mv, mt, ibd, 6, vbd, 16, sizeof(float) * 3, 64, 64, 0.f);
+
+	assert(mc == 1);
+	assert(ml[0].triangle_count == 2);
+	assert(ml[0].vertex_count == 4);
+
+	unsigned int tri0[3] = {mv[mt[0]], mv[mt[1]], mv[mt[2]]};
+	unsigned int tri1[3] = {mv[mt[3]], mv[mt[4]], mv[mt[5]]};
+
+	// technically triangles could also be flipped in the meshlet but for now just assume they aren't
+	assert(memcmp(tri0, ibd + 0, 3 * sizeof(unsigned int)) == 0);
+	assert(memcmp(tri1, ibd + 3, 3 * sizeof(unsigned int)) == 0);
+}
+
 static size_t allocCount;
 static size_t freeCount;
 
@@ -2094,6 +2116,7 @@ void runTests()
 	encodeFilterExpClamp();
 
 	clusterBoundsDegenerate();
+	meshletsSparse();
 
 	customAllocator();
 

--- a/demo/tests.cpp
+++ b/demo/tests.cpp
@@ -1040,6 +1040,28 @@ static void clusterBoundsDegenerate()
 	assert(bounds2.center[2] - bounds2.radius <= 0 && bounds2.center[2] + bounds2.radius >= 1);
 }
 
+static void meshletsDense()
+{
+	const float vbd[4 * 3] = {};
+	const unsigned int ibd[6] = {0, 2, 1, 1, 2, 3};
+
+	meshopt_Meshlet ml[1];
+	unsigned int mv[4];
+	unsigned char mt[8];
+	size_t mc = meshopt_buildMeshlets(ml, mv, mt, ibd, 6, vbd, 4, sizeof(float) * 3, 64, 64, 0.f);
+
+	assert(mc == 1);
+	assert(ml[0].triangle_count == 2);
+	assert(ml[0].vertex_count == 4);
+
+	unsigned int tri0[3] = {mv[mt[0]], mv[mt[1]], mv[mt[2]]};
+	unsigned int tri1[3] = {mv[mt[3]], mv[mt[4]], mv[mt[5]]};
+
+	// technically triangles could also be flipped in the meshlet but for now just assume they aren't
+	assert(memcmp(tri0, ibd + 0, 3 * sizeof(unsigned int)) == 0);
+	assert(memcmp(tri1, ibd + 3, 3 * sizeof(unsigned int)) == 0);
+}
+
 static void meshletsSparse()
 {
 	const float vbd[16 * 3] = {};
@@ -2116,6 +2138,8 @@ void runTests()
 	encodeFilterExpClamp();
 
 	clusterBoundsDegenerate();
+
+	meshletsDense();
 	meshletsSparse();
 
 	customAllocator();

--- a/src/clusterizer.cpp
+++ b/src/clusterizer.cpp
@@ -554,8 +554,8 @@ size_t meshopt_buildMeshlets(meshopt_Meshlet* meshlets, unsigned int* meshlet_ve
 	TriangleAdjacency2 adjacency = {};
 	buildTriangleAdjacency(adjacency, indices, index_count, vertex_count, allocator);
 
-	unsigned int* live_triangles = allocator.allocate<unsigned int>(vertex_count);
-	memcpy(live_triangles, adjacency.counts, vertex_count * sizeof(unsigned int));
+	// live triangle counts; note, we alias adjacency.counts as we remove triangles after emitting them so the counts always match
+	unsigned int* live_triangles = adjacency.counts;
 
 	size_t face_count = index_count / 3;
 
@@ -625,12 +625,9 @@ size_t meshopt_buildMeshlets(meshopt_Meshlet* meshlets, unsigned int* meshlet_ve
 			memset(&meshlet_cone_acc, 0, sizeof(meshlet_cone_acc));
 		}
 
-		live_triangles[a]--;
-		live_triangles[b]--;
-		live_triangles[c]--;
-
 		// remove emitted triangle from adjacency data
 		// this makes sure that we spend less time traversing these lists on subsequent iterations
+		// live triangle counts are updated as a byproduct of these adjustments
 		for (size_t k = 0; k < 3; ++k)
 		{
 			unsigned int index = indices[best_triangle * 3 + k];


### PR DESCRIPTION
When clusterizer is used to generate meshlets for a small subset of the
mesh, the bulk of the work is in O(vertex_count) loops inside adjacency
build as opposed to the actual clusterizer. Normally the mesh has more
indices than vertices, but for mesh subsets this relationship may be
reversed. This change implements automatic sparse update for adjacency,
which only fills the subset of the adjacency data used by the index buffer.

When using 64 triangle clusters on a 1M triangle mesh, this makes the
clusterization itself ~2x faster, and the hierarchical clustering
process can be ~25% faster as a result.

Additionally, this change also removes the redundant `live_triangles` buffer -
it is the same data as `adjacency.counts` and is always updated in sync, so
we can simply reuse the existing allocation. This saves memory, especially in
the aforementioned sparse builds when vertex count is large.

*This contribution is sponsored by Valve.*