### PR TITLE
clusterizer: Implement global meshlet flow

### DIFF
--- a/demo/main.cpp
+++ b/demo/main.cpp
@@ -1484,6 +1484,7 @@ void processDev(const char* path)
 
 	bool dump = getenv("DUMP") && atoi(getenv("DUMP"));
 
+	meshlets(mesh, /* scan= */ false, /* uniform= */ false, /* flex= */ false);
 	meshlets(mesh, /* scan= */ false, /* uniform= */ true, /* flex= */ false);
 	meshlets(mesh, /* scan= */ false, /* uniform= */ true, /* flex= */ true, dump);
 }

--- a/src/clusterizer.cpp
+++ b/src/clusterizer.cpp
@@ -837,8 +837,8 @@ size_t meshopt_buildMeshletsFlex(meshopt_Meshlet* meshlets, unsigned int* meshle
 		if (split || (meshlet.vertex_count + best_extra > max_vertices || meshlet.triangle_count >= max_triangles))
 		{
 			seed_count = pruneSeedTriangles(seeds, seed_count, emitted_flags);
-			if (seed_count + kMeshletAddSeeds <= kMeshletMaxSeeds)
-				seed_count += appendSeedTriangles(seeds + seed_count, meshlet, meshlet_vertices, indices, adjacency, triangles, live_triangles, cornerx, cornery, cornerz);
+			seed_count = (seed_count + kMeshletAddSeeds <= kMeshletMaxSeeds) ? seed_count : kMeshletMaxSeeds - kMeshletAddSeeds;
+			seed_count += appendSeedTriangles(seeds + seed_count, meshlet, meshlet_vertices, indices, adjacency, triangles, live_triangles, cornerx, cornery, cornerz);
 
 			unsigned int best_seed = selectSeedTriangle(seeds, seed_count, indices, triangles, live_triangles, cornerx, cornery, cornerz);
 

--- a/src/clusterizer.cpp
+++ b/src/clusterizer.cpp
@@ -658,6 +658,18 @@ size_t meshopt_buildMeshletsFlex(meshopt_Meshlet* meshlets, unsigned int* meshle
 	KDNode* nodes = allocator.allocate<KDNode>(face_count * 2);
 	kdtreeBuild(0, nodes, face_count * 2, &triangles[0].px, sizeof(Cone) / sizeof(float), kdindices, face_count, /* leaf_size= */ 8);
 
+	// find a specific corner of the mesh to use as a starting point for meshlet flow
+	float cornerx = FLT_MAX, cornery = FLT_MAX, cornerz = FLT_MAX;
+
+	for (size_t i = 0; i < face_count; ++i)
+	{
+		const Cone& tri = triangles[i];
+
+		cornerx = cornerx > tri.px ? tri.px : cornerx;
+		cornery = cornery > tri.py ? tri.py : cornery;
+		cornerz = cornerz > tri.pz ? tri.pz : cornerz;
+	}
+
 	// index of the vertex in the meshlet, 0xff if the vertex isn't used
 	unsigned char* used = allocator.allocate<unsigned char>(vertex_count);
 	memset(used, -1, vertex_count);

--- a/src/clusterizer.cpp
+++ b/src/clusterizer.cpp
@@ -485,7 +485,8 @@ static unsigned int appendSeedTriangles(unsigned int* seeds, const meshopt_Meshl
 
 		for (size_t j = 0; j < kMeshletAddSeeds; ++j)
 		{
-			if (best_neighbor_live < best_live[j] || (best_neighbor_live == best_live[j] && best_neighbor_score < best_score[j]))
+			// non-strict comparison reduces the number of duplicate seeds (triangles adjacent to multiple vertices)
+			if (best_neighbor_live < best_live[j] || (best_neighbor_live == best_live[j] && best_neighbor_score <= best_score[j]))
 			{
 				best_seeds[j] = best_neighbor;
 				best_live[j] = best_neighbor_live;


### PR DESCRIPTION
Up until now, the clusterizer made all decisions about how to continue and restart the meshlets based on local information - either current meshlet (for continuation) or previous meshlet (for restart). On large meshes, this
often resulted in a meandering traversal that left gaps in the mesh. These gaps would need to be filled later;
because the gaps had uneven sizes, this could result in disconnected clusters.

This change introduces global flow: the starting triangle for meshlets is now selected to prioritize a particular global traversal of the mesh. This is based on sorting by distance to a specific anchor point (arbitrarily chosen to be the negative corner of the bounding box), as well as by the sum of live counts which was the restart metric before this change. Both are important: distance sorting results in forcing meshlets to cover gaps in the mesh earlier which reduces the chance of disconnects, while live sorting results in a much cleaner meshlet fill locally.

Because of the live sorting, we can't easily use the KD tree (also, since we don't remove nodes from a KD tree, quering the same point will become progressively slower as more and more triangles would need to be skipped). This technically turns the sort above in a O(N) operation; if done before every meshlet, the entire process becomes O(N^2) and unusably slow for large meshes.

Instead, we maintain a set of triangle seeds of a limited size, and add a few seeds after finishing every meshlet, minimizing the metric above. Some corners are cut for performance, such as just selecting a single neighbor triangle per vertex and using a simpler replacement logic. The set is re-scored when starting every meshlet; this needs to be done for live triangles as we don't maintain that metric per triangle in an incremental fashion; however, since the set is of a limited size, the entire process stays linear and the performance degradation for meshlet generation is minimal (<1%).

This results in a significant improvement in cluster disconnections in various meshlet configurations (note, while 1.0 is the theoretical optimum, on a few of these meshes the mesh has many small disjoint features which makes 1.0 impossible to ever reach):

![image](https://github.com/user-attachments/assets/2f509352-10e8-4af2-8daf-b690eba92070)

Reducing cluster splits also results in a small reduction in boundary size (which slightly improves vertex sharing and reduces locked edges in clustered simplification) and occasionally a small reduction in overall meshlet count. Testing the rasterization performance on geometry dense scenes with various cluster culling optimizations yields a small runtime speedup (3-5% depending on the mesh and GPU, AMD/NV were tested). Raytracing performance seems to be affected to a smaller degree, because the test harness uses more aggressive "flex" setup than the chart above, but the overall number of meshlets is also slightly reduced because fewer of them need to be split.

*This contribution is sponsored by Valve.*