### PR TITLE
vertex/indexcodec: Add meshopt_decodeVertex/IndexVersion

### DIFF
--- a/demo/tests.cpp
+++ b/demo/tests.cpp
@@ -616,6 +616,25 @@ static void encodeVertexEmpty()
 	assert(meshopt_decodeVertexBuffer(NULL, 0, 16, &buffer[0], buffer.size()) == 0);
 }
 
+static void decodeVersion()
+{
+	assert(meshopt_decodeVertexVersion(reinterpret_cast<const unsigned char*>("\xa0"), 1) == 0);
+	assert(meshopt_decodeVertexVersion(reinterpret_cast<const unsigned char*>("\xa1"), 1) == 1);
+	assert(meshopt_decodeVertexVersion(reinterpret_cast<const unsigned char*>("\xa1hello"), 6) == 1);
+
+	assert(meshopt_decodeVertexVersion(NULL, 0) == -1);
+	assert(meshopt_decodeVertexVersion(reinterpret_cast<const unsigned char*>("\xa7"), 1) == -1);
+	assert(meshopt_decodeVertexVersion(reinterpret_cast<const unsigned char*>("\xb1"), 1) == -1);
+
+	assert(meshopt_decodeIndexVersion(reinterpret_cast<const unsigned char*>("\xe0"), 1) == 0);
+	assert(meshopt_decodeIndexVersion(reinterpret_cast<const unsigned char*>("\xd1"), 1) == 1);
+	assert(meshopt_decodeIndexVersion(reinterpret_cast<const unsigned char*>("\xe1hello"), 6) == 1);
+
+	assert(meshopt_decodeIndexVersion(NULL, 0) == -1);
+	assert(meshopt_decodeIndexVersion(reinterpret_cast<const unsigned char*>("\xa7"), 1) == -1);
+	assert(meshopt_decodeIndexVersion(reinterpret_cast<const unsigned char*>("\xa1"), 1) == -1);
+}
+
 static void decodeFilterOct8()
 {
 	const unsigned char data[4 * 4] = {
@@ -2150,6 +2169,8 @@ void runTests()
 		encodeVertexEmpty();
 		encodeVertexMemorySafe();
 	}
+
+	decodeVersion();
 
 	decodeFilterOct8();
 	decodeFilterOct12();

--- a/src/meshoptimizer.h
+++ b/src/meshoptimizer.h
@@ -244,6 +244,13 @@ MESHOPTIMIZER_API void meshopt_encodeIndexVersion(int version);
 MESHOPTIMIZER_API int meshopt_decodeIndexBuffer(void* destination, size_t index_count, size_t index_size, const unsigned char* buffer, size_t buffer_size);
 
 /**
+ * Get encoded index format version
+ * Returns format version of the encoded index buffer/sequence, or -1 if the buffer header is invalid
+ * Note that a non-negative value doesn't guarantee that the buffer will be decoded correctly if the input is malformed.
+ */
+MESHOPTIMIZER_API int meshopt_decodeIndexVersion(const unsigned char* buffer, size_t buffer_size);
+
+/**
  * Index sequence encoder
  * Encodes index sequence into an array of bytes that is generally smaller and compresses better compared to original.
  * Input index sequence can represent arbitrary topology; for triangle lists meshopt_encodeIndexBuffer is likely to be better.
@@ -302,6 +309,13 @@ MESHOPTIMIZER_API void meshopt_encodeVertexVersion(int version);
  * destination must contain enough space for the resulting vertex buffer (vertex_count * vertex_size bytes)
  */
 MESHOPTIMIZER_API int meshopt_decodeVertexBuffer(void* destination, size_t vertex_count, size_t vertex_size, const unsigned char* buffer, size_t buffer_size);
+
+/**
+ * Get encoded vertex format version
+ * Returns format version of the encoded vertex buffer, or -1 if the buffer header is invalid
+ * Note that a non-negative value doesn't guarantee that the buffer will be decoded correctly if the input is malformed.
+ */
+MESHOPTIMIZER_API int meshopt_decodeVertexVersion(const unsigned char* buffer, size_t buffer_size);
 
 /**
  * Vertex buffer filters


### PR DESCRIPTION
In some cases it may be useful to check the encoded blob's version ahead of time, for example to make sure it's encoded using the latest version, or to make sure that vertex codec v0 is used for glTF data.

Note that these functions just check the headers; they may return a valid version number even if the input is malformed.

While we're at it, unify the maximum version checks for both codecs.

*This contribution is sponsored by Valve.*