### PR TITLE
Experimental cluster partitioning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,7 @@ set(SOURCES
     src/indexgenerator.cpp
     src/overdrawanalyzer.cpp
     src/overdrawoptimizer.cpp
+    src/partition.cpp
     src/quantization.cpp
     src/simplifier.cpp
     src/spatialorder.cpp

--- a/demo/nanite.cpp
+++ b/demo/nanite.cpp
@@ -349,26 +349,27 @@ static std::vector<std::vector<int> > partition(const std::vector<Cluster>& clus
 	if (METIS & 1)
 		return partitionMetis(clusters, pending, remap);
 
-	(void)remap;
+	std::vector<unsigned int> cluster_indices;
+	std::vector<unsigned int> cluster_counts(pending.size());
 
-	std::vector<std::vector<int> > result;
-
-	size_t last_indices = 0;
-
-	// rough merge; while clusters are approximately spatially ordered, this should use a proper partitioning algorithm
 	for (size_t i = 0; i < pending.size(); ++i)
 	{
-		if (result.empty() || last_indices + clusters[pending[i]].indices.size() > kClusterSize * kGroupSize * 3)
-		{
-			result.push_back(std::vector<int>());
-			last_indices = 0;
-		}
+		const Cluster& cluster = clusters[pending[i]];
 
-		result.back().push_back(pending[i]);
-		last_indices += clusters[pending[i]].indices.size();
+		cluster_counts[i] = cluster.indices.size();
+
+		for (size_t j = 0; j < cluster.indices.size(); ++j)
+			cluster_indices.push_back(remap[cluster.indices[j]]);
 	}
 
-	return result;
+	std::vector<unsigned int> cluster_part(pending.size());
+	size_t partition_count = meshopt_partitionClusters(&cluster_part[0], &cluster_indices[0], cluster_indices.size(), &cluster_counts[0], cluster_counts.size(), remap.size(), 8);
+
+	std::vector<std::vector<int> > partitions(partition_count);
+	for (size_t i = 0; i < pending.size(); ++i)
+		partitions[cluster_part[i]].push_back(pending[i]);
+
+	return partitions;
 }
 
 static void lockBoundary(std::vector<unsigned char>& locks, const std::vector<std::vector<int> >& groups, const std::vector<Cluster>& clusters, const std::vector<unsigned int>& remap)

--- a/demo/nanite.cpp
+++ b/demo/nanite.cpp
@@ -362,7 +362,7 @@ static std::vector<std::vector<int> > partition(const std::vector<Cluster>& clus
 	{
 		const Cluster& cluster = clusters[pending[i]];
 
-		cluster_counts[i] = cluster.indices.size();
+		cluster_counts[i] = unsigned(cluster.indices.size());
 
 		for (size_t j = 0; j < cluster.indices.size(); ++j)
 			cluster_indices.push_back(remap[cluster.indices[j]]);

--- a/demo/nanite.cpp
+++ b/demo/nanite.cpp
@@ -491,7 +491,7 @@ static int measureUnique(std::vector<int>& used, const std::vector<unsigned int>
 	for (size_t i = 0; i < indices.size(); ++i)
 	{
 		unsigned int v = indices[i];
-		vertices += used[v] && (!locks || !(*locks)[v]);
+		vertices += used[v] && (!locks || (*locks)[v]);
 		used[v] = 0;
 	}
 

--- a/demo/nanite.cpp
+++ b/demo/nanite.cpp
@@ -352,6 +352,12 @@ static std::vector<std::vector<int> > partition(const std::vector<Cluster>& clus
 	std::vector<unsigned int> cluster_indices;
 	std::vector<unsigned int> cluster_counts(pending.size());
 
+	size_t total_index_count = 0;
+	for (size_t i = 0; i < pending.size(); ++i)
+		total_index_count += clusters[pending[i]].indices.size();
+
+	cluster_indices.reserve(total_index_count);
+
 	for (size_t i = 0; i < pending.size(); ++i)
 	{
 		const Cluster& cluster = clusters[pending[i]];
@@ -363,9 +369,12 @@ static std::vector<std::vector<int> > partition(const std::vector<Cluster>& clus
 	}
 
 	std::vector<unsigned int> cluster_part(pending.size());
-	size_t partition_count = meshopt_partitionClusters(&cluster_part[0], &cluster_indices[0], cluster_indices.size(), &cluster_counts[0], cluster_counts.size(), remap.size(), 8);
+	size_t partition_count = meshopt_partitionClusters(&cluster_part[0], &cluster_indices[0], cluster_indices.size(), &cluster_counts[0], cluster_counts.size(), remap.size(), kGroupSize);
 
 	std::vector<std::vector<int> > partitions(partition_count);
+	for (size_t i = 0; i < partition_count; ++i)
+		partitions[i].reserve(kGroupSize + 4);
+
 	for (size_t i = 0; i < pending.size(); ++i)
 		partitions[cluster_part[i]].push_back(pending[i]);
 

--- a/demo/tests.cpp
+++ b/demo/tests.cpp
@@ -1084,6 +1084,33 @@ static void meshletsSparse()
 	assert(memcmp(tri1, ibd + 3, 3 * sizeof(unsigned int)) == 0);
 }
 
+static void partitionBasic()
+{
+	// 0   1   2
+	//     3
+	// 4 5 6 7 8
+	//     9
+	// 10 11  12
+	const unsigned int ci[] = {
+	    0, 1, 3, 4, 5, 6,   //
+	    1, 2, 3, 6, 7, 8,   //
+	    4, 5, 6, 9, 10, 11, //
+	    6, 7, 8, 9, 11, 12, //
+	};
+
+	const unsigned int cc[4] = {6, 6, 6, 6};
+	unsigned int part[4];
+
+	assert(meshopt_partitionClusters(part, ci, sizeof(ci) / sizeof(ci[0]), cc, 4, 13, 1) == 4);
+	assert(part[0] == 0 && part[1] == 1 && part[2] == 2 && part[3] == 3);
+
+	assert(meshopt_partitionClusters(part, ci, sizeof(ci) / sizeof(ci[0]), cc, 4, 13, 2) == 2);
+	assert(part[0] == 0 && part[1] == 0 && part[2] == 1 && part[3] == 1);
+
+	assert(meshopt_partitionClusters(part, ci, sizeof(ci) / sizeof(ci[0]), cc, 4, 13, 4) == 1);
+	assert(part[0] == 0 && part[1] == 0 && part[2] == 0 && part[3] == 0);
+}
+
 static size_t allocCount;
 static size_t freeCount;
 
@@ -2141,6 +2168,8 @@ void runTests()
 
 	meshletsDense();
 	meshletsSparse();
+
+	partitionBasic();
 
 	customAllocator();
 

--- a/src/meshoptimizer.h
+++ b/src/meshoptimizer.h
@@ -590,6 +590,18 @@ MESHOPTIMIZER_API struct meshopt_Bounds meshopt_computeClusterBounds(const unsig
 MESHOPTIMIZER_API struct meshopt_Bounds meshopt_computeMeshletBounds(const unsigned int* meshlet_vertices, const unsigned char* meshlet_triangles, size_t triangle_count, const float* vertex_positions, size_t vertex_count, size_t vertex_positions_stride);
 
 /**
+ * Experimental: Cluster partitioner
+ * Partitions clusters into groups of similar size, prioritizing grouping clusters that share vertices.
+ *
+ * destination must contain enough space for the resulting partiotion data (cluster_count elements)
+ * destination[i] will contain the partition id for cluster i, with the total number of partitions returned by the function
+ * cluster_indices should have the vertex indices referenced by each cluster, stored sequentially
+ * cluster_index_counts should have the number of indices in each cluster; sum of all cluster_index_counts must be equal to total_index_count
+ * target_partition_size is a target size for each partition, in clusters; the resulting partitions may be smaller or larger
+ */
+MESHOPTIMIZER_EXPERIMENTAL size_t meshopt_partitionClusters(unsigned int* destination, const unsigned int* cluster_indices, size_t total_index_count, const unsigned int* cluster_index_counts, size_t cluster_count, size_t vertex_count, size_t target_partition_size);
+
+/**
  * Spatial sorter
  * Generates a remap table that can be used to reorder points for spatial locality.
  * Resulting remap table maps old vertices to new vertices and can be used in meshopt_remapVertexBuffer.

--- a/src/partition.cpp
+++ b/src/partition.cpp
@@ -67,6 +67,11 @@ static void buildClusterAdjacency(ClusterAdjacency& adjacency, const unsigned in
 			used[cluster_indices[j]] = 0;
 	}
 
+	// we can now allocate adjacency buffers
+	adjacency.offsets = allocator.allocate<unsigned int>(cluster_count + 1);
+	adjacency.clusters = allocator.allocate<unsigned int>(total_adjacency);
+	adjacency.shared = allocator.allocate<unsigned int>(total_adjacency);
+
 	// convert ref counts to offsets
 	size_t total_refs = 0;
 
@@ -101,11 +106,6 @@ static void buildClusterAdjacency(ClusterAdjacency& adjacency, const unsigned in
 	// after the previous pass, ref_offsets contain the end of the data for each vertex; shift it forward to get the start
 	memmove(ref_offsets + 1, ref_offsets, vertex_count * sizeof(unsigned int));
 	ref_offsets[0] = 0;
-
-	// we can now allocate adjacency buffers
-	adjacency.offsets = allocator.allocate<unsigned int>(cluster_count + 1);
-	adjacency.clusters = allocator.allocate<unsigned int>(total_adjacency);
-	adjacency.shared = allocator.allocate<unsigned int>(total_adjacency);
 
 	// fill cluster adjacency for each cluster...
 	adjacency.offsets[0] = 0;
@@ -161,6 +161,9 @@ static void buildClusterAdjacency(ClusterAdjacency& adjacency, const unsigned in
 		// mark the end of the adjacency list; the next cluster will start there as well
 		adjacency.offsets[i + 1] = adjacency.offsets[i] + unsigned(count);
 	}
+
+	// ref_offsets can't be deallocated as it was allocated before adjacency
+	allocator.deallocate(ref_data);
 }
 
 // TOOD part of prototype code, to be removed

--- a/src/partition.cpp
+++ b/src/partition.cpp
@@ -284,7 +284,7 @@ static int pickGroupToMerge(const ClusterGroup* groups, int id, const ClusterAdj
 			unsigned int score = countShared(groups, id, other, adjacency);
 
 			// favor smaller target groups
-			score += max_group_size - groups[other].size;
+			score += unsigned(max_group_size) - groups[other].size;
 
 			if (score > best_score)
 			{
@@ -321,7 +321,7 @@ size_t meshopt_partitionClusters(unsigned int* destination, const unsigned int* 
 	}
 
 	assert(cluster_nextoffset == total_index_count);
-	cluster_offsets[cluster_count] = total_index_count;
+	cluster_offsets[cluster_count] = unsigned(total_index_count);
 
 	// build cluster adjacency along with edge weights (shared vertex count)
 	ClusterAdjacency adjacency = {};
@@ -338,7 +338,7 @@ size_t meshopt_partitionClusters(unsigned int* destination, const unsigned int* 
 		groups[i].group = int(i);
 		groups[i].next = -1;
 		groups[i].size = 1;
-		groups[i].vertices = countTotal(groups, i, cluster_indices, cluster_offsets, used);
+		groups[i].vertices = countTotal(groups, int(i), cluster_indices, cluster_offsets, used);
 
 		GroupOrder item = {};
 		item.id = unsigned(i);

--- a/src/partition.cpp
+++ b/src/partition.cpp
@@ -1,0 +1,228 @@
+// This file is part of meshoptimizer library; see meshoptimizer.h for version/license details
+#include "meshoptimizer.h"
+
+#include <assert.h>
+
+// TOOD part of prototype code, to be removed
+#include <map>
+#include <vector>
+
+namespace meshopt
+{
+
+// TOOD part of prototype code, to be removed
+struct Cluster
+{
+	const unsigned int* indices;
+	size_t index_count;
+};
+
+static unsigned int countShared(const std::vector<int>& group1, const std::vector<int>& group2, const std::vector<std::map<size_t, unsigned int> >& adjacency)
+{
+	unsigned int total = 0;
+
+	for (size_t i1 = 0; i1 < group1.size(); ++i1)
+	{
+		const std::map<size_t, unsigned int>& adj = adjacency[group1[i1]];
+
+		for (size_t i2 = 0; i2 < group2.size(); ++i2)
+		{
+			std::map<size_t, unsigned int>::const_iterator it = adj.find(group2[i2]);
+			if (it != adj.end())
+				total += it->second;
+		}
+	}
+
+	return total;
+}
+
+static unsigned int countExternal(const std::vector<int>& group, const std::vector<Cluster>& clusters, std::vector<unsigned int>& valence)
+{
+	unsigned int total = 0;
+
+	for (size_t i = 0; i < group.size(); ++i)
+	{
+		const Cluster& cluster = clusters[group[i]];
+
+		for (size_t j = 0; j < cluster.index_count; ++j)
+			valence[cluster.indices[j]]--;
+	}
+
+	for (size_t i = 0; i < group.size(); ++i)
+	{
+		const Cluster& cluster = clusters[group[i]];
+
+		for (size_t j = 0; j < cluster.index_count; ++j)
+			total += valence[cluster.indices[j]] != 0;
+	}
+
+	for (size_t i = 0; i < group.size(); ++i)
+	{
+		const Cluster& cluster = clusters[group[i]];
+
+		for (size_t j = 0; j < cluster.index_count; ++j)
+			valence[cluster.indices[j]]++;
+	}
+
+	return total;
+}
+
+static std::vector<std::vector<int> > partitionMerge(const std::vector<Cluster>& clusters, size_t vertex_count)
+{
+	const size_t GROUP_SIZE = 8;
+	const size_t MAX_GROUP_SIZE = 12;
+
+	std::vector<std::vector<int> > result;
+	if (clusters.empty())
+		return result;
+
+	// Build index -> clusters mapping
+	std::map<unsigned int, std::vector<size_t> > indexToClusters;
+	for (size_t i = 0; i < clusters.size(); ++i)
+	{
+		const Cluster& cluster = clusters[i];
+		for (size_t j = 0; j < cluster.index_count; ++j)
+			indexToClusters[cluster.indices[j]].push_back(i);
+	}
+
+	// Build adjacency information
+	std::vector<std::map<size_t, unsigned int> > adjacency(clusters.size());
+
+	// For each remapped index, increment shared count for each pair of clusters that contains it
+	for (std::map<unsigned int, std::vector<size_t> >::const_iterator it = indexToClusters.begin(); it != indexToClusters.end(); ++it)
+	{
+		const std::vector<size_t>& clusterList = it->second;
+
+		for (size_t i = 0; i < clusterList.size(); ++i)
+		{
+			for (size_t j = i + 1; j < clusterList.size(); ++j)
+			{
+				size_t c1 = clusterList[i];
+				size_t c2 = clusterList[j];
+				adjacency[c1][c2]++;
+				adjacency[c2][c1]++;
+			}
+		}
+	}
+
+	std::vector<unsigned int> valence(vertex_count);
+	for (size_t i = 0; i < clusters.size(); ++i)
+	{
+		const Cluster& cluster = clusters[i];
+
+		for (size_t j = 0; j < cluster.index_count; ++j)
+			valence[cluster.indices[j]]++;
+	}
+
+	// Initially, create a singleton group for each cluster, stored as multimap sorted by external count
+	std::multimap<unsigned int, std::vector<int> > groups;
+	std::vector<std::multimap<unsigned int, std::vector<int> >::iterator> part(clusters.size(), groups.end());
+
+	for (size_t i = 0; i < clusters.size(); ++i)
+	{
+		std::vector<int> group;
+		group.push_back(i);
+		unsigned int ext = countExternal(group, clusters, valence);
+		std::multimap<unsigned int, std::vector<int> >::iterator it = groups.insert(std::make_pair(ext, group));
+		part[i] = it;
+	}
+
+	// Iteratively take group with smallest number of external vertices, merge it with another group that minimizes external vertices
+	while (!groups.empty())
+	{
+		std::vector<int> group = groups.begin()->second;
+		groups.erase(groups.begin());
+
+		for (size_t i = 0; i < group.size(); ++i)
+			part[group[i]] = groups.end();
+
+		if (group.size() >= GROUP_SIZE)
+		{
+			result.push_back(group);
+		}
+		else
+		{
+			std::multimap<unsigned int, std::vector<int> >::iterator bestGroup = groups.end();
+			unsigned int bestShared = 0;
+
+			for (size_t ci = 0; ci < group.size(); ++ci)
+			{
+				for (std::map<size_t, unsigned int>::iterator adj = adjacency[group[ci]].begin(); adj != adjacency[group[ci]].end(); ++adj)
+				{
+					std::multimap<unsigned int, std::vector<int> >::iterator it = part[adj->first];
+					if (it == groups.end())
+						continue;
+
+					if (group.size() + it->second.size() > MAX_GROUP_SIZE)
+						continue;
+
+					unsigned int shd = countShared(group, it->second, adjacency);
+
+					if (shd > bestShared)
+					{
+						bestShared = shd;
+						bestGroup = it;
+					}
+				}
+			}
+
+			if (bestGroup == groups.end())
+			{
+				// we're stuck, emit as is
+				result.push_back(group);
+			}
+			else
+			{
+				// combine and reinsert
+				std::vector<int> combined = group;
+				combined.insert(combined.end(), bestGroup->second.begin(), bestGroup->second.end());
+
+				unsigned int ext = countExternal(combined, clusters, valence);
+
+				for (size_t i = 0; i < bestGroup->second.size(); ++i)
+					part[bestGroup->second[i]] = groups.end();
+
+				groups.erase(bestGroup);
+				std::multimap<unsigned int, std::vector<int> >::iterator it = groups.insert(std::make_pair(ext, combined));
+
+				for (size_t i = 0; i < combined.size(); ++i)
+					part[combined[i]] = it;
+			}
+		}
+	}
+
+	return result;
+}
+
+} // namespace meshopt
+
+size_t meshopt_partitionClusters(unsigned int* destination, const unsigned int* cluster_indices, size_t total_index_count, const unsigned int* cluster_index_counts, size_t cluster_count, size_t vertex_count, size_t target_partition_size)
+{
+	using namespace meshopt;
+
+	assert(target_partition_size > 0);
+
+	(void)target_partition_size;
+
+	meshopt_Allocator allocator;
+
+	std::vector<Cluster> clusters(cluster_count);
+	const unsigned int* cluster_offset = cluster_indices;
+
+	for (size_t i = 0; i < cluster_count; ++i)
+	{
+		clusters[i].indices = cluster_offset;
+		clusters[i].index_count = cluster_index_counts[i];
+		cluster_offset += cluster_index_counts[i];
+	}
+
+	assert(cluster_offset == cluster_indices + total_index_count);
+
+	std::vector<std::vector<int> > groups = partitionMerge(clusters, vertex_count);
+
+	for (size_t i = 0; i < groups.size(); ++i)
+		for (size_t j = 0; j < groups[i].size(); ++j)
+			destination[groups[i][j]] = unsigned(i);
+
+	return groups.size();
+}

--- a/src/partition.cpp
+++ b/src/partition.cpp
@@ -7,6 +7,8 @@
 namespace meshopt
 {
 
+static const unsigned int kGroupSizeBias = 3;
+
 struct ClusterAdjacency
 {
 	unsigned int* offsets;
@@ -284,7 +286,7 @@ static int pickGroupToMerge(const ClusterGroup* groups, int id, const ClusterAdj
 			unsigned int score = countShared(groups, id, other, adjacency);
 
 			// favor smaller target groups
-			score += unsigned(max_group_size) - groups[other].size;
+			score += (unsigned(max_group_size) - groups[other].size) * kGroupSizeBias;
 
 			if (score > best_score)
 			{


### PR DESCRIPTION
This change introduces a new experimental algorithm,
`meshopt_partitionClusters`, which partitions the input clusters into
groups of approximately equal sizes, grouping neighboring clusters using
implied vertex-based adjacency and prioritizing groups that reduce
boundary vertices. This is intended as a replacement to METIS cluster
partitioning for hierarchical simplification pipelines.

The input to the algorithm is an index buffer for each cluster; the adjacency
is automatically inferred from this data. For best results on meshes with
vertex splits it's recommended to supply position-welded ("shadow") indices,
which can be generated via `meshopt_generateShadowIndexBuffer` on the
array before partitioning (see `main.cpp`/`simplifyClusters` example), or by
manually remapping the indices based on a vertex remap (see `nanite.cpp`/
`partition` example).

Note that right now, the algorithm does not use spatial proximity for
grouping considerations, and only groups clusters with shared vertices;
so on some meshes, single-cluster groups may be common for separate
small connected components. In this situation, METIS will group these
clusters pretty arbitrarily which isn't obviously better than leaving them
ungrouped. In both algorithms, adding fake links based on positional
data between clusters should fix this issue but in the future meshopt
algorithm will likely start taking vertex positions as well to automatically
mitigate that.

For the structure of the algorithm, three options were evaluated: greedy
walk (similar to clusterizer) with the extra feature of appending
isolated clusters to adjacent groups; parallel grow which started with a
set of seed clusters for each connected component and grew each group
starting from seeds; and greedy merge which keeps a sorted set of
unfinished groups and iteratively picks the smallest group and tries to
merge it with the best additional group. The merge algorithm generally
produced best results; the specific heuristics here matter as well, and after
a lot of experimentation the current sorting heuristic is just based on
total vertex count (so smaller clusters get merged first), and merge priority
is trying to maximize shared vertices between merged groups and to
merge with smaller groups as well. The heuristics are subject to change in
the future.

When used in a hierarchical pipeline, the new algorithm seems to generally
be similar or slightly better vs METIS in terms of resulting DAG quality and is
a little faster to compute the partition. The test results were mostly produced
using METIS to generate clusters, as meshopt clusterizer is currently known to
generate disconnected clusters and the number of disconnected clusters at
various LOD levels was a key comparison metric. That said, using meshopt
clusterizer with this partitioner also seems to produce slightly better results
vs meshopt clusterizer with METIS partitioner.

The target group size provided to the algorithm is a rough guideline; the
resulting partitions may be smaller or larger, and the group size logic might
require some adjustments in the future. The partitioner doesn't try too hard
to keep the partition sizes uniform, which is key for having a simpler algorithm
work.

Several of the potential future work items (positions as input, maybe more
targeted group size control) would require changing the interface, so just as
with all other experimental algorithms, the interface stability or behavior is
not guaranteed.

*This contribution is sponsored by Valve.*