### PR TITLE
demo: Hierarchical simplification cleanup/refactoring

### DIFF
--- a/demo/nanite.cpp
+++ b/demo/nanite.cpp
@@ -624,7 +624,7 @@ void nanite(const std::vector<Vertex>& vertices, const std::vector<unsigned int>
 #if TRACE
 				printf("stuck cluster: simplified %d => %d over threshold\n", int(merged.size() / 3), int(simplified.size() / 3));
 #endif
-				stuck_clusters++;
+				stuck_clusters += groups[i].size();
 				stuck_triangles += merged.size() / 3;
 				for (size_t j = 0; j < groups[i].size(); ++j)
 					retry.push_back(groups[i][j]);

--- a/demo/nanite.cpp
+++ b/demo/nanite.cpp
@@ -386,16 +386,11 @@ void nanite(const std::vector<Vertex>& vertices, const std::vector<unsigned int>
 		}
 	}
 
-	size_t total_triangles = 0;
 	size_t lowest_triangles = 0;
 	for (size_t i = 0; i < clusters.size(); ++i)
-	{
-		total_triangles += clusters[i].indices.size() / 3;
 		if (clusters[i].parent.error == FLT_MAX)
 			lowest_triangles += clusters[i].indices.size() / 3;
-	}
 
-	printf("total: %d triangles in %d clusters\n", int(total_triangles), int(clusters.size()));
 	printf("lowest lod: %d triangles\n", int(lowest_triangles));
 
 	// for testing purposes, we can compute a DAG cut from a given viewpoint and dump it as an OBJ

