### PR TITLE
clusterizer: Add buildMeshletsFlex with flexible cluster sizing

### DIFF
--- a/demo/main.cpp
+++ b/demo/main.cpp
@@ -990,10 +990,8 @@ static int follow(int* parents, int index)
 	return index;
 }
 
-void meshlets(const Mesh& mesh, bool scan = false, bool uniform = false, bool flex = false)
+void meshlets(const Mesh& mesh, bool scan = false, bool uniform = false, bool flex = false, bool dump = false)
 {
-	bool dump = getenv("DUMP") && atoi(getenv("DUMP"));
-
 	// NVidia-recommends 64/126; we round 126 down to a multiple of 4
 	// alternatively we also test uniform configuration with 64/64 which is better for AMD
 	const size_t max_vertices = 64;
@@ -1480,7 +1478,14 @@ void processDev(const char* path)
 	if (!loadMesh(mesh, path))
 		return;
 
-	meshlets(mesh, /* scan= */ false, /* uniform= */ true, /* flex= */ true);
+#ifdef _MSC_VER
+#pragma warning(disable : 4996)
+#endif
+
+	bool dump = getenv("DUMP") && atoi(getenv("DUMP"));
+
+	meshlets(mesh, /* scan= */ false, /* uniform= */ true, /* flex= */ false);
+	meshlets(mesh, /* scan= */ false, /* uniform= */ true, /* flex= */ true, dump);
 }
 
 void processNanite(const char* path)

--- a/demo/nanite.cpp
+++ b/demo/nanite.cpp
@@ -18,7 +18,7 @@
 #include <string.h>
 
 #include <algorithm>
-#include <map>
+#include <map> // only for METIS
 #include <vector>
 
 #ifndef _WIN32
