### PR TITLE
Improve partitioning scoring and group size limits

### DIFF
--- a/demo/nanite.cpp
+++ b/demo/nanite.cpp
@@ -576,6 +576,8 @@ void nanite(const std::vector<Vertex>& vertices, const std::vector<unsigned int>
 	while (pending.size() > 1)
 	{
 		std::vector<std::vector<int> > groups = partition(clusters, pending, remap);
+		double avg_group = double(pending.size()) / double(groups.size());
+
 		pending.clear();
 
 		std::vector<int> retry;
@@ -686,9 +688,9 @@ void nanite(const std::vector<Vertex>& vertices, const std::vector<unsigned int>
 		double inv_clusters = pending.empty() ? 0 : 1.0 / double(pending.size());
 
 		depth++;
-		printf("lod %d: %d clusters (%.1f%% full, %.1f tri/cl, %.1f vtx/cl, %.2f connected, %.1f boundary), %d triangles",
+		printf("lod %d: %d clusters (%.1f%% full, %.1f tri/cl, %.1f vtx/cl, %.2f connected, %.1f boundary, %.1f partition), %d triangles",
 		    depth, int(pending.size()),
-		    double(full_clusters) * inv_clusters * 100, double(triangles) * inv_clusters, double(xformed_lod) * inv_clusters, double(components_lod) * inv_clusters, double(boundary_lod) * inv_clusters,
+		    double(full_clusters) * inv_clusters * 100, double(triangles) * inv_clusters, double(xformed_lod) * inv_clusters, double(components_lod) * inv_clusters, double(boundary_lod) * inv_clusters, avg_group,
 		    int(triangles));
 		if (stuck_clusters)
 			printf("; stuck %d clusters (%d single, %d triangles)", stuck_clusters, single_clusters, int(stuck_triangles));

--- a/src/meshoptimizer.h
+++ b/src/meshoptimizer.h
@@ -738,6 +738,8 @@ inline size_t meshopt_buildMeshletsScan(meshopt_Meshlet* meshlets, unsigned int*
 template <typename T>
 inline meshopt_Bounds meshopt_computeClusterBounds(const T* indices, size_t index_count, const float* vertex_positions, size_t vertex_count, size_t vertex_positions_stride);
 template <typename T>
+inline size_t meshopt_partitionClusters(unsigned int* destination, const T* cluster_indices, size_t total_index_count, const unsigned int* cluster_index_counts, size_t cluster_count, size_t vertex_count, size_t target_partition_size);
+template <typename T>
 inline void meshopt_spatialSortTriangles(T* destination, const T* indices, size_t index_count, const float* vertex_positions, size_t vertex_count, size_t vertex_positions_stride);
 #endif
 
@@ -1122,6 +1124,14 @@ inline meshopt_Bounds meshopt_computeClusterBounds(const T* indices, size_t inde
 	meshopt_IndexAdapter<T> in(NULL, indices, index_count);
 
 	return meshopt_computeClusterBounds(in.data, index_count, vertex_positions, vertex_count, vertex_positions_stride);
+}
+
+template <typename T>
+inline size_t meshopt_partitionClusters(unsigned int* destination, const T* cluster_indices, size_t total_index_count, const unsigned int* cluster_index_counts, size_t cluster_count, size_t vertex_count, size_t target_partition_size)
+{
+	meshopt_IndexAdapter<T> in(NULL, cluster_indices, total_index_count);
+
+	return meshopt_partitionClusters(destination, in.data, total_index_count, cluster_index_counts, cluster_count, vertex_count, target_partition_size);
 }
 
 template <typename T>

--- a/src/partition.cpp
+++ b/src/partition.cpp
@@ -2,12 +2,11 @@
 #include "meshoptimizer.h"
 
 #include <assert.h>
+#include <math.h>
 #include <string.h>
 
 namespace meshopt
 {
-
-static const unsigned int kGroupSizeBias = 3;
 
 struct ClusterAdjacency
 {
@@ -264,12 +263,14 @@ static unsigned int countShared(const ClusterGroup* groups, int group1, int grou
 	return total;
 }
 
-static int pickGroupToMerge(const ClusterGroup* groups, int id, const ClusterAdjacency& adjacency, size_t max_group_size)
+static int pickGroupToMerge(const ClusterGroup* groups, int id, const ClusterAdjacency& adjacency, size_t max_partition_size)
 {
 	assert(groups[id].size > 0);
 
+	float group_rsqrt = 1.f / sqrtf(float(int(groups[id].vertices)));
+
 	int best_group = -1;
-	unsigned int best_score = 0;
+	float best_score = 0;
 
 	for (int ci = id; ci >= 0; ci = groups[ci].next)
 	{
@@ -280,13 +281,14 @@ static int pickGroupToMerge(const ClusterGroup* groups, int id, const ClusterAdj
 				continue;
 
 			assert(groups[other].size > 0);
-			if (groups[id].size + groups[other].size > max_group_size)
+			if (groups[id].size + groups[other].size > max_partition_size)
 				continue;
 
-			unsigned int score = countShared(groups, id, other, adjacency);
+			unsigned int shared = countShared(groups, id, other, adjacency);
+			float other_rsqrt = 1.f / sqrtf(float(int(groups[other].vertices)));
 
-			// favor smaller target groups
-			score += (unsigned(max_group_size) - groups[other].size) * kGroupSizeBias;
+			// normalize shared count by the expected boundary of each group (+ keeps scoring symmetric)
+			float score = float(int(shared)) * (group_rsqrt + other_rsqrt);
 
 			if (score > best_score)
 			{
@@ -395,7 +397,7 @@ size_t meshopt_partitionClusters(unsigned int* destination, const unsigned int* 
 		// update group sizes; note, the vertex update is an approximation which avoids recomputing the true size via countTotal
 		groups[top.id].size += groups[best_group].size;
 		groups[top.id].vertices += groups[best_group].vertices;
-		groups[top.id].vertices -= shared;
+		groups[top.id].vertices = (groups[top.id].vertices > shared) ? groups[top.id].vertices - shared : 1;
 
 		groups[best_group].size = 0;
 		groups[best_group].vertices = 0;

--- a/src/partition.cpp
+++ b/src/partition.cpp
@@ -307,6 +307,8 @@ size_t meshopt_partitionClusters(unsigned int* destination, const unsigned int* 
 
 	assert(target_partition_size > 0);
 
+	size_t max_partition_size = target_partition_size + target_partition_size * 3 / 8;
+
 	meshopt_Allocator allocator;
 
 	unsigned char* used = allocator.allocate<unsigned char>(vertex_count);
@@ -318,6 +320,8 @@ size_t meshopt_partitionClusters(unsigned int* destination, const unsigned int* 
 
 	for (size_t i = 0; i < cluster_count; ++i)
 	{
+		assert(cluster_index_counts[i] > 0);
+
 		cluster_offsets[i] = cluster_nextoffset;
 		cluster_nextoffset += cluster_index_counts[i];
 	}
@@ -369,7 +373,7 @@ size_t meshopt_partitionClusters(unsigned int* destination, const unsigned int* 
 		if (groups[top.id].size >= target_partition_size)
 			continue;
 
-		int best_group = pickGroupToMerge(groups, top.id, adjacency, target_partition_size + target_partition_size / 2);
+		int best_group = pickGroupToMerge(groups, top.id, adjacency, max_partition_size);
 
 		// we can't grow the group any more, emit as is
 		if (best_group == -1)


### PR DESCRIPTION
This is a small followup to the previous PR, which adjusts the metric used for merging to normalize the shared counts with respect to the expected group boundary, which in practice works similarly to the group size bias but is more principled, and slightly lowers the max partition size. The previous PR focused a little too much on reducing the boundary, and as a result the average partition size was a little higher than the target; slightly reducing the acceptable partition size makes this better, especially when the target is a power of two (as it blocks the "natural" way to get to 3/2*2^k by repeated doubling until the last merge).

Some other metrics were evaluated for merging heuristic; there's a few other interesting candidates, for example "mulrsqrt" (which replaces `+` in this PR by `*`) is equivalent to `expansion*^2` from KaPPa (Engineering a Scalable High Quality Graph Partitioner" (2010)), and also yields good results with somewhat smaller clusters; both would be fine but `+` keeps the values in a more reasonable range so we'll go with that for now ("sumrsqrt" below).

![image](https://github.com/user-attachments/assets/85f0cd2e-8b9d-405f-bccf-bea602c0ce34)   

The logic to determine maximum partition size is likely to be adjusted further in the future as most of the testing was done with `target_partition_size = 8` which may bias the results to ratios that work well for powers of two.

Also add templated overload for `meshopt_partitionClusters`.

*This contribution is sponsored by Valve.*