### PR TITLE
Stabilize a set of experimental APIs

### DIFF
--- a/demo/simplify.html
+++ b/demo/simplify.html
@@ -457,8 +457,6 @@
 
 			function simplify() {
 				MeshoptSimplifier.ready.then(function () {
-					MeshoptSimplifier.useExperimentalFeatures = true;
-
 					var threshold = Math.pow(10, -settings.errorThresholdLog10);
 
 					if (settings.autoLod) {

--- a/js/meshopt_simplifier.js
+++ b/js/meshopt_simplifier.js
@@ -205,10 +205,6 @@ var MeshoptSimplifier = (function () {
 		ready: ready,
 		supported: true,
 
-		// set this to true to be able to use simplifyPoints and simplifyWithAttributes
-		// note that these functions are experimental and may change interface/behavior in a way that will require revising calling code
-		useExperimentalFeatures: false,
-
 		compactMesh: function (indices) {
 			assert(
 				indices instanceof Uint32Array || indices instanceof Int32Array || indices instanceof Uint16Array || indices instanceof Int16Array
@@ -234,7 +230,6 @@ var MeshoptSimplifier = (function () {
 			var options = 0;
 			for (var i = 0; i < (flags ? flags.length : 0); ++i) {
 				assert(flags[i] in simplifyOptions);
-				assert(this.useExperimentalFeatures || flags[i] != 'Prune'); // set useExperimentalFeatures to use experimental flags like Prune
 				options |= simplifyOptions[flags[i]];
 			}
 
@@ -267,7 +262,6 @@ var MeshoptSimplifier = (function () {
 			target_error,
 			flags
 		) {
-			assert(this.useExperimentalFeatures); // set useExperimentalFeatures to use this; note that this function is experimental and may change interface in a way that will require revising calling code
 			assert(
 				indices instanceof Uint32Array || indices instanceof Int32Array || indices instanceof Uint16Array || indices instanceof Int16Array
 			);
@@ -330,7 +324,6 @@ var MeshoptSimplifier = (function () {
 		},
 
 		simplifyPoints: function (vertex_positions, vertex_positions_stride, target_vertex_count, vertex_colors, vertex_colors_stride, color_weight) {
-			assert(this.useExperimentalFeatures); // set useExperimentalFeatures to use this; note that this function is experimental and may change interface in a way that will require revising calling code
 			assert(vertex_positions instanceof Float32Array);
 			assert(vertex_positions.length % vertex_positions_stride == 0);
 			assert(vertex_positions_stride >= 3);

--- a/js/meshopt_simplifier.module.d.ts
+++ b/js/meshopt_simplifier.module.d.ts
@@ -6,8 +6,6 @@ export const MeshoptSimplifier: {
 	supported: boolean;
 	ready: Promise<void>;
 
-	useExperimentalFeatures: boolean;
-
 	compactMesh: (indices: Uint32Array) => [Uint32Array, number];
 
 	simplify: (
@@ -19,7 +17,6 @@ export const MeshoptSimplifier: {
 		flags?: Flags[]
 	) => [Uint32Array, number];
 
-	// Experimental; requires useExperimentalFeatures to be set to true
 	simplifyWithAttributes: (
 		indices: Uint32Array,
 		vertex_positions: Float32Array,
@@ -35,7 +32,6 @@ export const MeshoptSimplifier: {
 
 	getScale: (vertex_positions: Float32Array, vertex_positions_stride: number) => number;
 
-	// Experimental; requires useExperimentalFeatures to be set to true
 	simplifyPoints: (
 		vertex_positions: Float32Array,
 		vertex_positions_stride: number,

--- a/js/meshopt_simplifier.module.js
+++ b/js/meshopt_simplifier.module.js
@@ -204,10 +204,6 @@ var MeshoptSimplifier = (function () {
 		ready: ready,
 		supported: true,
 
-		// set this to true to be able to use simplifyPoints and simplifyWithAttributes
-		// note that these functions are experimental and may change interface/behavior in a way that will require revising calling code
-		useExperimentalFeatures: false,
-
 		compactMesh: function (indices) {
 			assert(
 				indices instanceof Uint32Array || indices instanceof Int32Array || indices instanceof Uint16Array || indices instanceof Int16Array
@@ -233,7 +229,6 @@ var MeshoptSimplifier = (function () {
 			var options = 0;
 			for (var i = 0; i < (flags ? flags.length : 0); ++i) {
 				assert(flags[i] in simplifyOptions);
-				assert(this.useExperimentalFeatures || flags[i] != 'Prune'); // set useExperimentalFeatures to use experimental flags like Prune
 				options |= simplifyOptions[flags[i]];
 			}
 
@@ -266,7 +261,6 @@ var MeshoptSimplifier = (function () {
 			target_error,
 			flags
 		) {
-			assert(this.useExperimentalFeatures); // set useExperimentalFeatures to use this; note that this function is experimental and may change interface in a way that will require revising calling code
 			assert(
 				indices instanceof Uint32Array || indices instanceof Int32Array || indices instanceof Uint16Array || indices instanceof Int16Array
 			);
@@ -329,7 +323,6 @@ var MeshoptSimplifier = (function () {
 		},
 
 		simplifyPoints: function (vertex_positions, vertex_positions_stride, target_vertex_count, vertex_colors, vertex_colors_stride, color_weight) {
-			assert(this.useExperimentalFeatures); // set useExperimentalFeatures to use this; note that this function is experimental and may change interface in a way that will require revising calling code
 			assert(vertex_positions instanceof Float32Array);
 			assert(vertex_positions.length % vertex_positions_stride == 0);
 			assert(vertex_positions_stride >= 3);

--- a/js/meshopt_simplifier.test.js
+++ b/js/meshopt_simplifier.test.js
@@ -6,8 +6,6 @@ process.on('unhandledRejection', (error) => {
 	process.exit(1);
 });
 
-simplifier.useExperimentalFeatures = true;
-
 var tests = {
 	compactMesh: function () {
 		var indices = new Uint32Array([0, 1, 3, 3, 1, 5]);

--- a/src/meshoptimizer.h
+++ b/src/meshoptimizer.h
@@ -565,7 +565,7 @@ MESHOPTIMIZER_API size_t meshopt_buildMeshletsBound(size_t index_count, size_t m
  * cone_weight should be set to 0 when cone culling is not used, and a value between 0 and 1 otherwise to balance between cluster size and cone culling efficiency; additionally, cone_weight can be set to a negative value to prioritize axis aligned clusters (for raytracing) instead
  * split_factor should be set to a non-negative value; when greater than 0, clusters that have large bounds may be split unless they are under the min_triangles threshold
  */
-MESHOPTIMIZER_API size_t meshopt_buildMeshletsFlex(struct meshopt_Meshlet* meshlets, unsigned int* meshlet_vertices, unsigned char* meshlet_triangles, const unsigned int* indices, size_t index_count, const float* vertex_positions, size_t vertex_count, size_t vertex_positions_stride, size_t max_vertices, size_t min_triangles, size_t max_triangles, float cone_weight, float split_factor);
+MESHOPTIMIZER_EXPERIMENTAL size_t meshopt_buildMeshletsFlex(struct meshopt_Meshlet* meshlets, unsigned int* meshlet_vertices, unsigned char* meshlet_triangles, const unsigned int* indices, size_t index_count, const float* vertex_positions, size_t vertex_count, size_t vertex_positions_stride, size_t max_vertices, size_t min_triangles, size_t max_triangles, float cone_weight, float split_factor);
 
 /**
  * Meshlet optimizer

--- a/src/meshoptimizer.h
+++ b/src/meshoptimizer.h
@@ -399,7 +399,7 @@ enum
 MESHOPTIMIZER_API size_t meshopt_simplify(unsigned int* destination, const unsigned int* indices, size_t index_count, const float* vertex_positions, size_t vertex_count, size_t vertex_positions_stride, size_t target_index_count, float target_error, unsigned int options, float* result_error);
 
 /**
- * Experimental: Mesh simplifier with attribute metric
+ * Mesh simplifier with attribute metric
  * The algorithm enhances meshopt_simplify by incorporating attribute values into the error metric used to prioritize simplification order; see meshopt_simplify documentation for details.
  * Note that the number of attributes affects memory requirements and running time; this algorithm requires ~1.5x more memory and time compared to meshopt_simplify when using 4 scalar attributes.
  *
@@ -408,7 +408,7 @@ MESHOPTIMIZER_API size_t meshopt_simplify(unsigned int* destination, const unsig
  * attribute_count must be <= 32
  * vertex_lock can be NULL; when it's not NULL, it should have a value for each vertex; 1 denotes vertices that can't be moved
  */
-MESHOPTIMIZER_EXPERIMENTAL size_t meshopt_simplifyWithAttributes(unsigned int* destination, const unsigned int* indices, size_t index_count, const float* vertex_positions, size_t vertex_count, size_t vertex_positions_stride, const float* vertex_attributes, size_t vertex_attributes_stride, const float* attribute_weights, size_t attribute_count, const unsigned char* vertex_lock, size_t target_index_count, float target_error, unsigned int options, float* result_error);
+MESHOPTIMIZER_API size_t meshopt_simplifyWithAttributes(unsigned int* destination, const unsigned int* indices, size_t index_count, const float* vertex_positions, size_t vertex_count, size_t vertex_positions_stride, const float* vertex_attributes, size_t vertex_attributes_stride, const float* attribute_weights, size_t attribute_count, const unsigned char* vertex_lock, size_t target_index_count, float target_error, unsigned int options, float* result_error);
 
 /**
  * Experimental: Mesh simplifier (sloppy)
@@ -426,7 +426,7 @@ MESHOPTIMIZER_EXPERIMENTAL size_t meshopt_simplifyWithAttributes(unsigned int* d
 MESHOPTIMIZER_EXPERIMENTAL size_t meshopt_simplifySloppy(unsigned int* destination, const unsigned int* indices, size_t index_count, const float* vertex_positions, size_t vertex_count, size_t vertex_positions_stride, size_t target_index_count, float target_error, float* result_error);
 
 /**
- * Experimental: Point cloud simplifier
+ * Point cloud simplifier
  * Reduces the number of points in the cloud to reach the given target
  * Returns the number of points after simplification, with destination containing new index data
  * The resulting index buffer references vertices from the original vertex buffer.
@@ -437,7 +437,7 @@ MESHOPTIMIZER_EXPERIMENTAL size_t meshopt_simplifySloppy(unsigned int* destinati
  * vertex_colors should can be NULL; when it's not NULL, it should have float3 color in the first 12 bytes of each vertex
  * color_weight determines relative priority of color wrt position; 1.0 is a safe default
  */
-MESHOPTIMIZER_EXPERIMENTAL size_t meshopt_simplifyPoints(unsigned int* destination, const float* vertex_positions, size_t vertex_count, size_t vertex_positions_stride, const float* vertex_colors, size_t vertex_colors_stride, float color_weight, size_t target_vertex_count);
+MESHOPTIMIZER_API size_t meshopt_simplifyPoints(unsigned int* destination, const float* vertex_positions, size_t vertex_count, size_t vertex_positions_stride, const float* vertex_colors, size_t vertex_colors_stride, float color_weight, size_t target_vertex_count);
 
 /**
  * Returns the error scaling factor used by the simplifier to convert between absolute and relative extents

--- a/src/meshoptimizer.h
+++ b/src/meshoptimizer.h
@@ -568,14 +568,14 @@ MESHOPTIMIZER_API size_t meshopt_buildMeshletsBound(size_t index_count, size_t m
 MESHOPTIMIZER_API size_t meshopt_buildMeshletsFlex(struct meshopt_Meshlet* meshlets, unsigned int* meshlet_vertices, unsigned char* meshlet_triangles, const unsigned int* indices, size_t index_count, const float* vertex_positions, size_t vertex_count, size_t vertex_positions_stride, size_t max_vertices, size_t min_triangles, size_t max_triangles, float cone_weight, float split_factor);
 
 /**
- * Experimental: Meshlet optimizer
+ * Meshlet optimizer
  * Reorders meshlet vertices and triangles to maximize locality to improve rasterizer throughput
  *
  * meshlet_triangles and meshlet_vertices must refer to meshlet triangle and vertex index data; when buildMeshlets* is used, these
  * need to be computed from meshlet's vertex_offset and triangle_offset
  * triangle_count and vertex_count must not exceed implementation limits (vertex_count <= 255 - not 256!, triangle_count <= 512)
  */
-MESHOPTIMIZER_EXPERIMENTAL void meshopt_optimizeMeshlet(unsigned int* meshlet_vertices, unsigned char* meshlet_triangles, size_t triangle_count, size_t vertex_count);
+MESHOPTIMIZER_API void meshopt_optimizeMeshlet(unsigned int* meshlet_vertices, unsigned char* meshlet_triangles, size_t triangle_count, size_t vertex_count);
 
 struct meshopt_Bounds
 {

--- a/src/meshoptimizer.h
+++ b/src/meshoptimizer.h
@@ -292,7 +292,7 @@ MESHOPTIMIZER_API size_t meshopt_encodeVertexBufferBound(size_t vertex_count, si
  *
  * level should be in the range [0, 3] with 0 being the fastest and 3 being the slowest and producing the best compression ratio.
  */
-MESHOPTIMIZER_API size_t meshopt_encodeVertexBufferLevel(unsigned char* buffer, size_t buffer_size, const void* vertices, size_t vertex_count, size_t vertex_size, int level);
+MESHOPTIMIZER_EXPERIMENTAL size_t meshopt_encodeVertexBufferLevel(unsigned char* buffer, size_t buffer_size, const void* vertices, size_t vertex_count, size_t vertex_size, int level);
 
 /**
  * Set vertex encoder format version

--- a/src/meshoptimizer.h
+++ b/src/meshoptimizer.h
@@ -358,7 +358,7 @@ enum meshopt_EncodeExpMode
 	meshopt_EncodeExpSharedVector,
 	/* When encoding exponents, use shared value for each component of all vectors (best compression) */
 	meshopt_EncodeExpSharedComponent,
-	/* Experimental: When encoding exponents, use separate values for each component, but clamp to 0 (good quality if very small values are not important) */
+	/* When encoding exponents, use separate values for each component, but clamp to 0 (good quality if very small values are not important) */
 	meshopt_EncodeExpClamped,
 };
 


### PR DESCRIPTION
The following APIs are marked as stable:

- `meshopt_EncodeExpClamped` enum for `meshopt_encodeFilterExp`
- `meshopt_simplifyWithAttributes`
- `meshopt_simplifyPoints`
- `meshopt_optimizeMeshlet`

Stability (as opposed to "experimental" status) means that the interface of these functions will not change, and existing behavior will not see major changes: this does not mean these functions may not see further improvements (e.g. simplifier and meshlet optimizer may see further work that improves the output quality or locality), but this means that for example the attribute/color weights should not have to be retuned after future version upgrades.

Accordingly, `MeshoptSimplifier` no longer has `useExperimentalFeatures` attribute. "Prune" flag for simplification remains experimental but it does not seem to justify a whole extra enablement mechanism.

Additionally this change fixes function attributes on recently added `meshopt_encodeVertexBufferLevel` and `meshopt_buildMeshletsFlex`, that were meant to be experimental but didn't have the correct function macro specified.

*This contribution is sponsored by Valve.*