### PR TITLE
demo: Implement various metrics for hierarchical simplification

### DIFF
--- a/demo/main.cpp
+++ b/demo/main.cpp
@@ -976,8 +976,8 @@ void meshlets(const Mesh& mesh, bool scan = false, bool uniform = false)
 	double avg_vertices = 0;
 	double avg_triangles = 0;
 	double avg_boundary = 0;
+	double avg_connected = 0;
 	size_t not_full = 0;
-	size_t not_connected = 0;
 
 	std::vector<int> boundary(mesh.vertices.size());
 
@@ -1022,16 +1022,17 @@ void meshlets(const Mesh& mesh, bool scan = false, bool uniform = false)
 			roots += follow(parents, j) == int(j);
 
 		assert(roots != 0);
-		not_connected += roots > 1;
+		avg_connected += roots;
 	}
 
 	avg_vertices /= double(meshlets.size());
 	avg_triangles /= double(meshlets.size());
 	avg_boundary /= double(meshlets.size());
+	avg_connected /= double(meshlets.size());
 
-	printf("Meshlets%c: %d meshlets (avg vertices %.1f, avg triangles %.1f, avg boundary %.1f, not full %d, not connected %d) in %.2f msec\n",
+	printf("Meshlets%c: %d meshlets (avg vertices %.1f, avg triangles %.1f, avg boundary %.1f, avg connected %.2f, not full %d) in %.2f msec\n",
 	    scan ? 'S' : (uniform ? 'U' : ' '),
-	    int(meshlets.size()), avg_vertices, avg_triangles, avg_boundary, int(not_full), int(not_connected), (end - start) * 1000);
+	    int(meshlets.size()), avg_vertices, avg_triangles, avg_boundary, avg_connected, int(not_full), (end - start) * 1000);
 
 	float camera[3] = {100, 100, 100};
 
@@ -1401,17 +1402,7 @@ void processDev(const char* path)
 	if (!loadMesh(mesh, path))
 		return;
 
-	Mesh copy = mesh;
-	meshopt_optimizeVertexCache(&copy.indices[0], &copy.indices[0], copy.indices.size(), copy.vertices.size());
-	meshopt_optimizeVertexFetch(&copy.vertices[0], &copy.indices[0], copy.indices.size(), &copy.vertices[0], copy.vertices.size(), sizeof(Vertex));
-
-	meshopt_encodeVertexVersion(0);
-	encodeVertex<PackedVertex>(copy, "L");
-	meshopt_encodeVertexVersion(1);
-	encodeVertex<PackedVertex>(copy, "0", 0);
-	encodeVertex<PackedVertex>(copy, "1", 1);
-	encodeVertex<PackedVertex>(copy, "2", 2);
-	encodeVertex<PackedVertex>(copy, "3", 3);
+	meshlets(mesh);
 }
 
 void processNanite(const char* path)

--- a/demo/nanite.cpp
+++ b/demo/nanite.cpp
@@ -793,12 +793,12 @@ void nanite(const std::vector<Vertex>& vertices, const std::vector<unsigned int>
 			}
 		}
 
+		double inv_clusters = pending.empty() ? 0 : 1.0 / double(pending.size());
+
 		depth++;
-		printf("lod %d: simplified %d clusters (%d full, %.1f tri/cl, %.1f vtx/cl, %.2f connected), %d triangles; stuck %d clusters (%d single), %d triangles\n",
-		    depth, int(pending.size()), full_clusters,
-		    pending.empty() ? 0 : double(triangles) / double(pending.size()),
-		    pending.empty() ? 0 : double(xformed_lod) / double(pending.size()),
-		    pending.empty() ? 0 : double(components_lod) / double(pending.size()),
+		printf("lod %d: simplified %d clusters (%.1f%% full, %.1f tri/cl, %.1f vtx/cl, %.2f connected), %d triangles; stuck %d clusters (%d single), %d triangles\n",
+		    depth, int(pending.size()),
+		    double(full_clusters) * inv_clusters * 100, double(triangles) * inv_clusters, double(xformed_lod) * inv_clusters, double(components_lod) * inv_clusters,
 		    int(triangles), stuck_clusters, single_clusters, int(stuck_triangles));
 
 		if (kUseRetry)

--- a/demo/nanite.cpp
+++ b/demo/nanite.cpp
@@ -430,7 +430,7 @@ static int follow(std::vector<int>& parents, int index)
 	return index;
 }
 
-static int connected(std::vector<int>& parents, const std::vector<unsigned int>& indices, const std::vector<unsigned int>& remap)
+static int measureComponents(std::vector<int>& parents, const std::vector<unsigned int>& indices, const std::vector<unsigned int>& remap)
 {
 	assert(parents.size() == remap.size());
 
@@ -468,7 +468,7 @@ static int connected(std::vector<int>& parents, const std::vector<unsigned int>&
 	return roots;
 }
 
-static int xformed(std::vector<int>& used, const std::vector<unsigned int>& indices)
+static int measureUnique(std::vector<int>& used, const std::vector<unsigned int>& indices)
 {
 	for (size_t i = 0; i < indices.size(); ++i)
 	{
@@ -545,8 +545,8 @@ void nanite(const std::vector<Vertex>& vertices, const std::vector<unsigned int>
 	size_t xformed_initial = 0;
 	for (size_t i = 0; i < clusters.size(); ++i)
 	{
-		components_initial += connected(parents, clusters[i].indices, remap);
-		xformed_initial += xformed(parents, clusters[i].indices);
+		components_initial += measureComponents(parents, clusters[i].indices, remap);
+		xformed_initial += measureUnique(parents, clusters[i].indices);
 	}
 
 	printf("lod 0: %d clusters (%.1f tri/cl, %.1f vtx/cl, %.2f connected), %d triangles\n",
@@ -664,8 +664,8 @@ void nanite(const std::vector<Vertex>& vertices, const std::vector<unsigned int>
 
 				triangles += split[j].indices.size() / 3;
 				full_clusters += split[j].indices.size() == kClusterSize * 3;
-				components_lod += connected(parents, split[j].indices, remap);
-				xformed_lod += xformed(parents, split[j].indices);
+				components_lod += measureComponents(parents, split[j].indices, remap);
+				xformed_lod += measureUnique(parents, split[j].indices);
 			}
 		}
 

--- a/demo/nanite.cpp
+++ b/demo/nanite.cpp
@@ -549,6 +549,8 @@ void nanite(const std::vector<Vertex>& vertices, const std::vector<unsigned int>
 		xformed_initial += measureUnique(parents, clusters[i].indices);
 	}
 
+	printf("ideal lod chain: %.1f levels\n", log2(double(indices.size() / 3) / double(kClusterSize)));
+
 	printf("lod 0: %d clusters (%.1f tri/cl, %.1f vtx/cl, %.2f connected), %d triangles\n",
 	    int(clusters.size()),
 	    double(indices.size() / 3) / double(clusters.size()),


### PR DESCRIPTION
We now analyze connectivity, vertex transform and boundary size for all clusters and output summary statistics per level of detail (DAG depth). This allows more granular analysis and comparison of various algorithms and tweaks.

With these it's more clear that Metis non-recursive clusterization is generally better than the recursive variant, so this change also removes the recursive variant for simplicity.

Note that for now, the code that computes metrics (and is thus non-operational) is intermixed with the code that computes the actual DAG. Since for now this demo is not intended as production-ready example, this is fine but the demo will need to be reworked in the future to serve as a good example.

*This contribution is sponsored by Valve.*