### PR TITLE
gltfpack: Warn when position quantization error is significant

### DIFF
--- a/gltf/stream.cpp
+++ b/gltf/stream.cpp
@@ -122,7 +122,7 @@ QuantizationPosition prepareQuantizationPosition(const std::vector<Mesh>& meshes
 		float max_rel_error = 0;
 
 		for (size_t i = 0; i < meshes.size(); ++i)
-			if (bounds[i].isValid())
+			if (bounds[i].isValid() && bounds[i].getExtent() > 1e-2f)
 				max_rel_error = std::max(max_rel_error, error / bounds[i].getExtent());
 
 		if (max_rel_error > 5e-2f)


### PR DESCRIPTION
When float quantization is not used, we use the same quantization
settings for all meshes. This simplifies the flow as skins and materials
may need to change based on the quantization grid, and in some cases
eliminates micro gaps between meshes, but may result in reduced
precision compared to using per-mesh grids.

For now we detect this case and suggest increasing the number of bits
used for positions or switching to floating-point quantization.

One other possible option that can improve this is `-kn` but this is more
situational so for now the warning message doesn't recommend it.

Closes #433