--- a/demo/nanite.cpp
+++ b/demo/nanite.cpp
@@ -212,6 +212,7 @@ static std::vector<std::vector<int> > partition(const std::vector<Cluster>& clus
 
 static void lockBoundary(std::vector<unsigned char>& locks, const std::vector<std::vector<int> >& groups, const std::vector<Cluster>& clusters, const std::vector<unsigned int>& remap)
 {
+	// for each remapped vertex, keep track of index of the group it's in (or -2 if it's in multiple groups)
 	std::vector<int> groupmap(locks.size(), -1);
 
 	for (size_t i = 0; i < groups.size(); ++i)

--- a/demo/nanite.cpp
+++ b/demo/nanite.cpp
@@ -428,6 +428,195 @@ static std::vector<unsigned int> simplify(const std::vector<Vertex>& vertices, c
 	return lod;
 }
 
+static void dumpMetrics(int level, const std::vector<Cluster>& queue, const std::vector<std::vector<int> >& groups, const std::vector<unsigned int>& remap, const std::vector<unsigned char>& locks, const std::vector<int>& retry);
+
+static bool loadMetis()
+{
+#ifdef _WIN32
+	return false;
+#else
+	void* handle = dlopen("libmetis.so", RTLD_NOW | RTLD_LOCAL);
+	if (!handle)
+		return false;
+
+	METIS_SetDefaultOptions = (int (*)(int*))dlsym(handle, "METIS_SetDefaultOptions");
+	METIS_PartGraphRecursive = (int (*)(int*, int*, int*, int*, int*, int*, int*, int*, float*, float*, int*, int*, int*))dlsym(handle, "METIS_PartGraphRecursive");
+
+	return METIS_SetDefaultOptions && METIS_PartGraphRecursive;
+#endif
+}
+
+void dumpObj(const std::vector<Vertex>& vertices, const std::vector<unsigned int>& indices, bool recomputeNormals = false);
+void dumpObj(const char* section, const std::vector<unsigned int>& indices);
+
+void nanite(const std::vector<Vertex>& vertices, const std::vector<unsigned int>& indices)
+{
+	static const char* metis = getenv("METIS");
+	METIS = metis ? atoi(metis) : 0;
+
+	if (METIS)
+	{
+		if (loadMetis())
+			printf("using metis for %s\n", (METIS & 3) == 3 ? "clustering and partition" : ((METIS & 1) ? "partition only" : "clustering only"));
+		else
+			printf("metis library is not available\n"), METIS = 0;
+	}
+
+	static const char* dump = getenv("DUMP");
+
+	int depth = 0;
+	std::vector<unsigned char> locks(vertices.size());
+
+	// for cluster connectivity, we need a position-only remap that maps vertices with the same position to the same index
+	// it's more efficient to build it once; unfortunately, meshopt_generateVertexRemap doesn't support stride so we need to use *Multi version
+	std::vector<unsigned int> remap(vertices.size());
+	meshopt_Stream position = {&vertices[0].px, sizeof(float) * 3, sizeof(Vertex)};
+	meshopt_generateVertexRemapMulti(&remap[0], &indices[0], indices.size(), vertices.size(), &position, 1);
+
+	// initial clusterization splits the original mesh
+	std::vector<Cluster> clusters = clusterize(vertices, indices);
+	for (size_t i = 0; i < clusters.size(); ++i)
+		clusters[i].self = bounds(vertices, clusters[i].indices, 0.f);
+
+	printf("ideal lod chain: %.1f levels\n", log2(double(indices.size() / 3) / double(kClusterSize)));
+
+	std::vector<int> pending(clusters.size());
+	for (size_t i = 0; i < clusters.size(); ++i)
+		pending[i] = int(i);
+
+	// merge and simplify clusters until we can't merge anymore
+	while (pending.size() > 1)
+	{
+		std::vector<std::vector<int> > groups = partition(clusters, pending, remap);
+
+		if (kUseLocks)
+			lockBoundary(locks, groups, clusters, remap);
+
+		pending.clear();
+
+		std::vector<int> retry;
+
+		size_t triangles = 0;
+		size_t stuck_triangles = 0;
+
+		if (dump && depth == atoi(dump))
+			dumpObj(vertices, std::vector<unsigned int>());
+
+		// every group needs to be simplified now
+		for (size_t i = 0; i < groups.size(); ++i)
+		{
+			if (groups[i].empty())
+				continue; // metis shortcut
+
+			std::vector<unsigned int> merged;
+			for (size_t j = 0; j < groups[i].size(); ++j)
+				merged.insert(merged.end(), clusters[groups[i][j]].indices.begin(), clusters[groups[i][j]].indices.end());
+
+			if (dump && depth == atoi(dump))
+			{
+				for (size_t j = 0; j < groups[i].size(); ++j)
+					dumpObj("cluster", clusters[groups[i][j]].indices);
+
+				dumpObj("group", merged);
+			}
+
+			// aim to reduce group size in half
+			size_t target_size = (merged.size() / 3) / 2 * 3;
+
+			float error = 0.f;
+			std::vector<unsigned int> simplified = simplify(vertices, merged, kUseLocks ? &locks : NULL, target_size, &error);
+			if (simplified.size() > merged.size() * kSimplifyThreshold)
+			{
+				stuck_triangles += merged.size() / 3;
+				for (size_t j = 0; j < groups[i].size(); ++j)
+					retry.push_back(groups[i][j]);
+				continue; // simplification is stuck; abandon the merge
+			}
+
+			// enforce bounds and error monotonicity
+			// note: it is incorrect to use the precise bounds of the merged or simplified mesh, because this may violate monotonicity
+			LODBounds groupb = boundsMerge(clusters, groups[i]);
+			groupb.error += error; // this may overestimate the error, but we are starting from the simplified mesh so this is a little more correct
+
+			std::vector<Cluster> split = clusterize(vertices, simplified);
+
+			// update parent bounds and error for all clusters in the group
+			// note that all clusters in the group need to switch simultaneously so they have the same bounds
+			for (size_t j = 0; j < groups[i].size(); ++j)
+			{
+				assert(clusters[groups[i][j]].parent.error == FLT_MAX);
+				clusters[groups[i][j]].parent = groupb;
+			}
+
+			for (size_t j = 0; j < split.size(); ++j)
+			{
+				split[j].self = groupb;
+
+				clusters.push_back(split[j]); // std::move
+				pending.push_back(int(clusters.size()) - 1);
+
+				triangles += split[j].indices.size() / 3;
+			}
+		}
+
+		dumpMetrics(depth, clusters, groups, remap, locks, retry);
+		depth++;
+
+		if (kUseRetry)
+		{
+			if (triangles < stuck_triangles / 3)
+				break;
+
+			pending.insert(pending.end(), retry.begin(), retry.end());
+		}
+	}
+
+	size_t total_triangles = 0;
+	size_t lowest_triangles = 0;
+	for (size_t i = 0; i < clusters.size(); ++i)
+	{
+		total_triangles += clusters[i].indices.size() / 3;
+		if (clusters[i].parent.error == FLT_MAX)
+			lowest_triangles += clusters[i].indices.size() / 3;
+	}
+
+	printf("total: %d triangles in %d clusters\n", int(total_triangles), int(clusters.size()));
+	printf("lowest lod: %d triangles\n", int(lowest_triangles));
+
+	// for testing purposes, we can compute a DAG cut from a given viewpoint and dump it as an OBJ
+	float maxx = 0.f, maxy = 0.f, maxz = 0.f;
+	for (size_t i = 0; i < vertices.size(); ++i)
+	{
+		maxx = std::max(maxx, vertices[i].px * 2);
+		maxy = std::max(maxy, vertices[i].py * 2);
+		maxz = std::max(maxz, vertices[i].pz * 2);
+	}
+
+	float threshold = 2e-3f; // 2 pixels at 1080p
+	float fovy = 60.f;
+	float znear = 1e-2f;
+	float proj = 1.f / tanf(fovy * 3.1415926f / 180.f * 0.5f);
+
+	std::vector<unsigned int> cut;
+	for (size_t i = 0; i < clusters.size(); ++i)
+		if (boundsError(clusters[i].self, maxx, maxy, maxz, proj, znear) <= threshold && boundsError(clusters[i].parent, maxx, maxy, maxz, proj, znear) > threshold)
+			cut.insert(cut.end(), clusters[i].indices.begin(), clusters[i].indices.end());
+
+	printf("cut (%.3f): %d triangles\n", threshold, int(cut.size() / 3));
+
+	if (dump && -1 == atoi(dump))
+	{
+		dumpObj(vertices, cut);
+
+		for (size_t i = 0; i < clusters.size(); ++i)
+			if (boundsError(clusters[i].self, maxx, maxy, maxz, proj, znear) <= threshold && boundsError(clusters[i].parent, maxx, maxy, maxz, proj, znear) > threshold)
+				dumpObj("cluster", clusters[i].indices);
+	}
+}
+
+// What follows is code that is helpful for collecting metrics, visualizing cuts, etc.
+// This code is not used in the actual clustering implementation and can be ignored.
+
 static int follow(std::vector<int>& parents, int index)
 {
 	while (index != parents[index])
@@ -545,212 +734,4 @@ static void dumpMetrics(int level, const std::vector<Cluster>& queue, const std:
 	if (stuck_clusters)
 		printf("; stuck %d clusters (%d triangles)", stuck_clusters, stuck_triangles);
 	printf("\n");
-}
-
-static bool loadMetis()
-{
-#ifdef _WIN32
-	return false;
-#else
-	void* handle = dlopen("libmetis.so", RTLD_NOW | RTLD_LOCAL);
-	if (!handle)
-		return false;
-
-	METIS_SetDefaultOptions = (int (*)(int*))dlsym(handle, "METIS_SetDefaultOptions");
-	METIS_PartGraphRecursive = (int (*)(int*, int*, int*, int*, int*, int*, int*, int*, float*, float*, int*, int*, int*))dlsym(handle, "METIS_PartGraphRecursive");
-
-	return METIS_SetDefaultOptions && METIS_PartGraphRecursive;
-#endif
-}
-
-void dumpObj(const std::vector<Vertex>& vertices, const std::vector<unsigned int>& indices, bool recomputeNormals = false);
-void dumpObj(const char* section, const std::vector<unsigned int>& indices);
-
-void nanite(const std::vector<Vertex>& vertices, const std::vector<unsigned int>& indices)
-{
-	static const char* metis = getenv("METIS");
-	METIS = metis ? atoi(metis) : 0;
-
-	if (METIS)
-	{
-		if (loadMetis())
-			printf("using metis for %s\n", (METIS & 3) == 3 ? "clustering and partition" : ((METIS & 1) ? "partition only" : "clustering only"));
-		else
-			printf("metis library is not available\n"), METIS = 0;
-	}
-
-	static const char* dump = getenv("DUMP");
-
-#ifndef NDEBUG
-	std::vector<std::pair<int, int> > dag_debug;
-#endif
-
-	int depth = 0;
-	std::vector<unsigned char> locks(vertices.size());
-
-	// for cluster connectivity, we need a position-only remap that maps vertices with the same position to the same index
-	// it's more efficient to build it once; unfortunately, meshopt_generateVertexRemap doesn't support stride so we need to use *Multi version
-	std::vector<unsigned int> remap(vertices.size());
-	meshopt_Stream position = {&vertices[0].px, sizeof(float) * 3, sizeof(Vertex)};
-	meshopt_generateVertexRemapMulti(&remap[0], &indices[0], indices.size(), vertices.size(), &position, 1);
-
-	// initial clusterization splits the original mesh
-	std::vector<Cluster> clusters = clusterize(vertices, indices);
-	for (size_t i = 0; i < clusters.size(); ++i)
-		clusters[i].self = bounds(vertices, clusters[i].indices, 0.f);
-
-	printf("ideal lod chain: %.1f levels\n", log2(double(indices.size() / 3) / double(kClusterSize)));
-
-	std::vector<int> pending(clusters.size());
-	for (size_t i = 0; i < clusters.size(); ++i)
-		pending[i] = int(i);
-
-	// merge and simplify clusters until we can't merge anymore
-	while (pending.size() > 1)
-	{
-		std::vector<std::vector<int> > groups = partition(clusters, pending, remap);
-
-		if (kUseLocks)
-			lockBoundary(locks, groups, clusters, remap);
-
-		pending.clear();
-
-		std::vector<int> retry;
-
-		size_t triangles = 0;
-		size_t stuck_triangles = 0;
-
-		if (dump && depth == atoi(dump))
-			dumpObj(vertices, std::vector<unsigned int>());
-
-		// every group needs to be simplified now
-		for (size_t i = 0; i < groups.size(); ++i)
-		{
-			if (groups[i].empty())
-				continue; // metis shortcut
-
-			std::vector<unsigned int> merged;
-			for (size_t j = 0; j < groups[i].size(); ++j)
-				merged.insert(merged.end(), clusters[groups[i][j]].indices.begin(), clusters[groups[i][j]].indices.end());
-
-			if (dump && depth == atoi(dump))
-			{
-				for (size_t j = 0; j < groups[i].size(); ++j)
-					dumpObj("cluster", clusters[groups[i][j]].indices);
-
-				dumpObj("group", merged);
-			}
-
-			// aim to reduce group size in half
-			size_t target_size = (merged.size() / 3) / 2 * 3;
-
-			float error = 0.f;
-			std::vector<unsigned int> simplified = simplify(vertices, merged, kUseLocks ? &locks : NULL, target_size, &error);
-			if (simplified.size() > merged.size() * kSimplifyThreshold)
-			{
-				stuck_triangles += merged.size() / 3;
-				for (size_t j = 0; j < groups[i].size(); ++j)
-					retry.push_back(groups[i][j]);
-				continue; // simplification is stuck; abandon the merge
-			}
-
-			// enforce bounds and error monotonicity
-			// note: it is incorrect to use the precise bounds of the merged or simplified mesh, because this may violate monotonicity
-			LODBounds groupb = boundsMerge(clusters, groups[i]);
-			groupb.error += error; // this may overestimate the error, but we are starting from the simplified mesh so this is a little more correct
-
-			std::vector<Cluster> split = clusterize(vertices, simplified);
-
-			// update parent bounds and error for all clusters in the group
-			// note that all clusters in the group need to switch simultaneously so they have the same bounds
-			for (size_t j = 0; j < groups[i].size(); ++j)
-			{
-				assert(clusters[groups[i][j]].parent.error == FLT_MAX);
-				clusters[groups[i][j]].parent = groupb;
-			}
-
-#ifndef NDEBUG
-			// record DAG edges for validation during the cut
-			for (size_t j = 0; j < groups[i].size(); ++j)
-				for (size_t k = 0; k < split.size(); ++k)
-					dag_debug.push_back(std::make_pair(groups[i][j], int(clusters.size()) + int(k)));
-#endif
-
-			for (size_t j = 0; j < split.size(); ++j)
-			{
-				split[j].self = groupb;
-
-				clusters.push_back(split[j]); // std::move
-				pending.push_back(int(clusters.size()) - 1);
-
-				triangles += split[j].indices.size() / 3;
-			}
-		}
-
-		dumpMetrics(depth, clusters, groups, remap, locks, retry);
-		depth++;
-
-		if (kUseRetry)
-		{
-			if (triangles < stuck_triangles / 3)
-				break;
-
-			pending.insert(pending.end(), retry.begin(), retry.end());
-		}
-	}
-
-	size_t total_triangles = 0;
-	size_t lowest_triangles = 0;
-	for (size_t i = 0; i < clusters.size(); ++i)
-	{
-		total_triangles += clusters[i].indices.size() / 3;
-		if (clusters[i].parent.error == FLT_MAX)
-			lowest_triangles += clusters[i].indices.size() / 3;
-	}
-
-	printf("total: %d triangles in %d clusters\n", int(total_triangles), int(clusters.size()));
-	printf("lowest lod: %d triangles\n", int(lowest_triangles));
-
-	// for testing purposes, we can compute a DAG cut from a given viewpoint and dump it as an OBJ
-	float maxx = 0.f, maxy = 0.f, maxz = 0.f;
-	for (size_t i = 0; i < vertices.size(); ++i)
-	{
-		maxx = std::max(maxx, vertices[i].px * 2);
-		maxy = std::max(maxy, vertices[i].py * 2);
-		maxz = std::max(maxz, vertices[i].pz * 2);
-	}
-
-	float threshold = 2e-3f; // 2 pixels at 1080p
-	float fovy = 60.f;
-	float znear = 1e-2f;
-	float proj = 1.f / tanf(fovy * 3.1415926f / 180.f * 0.5f);
-
-	std::vector<unsigned int> cut;
-	for (size_t i = 0; i < clusters.size(); ++i)
-		if (boundsError(clusters[i].self, maxx, maxy, maxz, proj, znear) <= threshold && boundsError(clusters[i].parent, maxx, maxy, maxz, proj, znear) > threshold)
-			cut.insert(cut.end(), clusters[i].indices.begin(), clusters[i].indices.end());
-
-#ifndef NDEBUG
-	for (size_t i = 0; i < dag_debug.size(); ++i)
-	{
-		int j = dag_debug[i].first, k = dag_debug[i].second;
-		float ej = boundsError(clusters[j].self, maxx, maxy, maxz, proj, znear);
-		float ejp = boundsError(clusters[j].parent, maxx, maxy, maxz, proj, znear);
-		float ek = boundsError(clusters[k].self, maxx, maxy, maxz, proj, znear);
-
-		assert(ej <= ek);
-		assert(ejp >= ej);
-	}
-#endif
-
-	printf("cut (%.3f): %d triangles\n", threshold, int(cut.size() / 3));
-
-	if (dump && -1 == atoi(dump))
-	{
-		dumpObj(vertices, cut);
-
-		for (size_t i = 0; i < clusters.size(); ++i)
-			if (boundsError(clusters[i].self, maxx, maxy, maxz, proj, znear) <= threshold && boundsError(clusters[i].parent, maxx, maxy, maxz, proj, znear) > threshold)
-				dumpObj("cluster", clusters[i].indices);
-	}
 }

--- a/demo/nanite.cpp
+++ b/demo/nanite.cpp
@@ -135,100 +135,8 @@ static float boundsError(const LODBounds& bounds, float camera_x, float camera_y
 	return bounds.error / (d > camera_znear ? d : camera_znear) * (camera_proj * 0.5f);
 }
 
-static std::vector<Cluster> clusterizeMetis(const std::vector<Vertex>& vertices, const std::vector<unsigned int>& indices)
-{
-	std::vector<unsigned int> shadowib(indices.size());
-	meshopt_generateShadowIndexBuffer(&shadowib[0], &indices[0], indices.size(), &vertices[0].px, vertices.size(), sizeof(float) * 3, sizeof(Vertex));
-
-	std::vector<std::vector<int> > trilist(vertices.size());
-
-	for (size_t i = 0; i < indices.size(); ++i)
-		trilist[shadowib[i]].push_back(int(i / 3));
-
-	std::vector<int> xadj(indices.size() / 3 + 1);
-	std::vector<int> adjncy;
-	std::vector<int> adjwgt;
-	std::vector<int> part(indices.size() / 3);
-
-	std::vector<int> scratch;
-
-	for (size_t i = 0; i < indices.size() / 3; ++i)
-	{
-		unsigned int a = shadowib[i * 3 + 0], b = shadowib[i * 3 + 1], c = shadowib[i * 3 + 2];
-
-		scratch.clear();
-		scratch.insert(scratch.end(), trilist[a].begin(), trilist[a].end());
-		scratch.insert(scratch.end(), trilist[b].begin(), trilist[b].end());
-		scratch.insert(scratch.end(), trilist[c].begin(), trilist[c].end());
-		std::sort(scratch.begin(), scratch.end());
-
-		for (size_t j = 0; j < scratch.size(); ++j)
-		{
-			if (scratch[j] == int(i))
-				continue;
-
-			if (j == 0 || scratch[j] != scratch[j - 1])
-			{
-				adjncy.push_back(scratch[j]);
-				adjwgt.push_back(1);
-			}
-			else if (j != 0)
-			{
-				assert(scratch[j] == scratch[j - 1]);
-				adjwgt.back()++;
-			}
-		}
-
-		xadj[i + 1] = int(adjncy.size());
-	}
-
-	int options[METIS_NOPTIONS];
-	METIS_SetDefaultOptions(options);
-	options[METIS_OPTION_SEED] = 42;
-	options[METIS_OPTION_UFACTOR] = 1; // minimize partition imbalance
-
-	// since Metis can't enforce partition sizes, add a little slop to reduce the change we need to split results further
-	int nvtxs = int(indices.size() / 3);
-	int ncon = 1;
-	int nparts = int(indices.size() / 3 + (kClusterSize - kMetisSlop) - 1) / (kClusterSize - kMetisSlop);
-	int edgecut = 0;
-
-	// not sure why this is a special case that we need to handle but okay metis
-	if (nparts > 1)
-	{
-		int r = METIS_PartGraphRecursive(&nvtxs, &ncon, &xadj[0], &adjncy[0], NULL, NULL, &adjwgt[0], &nparts, NULL, NULL, options, &edgecut, &part[0]);
-		assert(r == METIS_OK);
-		(void)r;
-	}
-
-	std::vector<Cluster> result(nparts);
-
-	for (size_t i = 0; i < indices.size() / 3; ++i)
-	{
-		result[part[i]].indices.push_back(indices[i * 3 + 0]);
-		result[part[i]].indices.push_back(indices[i * 3 + 1]);
-		result[part[i]].indices.push_back(indices[i * 3 + 2]);
-	}
-
-	for (int i = 0; i < nparts; ++i)
-	{
-		result[i].parent.error = FLT_MAX;
-
-		// need to split the cluster further...
-		// this could use meshopt but we're trying to get a complete baseline from metis
-		if (result[i].indices.size() > kClusterSize * 3)
-		{
-			std::vector<Cluster> splits = clusterizeMetis(vertices, result[i].indices);
-			assert(splits.size() > 1);
-
-			result[i] = splits[0];
-			for (size_t j = 1; j < splits.size(); ++j)
-				result.push_back(splits[j]);
-		}
-	}
-
-	return result;
-}
+static std::vector<Cluster> clusterizeMetis(const std::vector<Vertex>& vertices, const std::vector<unsigned int>& indices);
+static std::vector<std::vector<int> > partitionMetis(const std::vector<Cluster>& clusters, const std::vector<int>& pending, const std::vector<unsigned int>& remap);
 
 static std::vector<Cluster> clusterize(const std::vector<Vertex>& vertices, const std::vector<unsigned int>& indices)
 {
@@ -263,85 +171,6 @@ static std::vector<Cluster> clusterize(const std::vector<Vertex>& vertices, cons
 	}
 
 	return clusters;
-}
-
-static std::vector<std::vector<int> > partitionMetis(const std::vector<Cluster>& clusters, const std::vector<int>& pending, const std::vector<unsigned int>& remap)
-{
-	std::vector<std::vector<int> > result;
-	std::vector<std::vector<int> > vertices(remap.size());
-
-	for (size_t i = 0; i < pending.size(); ++i)
-	{
-		const Cluster& cluster = clusters[pending[i]];
-
-		for (size_t j = 0; j < cluster.indices.size(); ++j)
-		{
-			int v = remap[cluster.indices[j]];
-
-			std::vector<int>& list = vertices[v];
-			if (list.empty() || list.back() != int(i))
-				list.push_back(int(i));
-		}
-	}
-
-	std::map<std::pair<int, int>, int> adjacency;
-
-	for (size_t v = 0; v < vertices.size(); ++v)
-	{
-		const std::vector<int>& list = vertices[v];
-
-		for (size_t i = 0; i < list.size(); ++i)
-			for (size_t j = i + 1; j < list.size(); ++j)
-				adjacency[std::make_pair(std::min(list[i], list[j]), std::max(list[i], list[j]))]++;
-	}
-
-	std::vector<std::vector<std::pair<int, int> > > neighbors(pending.size());
-
-	for (std::map<std::pair<int, int>, int>::iterator it = adjacency.begin(); it != adjacency.end(); ++it)
-	{
-		neighbors[it->first.first].push_back(std::make_pair(it->first.second, it->second));
-		neighbors[it->first.second].push_back(std::make_pair(it->first.first, it->second));
-	}
-
-	std::vector<int> xadj(pending.size() + 1);
-	std::vector<int> adjncy;
-	std::vector<int> adjwgt;
-	std::vector<int> part(pending.size());
-
-	for (size_t i = 0; i < pending.size(); ++i)
-	{
-		for (size_t j = 0; j < neighbors[i].size(); ++j)
-		{
-			adjncy.push_back(neighbors[i][j].first);
-			adjwgt.push_back(neighbors[i][j].second);
-		}
-
-		xadj[i + 1] = int(adjncy.size());
-	}
-
-	int options[METIS_NOPTIONS];
-	METIS_SetDefaultOptions(options);
-	options[METIS_OPTION_SEED] = 42;
-	options[METIS_OPTION_UFACTOR] = 100;
-
-	int nvtxs = int(pending.size());
-	int ncon = 1;
-	int nparts = int(pending.size() + kGroupSize - 1) / kGroupSize;
-	int edgecut = 0;
-
-	// not sure why this is a special case that we need to handle but okay metis
-	if (nparts > 1)
-	{
-		int r = METIS_PartGraphRecursive(&nvtxs, &ncon, &xadj[0], &adjncy[0], NULL, NULL, &adjwgt[0], &nparts, NULL, NULL, options, &edgecut, &part[0]);
-		assert(r == METIS_OK);
-		(void)r;
-	}
-
-	result.resize(nparts);
-	for (size_t i = 0; i < part.size(); ++i)
-		result[part[i]].push_back(pending[i]);
-
-	return result;
 }
 
 static std::vector<std::vector<int> > partition(const std::vector<Cluster>& clusters, const std::vector<int>& pending, const std::vector<unsigned int>& remap)
@@ -430,21 +259,7 @@ static std::vector<unsigned int> simplify(const std::vector<Vertex>& vertices, c
 
 static void dumpMetrics(int level, const std::vector<Cluster>& queue, const std::vector<std::vector<int> >& groups, const std::vector<unsigned int>& remap, const std::vector<unsigned char>& locks, const std::vector<int>& retry);
 
-static bool loadMetis()
-{
-#ifdef _WIN32
-	return false;
-#else
-	void* handle = dlopen("libmetis.so", RTLD_NOW | RTLD_LOCAL);
-	if (!handle)
-		return false;
-
-	METIS_SetDefaultOptions = (int (*)(int*))dlsym(handle, "METIS_SetDefaultOptions");
-	METIS_PartGraphRecursive = (int (*)(int*, int*, int*, int*, int*, int*, int*, int*, float*, float*, int*, int*, int*))dlsym(handle, "METIS_PartGraphRecursive");
-
-	return METIS_SetDefaultOptions && METIS_PartGraphRecursive;
-#endif
-}
+static bool loadMetis();
 
 void dumpObj(const std::vector<Vertex>& vertices, const std::vector<unsigned int>& indices, bool recomputeNormals = false);
 void dumpObj(const char* section, const std::vector<unsigned int>& indices);
@@ -612,6 +427,199 @@ void nanite(const std::vector<Vertex>& vertices, const std::vector<unsigned int>
 			if (boundsError(clusters[i].self, maxx, maxy, maxz, proj, znear) <= threshold && boundsError(clusters[i].parent, maxx, maxy, maxz, proj, znear) > threshold)
 				dumpObj("cluster", clusters[i].indices);
 	}
+}
+
+// What follows is code that optionally uses METIS library to perform partitioning and/or clustering.
+// The focus of this example is on combining meshopt_ algorithms, but METIS fallbacks are provided for now.
+
+static bool loadMetis()
+{
+#ifdef _WIN32
+	return false;
+#else
+	void* handle = dlopen("libmetis.so", RTLD_NOW | RTLD_LOCAL);
+	if (!handle)
+		return false;
+
+	METIS_SetDefaultOptions = (int (*)(int*))dlsym(handle, "METIS_SetDefaultOptions");
+	METIS_PartGraphRecursive = (int (*)(int*, int*, int*, int*, int*, int*, int*, int*, float*, float*, int*, int*, int*))dlsym(handle, "METIS_PartGraphRecursive");
+
+	return METIS_SetDefaultOptions && METIS_PartGraphRecursive;
+#endif
+}
+
+static std::vector<Cluster> clusterizeMetis(const std::vector<Vertex>& vertices, const std::vector<unsigned int>& indices)
+{
+	std::vector<unsigned int> shadowib(indices.size());
+	meshopt_generateShadowIndexBuffer(&shadowib[0], &indices[0], indices.size(), &vertices[0].px, vertices.size(), sizeof(float) * 3, sizeof(Vertex));
+
+	std::vector<std::vector<int> > trilist(vertices.size());
+
+	for (size_t i = 0; i < indices.size(); ++i)
+		trilist[shadowib[i]].push_back(int(i / 3));
+
+	std::vector<int> xadj(indices.size() / 3 + 1);
+	std::vector<int> adjncy;
+	std::vector<int> adjwgt;
+	std::vector<int> part(indices.size() / 3);
+
+	std::vector<int> scratch;
+
+	for (size_t i = 0; i < indices.size() / 3; ++i)
+	{
+		unsigned int a = shadowib[i * 3 + 0], b = shadowib[i * 3 + 1], c = shadowib[i * 3 + 2];
+
+		scratch.clear();
+		scratch.insert(scratch.end(), trilist[a].begin(), trilist[a].end());
+		scratch.insert(scratch.end(), trilist[b].begin(), trilist[b].end());
+		scratch.insert(scratch.end(), trilist[c].begin(), trilist[c].end());
+		std::sort(scratch.begin(), scratch.end());
+
+		for (size_t j = 0; j < scratch.size(); ++j)
+		{
+			if (scratch[j] == int(i))
+				continue;
+
+			if (j == 0 || scratch[j] != scratch[j - 1])
+			{
+				adjncy.push_back(scratch[j]);
+				adjwgt.push_back(1);
+			}
+			else if (j != 0)
+			{
+				assert(scratch[j] == scratch[j - 1]);
+				adjwgt.back()++;
+			}
+		}
+
+		xadj[i + 1] = int(adjncy.size());
+	}
+
+	int options[METIS_NOPTIONS];
+	METIS_SetDefaultOptions(options);
+	options[METIS_OPTION_SEED] = 42;
+	options[METIS_OPTION_UFACTOR] = 1; // minimize partition imbalance
+
+	// since Metis can't enforce partition sizes, add a little slop to reduce the change we need to split results further
+	int nvtxs = int(indices.size() / 3);
+	int ncon = 1;
+	int nparts = int(indices.size() / 3 + (kClusterSize - kMetisSlop) - 1) / (kClusterSize - kMetisSlop);
+	int edgecut = 0;
+
+	// not sure why this is a special case that we need to handle but okay metis
+	if (nparts > 1)
+	{
+		int r = METIS_PartGraphRecursive(&nvtxs, &ncon, &xadj[0], &adjncy[0], NULL, NULL, &adjwgt[0], &nparts, NULL, NULL, options, &edgecut, &part[0]);
+		assert(r == METIS_OK);
+		(void)r;
+	}
+
+	std::vector<Cluster> result(nparts);
+
+	for (size_t i = 0; i < indices.size() / 3; ++i)
+	{
+		result[part[i]].indices.push_back(indices[i * 3 + 0]);
+		result[part[i]].indices.push_back(indices[i * 3 + 1]);
+		result[part[i]].indices.push_back(indices[i * 3 + 2]);
+	}
+
+	for (int i = 0; i < nparts; ++i)
+	{
+		result[i].parent.error = FLT_MAX;
+
+		// need to split the cluster further...
+		// this could use meshopt but we're trying to get a complete baseline from metis
+		if (result[i].indices.size() > kClusterSize * 3)
+		{
+			std::vector<Cluster> splits = clusterizeMetis(vertices, result[i].indices);
+			assert(splits.size() > 1);
+
+			result[i] = splits[0];
+			for (size_t j = 1; j < splits.size(); ++j)
+				result.push_back(splits[j]);
+		}
+	}
+
+	return result;
+}
+
+static std::vector<std::vector<int> > partitionMetis(const std::vector<Cluster>& clusters, const std::vector<int>& pending, const std::vector<unsigned int>& remap)
+{
+	std::vector<std::vector<int> > result;
+	std::vector<std::vector<int> > vertices(remap.size());
+
+	for (size_t i = 0; i < pending.size(); ++i)
+	{
+		const Cluster& cluster = clusters[pending[i]];
+
+		for (size_t j = 0; j < cluster.indices.size(); ++j)
+		{
+			int v = remap[cluster.indices[j]];
+
+			std::vector<int>& list = vertices[v];
+			if (list.empty() || list.back() != int(i))
+				list.push_back(int(i));
+		}
+	}
+
+	std::map<std::pair<int, int>, int> adjacency;
+
+	for (size_t v = 0; v < vertices.size(); ++v)
+	{
+		const std::vector<int>& list = vertices[v];
+
+		for (size_t i = 0; i < list.size(); ++i)
+			for (size_t j = i + 1; j < list.size(); ++j)
+				adjacency[std::make_pair(std::min(list[i], list[j]), std::max(list[i], list[j]))]++;
+	}
+
+	std::vector<std::vector<std::pair<int, int> > > neighbors(pending.size());
+
+	for (std::map<std::pair<int, int>, int>::iterator it = adjacency.begin(); it != adjacency.end(); ++it)
+	{
+		neighbors[it->first.first].push_back(std::make_pair(it->first.second, it->second));
+		neighbors[it->first.second].push_back(std::make_pair(it->first.first, it->second));
+	}
+
+	std::vector<int> xadj(pending.size() + 1);
+	std::vector<int> adjncy;
+	std::vector<int> adjwgt;
+	std::vector<int> part(pending.size());
+
+	for (size_t i = 0; i < pending.size(); ++i)
+	{
+		for (size_t j = 0; j < neighbors[i].size(); ++j)
+		{
+			adjncy.push_back(neighbors[i][j].first);
+			adjwgt.push_back(neighbors[i][j].second);
+		}
+
+		xadj[i + 1] = int(adjncy.size());
+	}
+
+	int options[METIS_NOPTIONS];
+	METIS_SetDefaultOptions(options);
+	options[METIS_OPTION_SEED] = 42;
+	options[METIS_OPTION_UFACTOR] = 100;
+
+	int nvtxs = int(pending.size());
+	int ncon = 1;
+	int nparts = int(pending.size() + kGroupSize - 1) / kGroupSize;
+	int edgecut = 0;
+
+	// not sure why this is a special case that we need to handle but okay metis
+	if (nparts > 1)
+	{
+		int r = METIS_PartGraphRecursive(&nvtxs, &ncon, &xadj[0], &adjncy[0], NULL, NULL, &adjwgt[0], &nparts, NULL, NULL, options, &edgecut, &part[0]);
+		assert(r == METIS_OK);
+		(void)r;
+	}
+
+	result.resize(nparts);
+	for (size_t i = 0; i < part.size(); ++i)
+		result[part[i]].push_back(pending[i]);
+
+	return result;
 }
 
 // What follows is code that is helpful for collecting metrics, visualizing cuts, etc.


### PR DESCRIPTION
This change mostly refactors the code to be easier to understand and follow:

- All metrics computations are centralized in a separate function so that it doesn't obscure the processing flow
- All metrics and METIS related implementations moved to the end of the file
- Remove some redundant statistics and fix some metrics that were off between levels

Also remove single cluster special case. In general, it's not clear that it needs to be special-cased, as a group with merged disconnected clusters is just effectively synchronizing the LOD transition decisions between different clusters; but for now since meshopt partitioning leaves these alone, this helps reduce the overall triangle count a bit further for some meshes.

*This contribution is sponsored by Valve.*