@@ -145,14 +145,16 @@ static std::vector<Cluster> clusterize(const std::vector<Vertex>& vertices, cons
 
 	const size_t max_vertices = 192; // TODO: depends on kClusterSize, also may want to dial down for mesh shaders
 	const size_t max_triangles = kClusterSize;
+	const size_t min_triangles = (kClusterSize / 3) & ~3;
+	const float split_factor = 2.0f;
 
-	size_t max_meshlets = meshopt_buildMeshletsBound(indices.size(), max_vertices, max_triangles);
+	size_t max_meshlets = meshopt_buildMeshletsBound(indices.size(), max_vertices, min_triangles);
 
 	std::vector<meshopt_Meshlet> meshlets(max_meshlets);
 	std::vector<unsigned int> meshlet_vertices(max_meshlets * max_vertices);
 	std::vector<unsigned char> meshlet_triangles(max_meshlets * max_triangles * 3);
 
-	meshlets.resize(meshopt_buildMeshlets(&meshlets[0], &meshlet_vertices[0], &meshlet_triangles[0], &indices[0], indices.size(), &vertices[0].px, vertices.size(), sizeof(Vertex), max_vertices, max_triangles, 0.f));
+	meshlets.resize(meshopt_buildMeshletsFlex(&meshlets[0], &meshlet_vertices[0], &meshlet_triangles[0], &indices[0], indices.size(), &vertices[0].px, vertices.size(), sizeof(Vertex), max_vertices, min_triangles, max_triangles, 0.f, split_factor));
 
 	std::vector<Cluster> clusters(meshlets.size());
 

--- a/src/meshoptimizer.h
+++ b/src/meshoptimizer.h
@@ -766,6 +766,8 @@ inline size_t meshopt_buildMeshlets(meshopt_Meshlet* meshlets, unsigned int* mes
 template <typename T>
 inline size_t meshopt_buildMeshletsScan(meshopt_Meshlet* meshlets, unsigned int* meshlet_vertices, unsigned char* meshlet_triangles, const T* indices, size_t index_count, size_t vertex_count, size_t max_vertices, size_t max_triangles);
 template <typename T>
+inline size_t meshopt_buildMeshletsFlex(meshopt_Meshlet* meshlets, unsigned int* meshlet_vertices, unsigned char* meshlet_triangles, const T* indices, size_t index_count, const float* vertex_positions, size_t vertex_count, size_t vertex_positions_stride, size_t max_vertices, size_t min_triangles, size_t max_triangles, float cone_weight, float split_factor);
+template <typename T>
 inline meshopt_Bounds meshopt_computeClusterBounds(const T* indices, size_t index_count, const float* vertex_positions, size_t vertex_count, size_t vertex_positions_stride);
 template <typename T>
 inline size_t meshopt_partitionClusters(unsigned int* destination, const T* cluster_indices, size_t total_index_count, const unsigned int* cluster_index_counts, size_t cluster_count, size_t vertex_count, size_t target_partition_size);
@@ -1146,6 +1148,14 @@ inline size_t meshopt_buildMeshletsScan(meshopt_Meshlet* meshlets, unsigned int*
 	meshopt_IndexAdapter<T> in(NULL, indices, index_count);
 
 	return meshopt_buildMeshletsScan(meshlets, meshlet_vertices, meshlet_triangles, in.data, index_count, vertex_count, max_vertices, max_triangles);
+}
+
+template <typename T>
+inline size_t meshopt_buildMeshletsFlex(meshopt_Meshlet* meshlets, unsigned int* meshlet_vertices, unsigned char* meshlet_triangles, const T* indices, size_t index_count, const float* vertex_positions, size_t vertex_count, size_t vertex_positions_stride, size_t max_vertices, size_t min_triangles, size_t max_triangles, float cone_weight, float split_factor)
+{
+	meshopt_IndexAdapter<T> in(NULL, indices, index_count);
+
+	return meshopt_buildMeshletsFlex(meshlets, meshlet_vertices, meshlet_triangles, in.data, index_count, vertex_positions, vertex_count, vertex_positions_stride, max_vertices, min_triangles, max_triangles, cone_weight, split_factor);
 }
 
 template <typename T>

--- a/src/meshoptimizer.h
+++ b/src/meshoptimizer.h
@@ -552,6 +552,22 @@ MESHOPTIMIZER_API size_t meshopt_buildMeshletsScan(struct meshopt_Meshlet* meshl
 MESHOPTIMIZER_API size_t meshopt_buildMeshletsBound(size_t index_count, size_t max_vertices, size_t max_triangles);
 
 /**
+ * Experimental: Meshlet builder with flexible cluster sizes
+ * Splits the mesh into a set of meshlets, similarly to meshopt_buildMeshlets, but allows to specify minimum and maximum number of triangles per meshlet.
+ * Clusters between min and max triangle counts are split when the cluster size would have exceeded the expected cluster size by more than split_factor.
+ * Additionally, allows to switch to axis aligned clusters by setting cone_weight to a negative value.
+ *
+ * meshlets must contain enough space for all meshlets, worst case size can be computed with meshopt_buildMeshletsBound using min_triangles (not max!)
+ * meshlet_vertices must contain enough space for all meshlets, worst case size is equal to max_meshlets * max_vertices
+ * meshlet_triangles must contain enough space for all meshlets, worst case size is equal to max_meshlets * max_triangles * 3
+ * vertex_positions should have float3 position in the first 12 bytes of each vertex
+ * max_vertices, min_triangles and max_triangles must not exceed implementation limits (max_vertices <= 255 - not 256!, max_triangles <= 512; min_triangles <= max_triangles; both min_triangles and max_triangles must be divisible by 4)
+ * cone_weight should be set to 0 when cone culling is not used, and a value between 0 and 1 otherwise to balance between cluster size and cone culling efficiency; additionally, cone_weight can be set to a negative value to prioritize axis aligned clusters (for raytracing) instead
+ * split_factor should be set to a non-negative value; when greater than 0, clusters that have large bounds may be split unless they are under the min_triangles threshold
+ */
+MESHOPTIMIZER_API size_t meshopt_buildMeshletsFlex(struct meshopt_Meshlet* meshlets, unsigned int* meshlet_vertices, unsigned char* meshlet_triangles, const unsigned int* indices, size_t index_count, const float* vertex_positions, size_t vertex_count, size_t vertex_positions_stride, size_t max_vertices, size_t min_triangles, size_t max_triangles, float cone_weight, float split_factor);
+
+/**
  * Experimental: Meshlet optimizer
  * Reorders meshlet vertices and triangles to maximize locality to improve rasterizer throughput
  *


### PR DESCRIPTION
In some cases, producing clusters from two disconnected regions of the
mesh may result in efficiency loss in the downstream algorithms; this is
sometimes hard to avoid due to unpredictable traversal flow. This change
introduces a variant of the existing meshlet builder,
`meshopt_buildMeshletsFlex`, which has two triangle count limits: a lower
and upper limit. When a cluster is below a lower limit, the logic
remains the same, however for larger clusters we allow splitting the
resulting cluster if not doing that would result in excessively large
volume, as measured by `split_factor`.

For now, `split_factor` is applied to the expected radius to serve as a
cutoff value; this assumes somewhat uniform input triangle sizes, but
also protects against clusters that are already disjointly merged (due
to splits while they are under the minimum limit) becoming even larger.

Additionally, it is now possible to switch to a sizing heuristic that
favors axis aligned cluster bounds; to do that, a negative `cone_weight`
must be passed, since in these cases cone weighting is not useful. This
is especially valuable for ray tracing workloads when an efficient BVH
must be built over the resulting clusters.

The adaptive cluster sizing on splits mirrors early plans in https://github.com/zeux/meshoptimizer/issues/531#issuecomment-1404545237.

This can be useful for:

- Hierarchical simplification; using regular `cone_weight` (`0`/`0.25` based on whether cone culling is relevant at runtime) and a more flexible triangle count range with `split_factor=2` reduces the cluster splits which improves the DAG quality on subsequent levels 
- Clustered ray tracing via `VK_NV_cluster_acceleration_structure`; using a flexible triangle count range with `split_factor=2` reduces cluster splits which results in a more efficient BLAS, and using `cone_weight=-1` produces cluster boundaries that are better aligned with cardinal axes which reduces overlap and improves AS quality

The specific splitting behavior is subject to change; future work includes more tweaks to the axis aligned metric and improvements to global traversal order that should naturally reduce the split conditions further.

*Thanks to Nvidia for providing an early version of the patch that this PR is based on.*
*This contribution is sponsored by Valve.*