### PR TITLE
clusterizer: Expose sphere bounds computation

### DIFF
--- a/demo/tests.cpp
+++ b/demo/tests.cpp
@@ -1059,6 +1059,36 @@ static void clusterBoundsDegenerate()
 	assert(bounds2.center[2] - bounds2.radius <= 0 && bounds2.center[2] + bounds2.radius >= 1);
 }
 
+static void sphereBounds()
+{
+	const float vbr[] = {
+	    0, 0, 0, 0,
+	    0, 1, 0, 1,
+	    0, 0, 1, 2,
+	    1, 0, 1, 3, // clang-format
+	};
+
+	// without the radius, the center is somewhere inside the tetrahedron
+	// note that we currently compute a somewhat suboptimal sphere here due to the tetrahedron being perfecly axis aligned
+	meshopt_Bounds bounds = meshopt_computeSphereBounds(vbr, 4, sizeof(float) * 4, NULL, 0);
+	assert(bounds.radius < 0.97f);
+
+	// forcing a better initial guess for the center by using different radii produces a close to optimal sphere
+	float eps[4] = {1e-3f, 2e-3f, 3e-3f, 4e-3f};
+	meshopt_Bounds boundse = meshopt_computeSphereBounds(vbr, 4, sizeof(float) * 4, eps, sizeof(float));
+	assert(fabsf(boundse.center[0] - 0.5f) < 1e-2f);
+	assert(fabsf(boundse.center[1] - 0.5f) < 1e-2f);
+	assert(fabsf(boundse.center[2] - 0.5f) < 1e-2f);
+	assert(boundse.radius < 0.87f);
+
+	// when using the radius, the last sphere envelops the entire set
+	meshopt_Bounds boundsr = meshopt_computeSphereBounds(vbr, 4, sizeof(float) * 4, vbr + 3, sizeof(float) * 4);
+	assert(fabsf(boundsr.center[0] - 1.f) < 1e-2f);
+	assert(fabsf(boundsr.center[1] - 0.f) < 1e-2f);
+	assert(fabsf(boundsr.center[2] - 1.f) < 1e-2f);
+	assert(fabsf(boundsr.radius - 3.f) < 1e-2f);
+}
+
 static void meshletsEmpty()
 {
 	const float vbd[4 * 3] = {};
@@ -2256,6 +2286,7 @@ void runTests()
 	encodeFilterExpClamp();
 
 	clusterBoundsDegenerate();
+	sphereBounds();
 
 	meshletsEmpty();
 	meshletsDense();

--- a/src/clusterizer.cpp
+++ b/src/clusterizer.cpp
@@ -1009,23 +1009,10 @@ meshopt_Bounds meshopt_computeSphereBounds(const float* positions, size_t count,
 	float psphere[4] = {};
 	computeBoundingSphere(psphere, positions, count, positions_stride, radii ? radii : &rzero, radii ? radii_stride : 0);
 
-	float pradius = 0;
-
-	for (size_t i = 0; i < count; ++i)
-	{
-		const float* position = positions + i * (positions_stride / sizeof(float));
-		float radius = radii ? radii[i * (radii_stride / sizeof(float))] : 0;
-
-		float dx = position[0] - psphere[0], dy = position[1] - psphere[1], dz = position[2] - psphere[2];
-		float distance = sqrtf(dx * dx + dy * dy + dz * dz) + radius;
-
-		pradius = pradius < distance ? distance : pradius;
-	}
-
 	bounds.center[0] = psphere[0];
 	bounds.center[1] = psphere[1];
 	bounds.center[2] = psphere[2];
-	bounds.radius = pradius;
+	bounds.radius = psphere[3];
 
 	return bounds;
 }

--- a/src/meshoptimizer.h
+++ b/src/meshoptimizer.h
@@ -619,6 +619,8 @@ struct meshopt_Bounds
 MESHOPTIMIZER_API struct meshopt_Bounds meshopt_computeClusterBounds(const unsigned int* indices, size_t index_count, const float* vertex_positions, size_t vertex_count, size_t vertex_positions_stride);
 MESHOPTIMIZER_API struct meshopt_Bounds meshopt_computeMeshletBounds(const unsigned int* meshlet_vertices, const unsigned char* meshlet_triangles, size_t triangle_count, const float* vertex_positions, size_t vertex_count, size_t vertex_positions_stride);
 
+MESHOPTIMIZER_EXPERIMENTAL struct meshopt_Bounds meshopt_computeSphereBounds(const float* positions, size_t count, size_t positions_stride, const float* radii, size_t radii_stride);
+
 /**
  * Experimental: Cluster partitioner
  * Partitions clusters into groups of similar size, prioritizing grouping clusters that share vertices.

--- a/src/meshoptimizer.h
+++ b/src/meshoptimizer.h
@@ -434,7 +434,7 @@ MESHOPTIMIZER_EXPERIMENTAL size_t meshopt_simplifySloppy(unsigned int* destinati
  *
  * destination must contain enough space for the target index buffer (target_vertex_count elements)
  * vertex_positions should have float3 position in the first 12 bytes of each vertex
- * vertex_colors should can be NULL; when it's not NULL, it should have float3 color in the first 12 bytes of each vertex
+ * vertex_colors can be NULL; when it's not NULL, it should have float3 color in the first 12 bytes of each vertex
  * color_weight determines relative priority of color wrt position; 1.0 is a safe default
  */
 MESHOPTIMIZER_API size_t meshopt_simplifyPoints(unsigned int* destination, const float* vertex_positions, size_t vertex_count, size_t vertex_positions_stride, const float* vertex_colors, size_t vertex_colors_stride, float color_weight, size_t target_vertex_count);
@@ -619,6 +619,13 @@ struct meshopt_Bounds
 MESHOPTIMIZER_API struct meshopt_Bounds meshopt_computeClusterBounds(const unsigned int* indices, size_t index_count, const float* vertex_positions, size_t vertex_count, size_t vertex_positions_stride);
 MESHOPTIMIZER_API struct meshopt_Bounds meshopt_computeMeshletBounds(const unsigned int* meshlet_vertices, const unsigned char* meshlet_triangles, size_t triangle_count, const float* vertex_positions, size_t vertex_count, size_t vertex_positions_stride);
 
+/**
+ * Experimental: Sphere bounds generator
+ * Creates bounding sphere around a set of points or a set of spheres; returns the center and radius of the sphere, with other fields of the result set to 0.
+ *
+ * positions should have float3 position in the first 12 bytes of each element
+ * radii can be NULL; when it's not NULL, it should have a non-negative float radius in the first 4 bytes of each element
+ */
 MESHOPTIMIZER_EXPERIMENTAL struct meshopt_Bounds meshopt_computeSphereBounds(const float* positions, size_t count, size_t positions_stride, const float* radii, size_t radii_stride);
 
 /**


### PR DESCRIPTION
The existing functions for computing cluster bounds,
`meshopt_computeMeshletBounds` and `meshopt_computeClusterBounds`, rely on
an internal algorithm to compute bounding spheres. This algorithm can be
useful in a few other cases:

- The cluster functions limit the input size to avoid allocations, as
  they need to reshape the inputs into a form that can be consumed by
  the internal function; sometimes it's convenient to compute a bounding
  sphere of what is essentially an unbounded point cloud
- For hierarchical simplification, it's useful to be able to compute a
  bounding sphere for an input set of spheres instead of just points.

This change exposes a basic implementation of both of the above with one
(experimental) function that takes a set of points and, optionally, a per-point radius:

```c++
meshopt_Bounds meshopt_computeSphereBounds(
  const float* positions, size_t count, size_t positions_stride,
  const float* radii, size_t radii_stride);
```

The implementation follows the existing code (which uses Jack Ritter's approximate
algorithm), adjusted to account for per-point radius when computing extremum
points and expanding the sphere (thanks to `nv_cluster_lod_builder` for the idea).
See 201fc5696676d7e01d691d10c0f590452c5fa70a for derivation of the math adjustments.

This PR also updates the hierarchical simplification demo to use this function, which
results in tighter spheres compared to the basic sphere merge algorithm that was
hand-coded there before.

*This contribution is sponsored by Valve.*