### PR TITLE
clusterizer: Implement experimental BVH clusterizer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -228,6 +228,9 @@ codectest: tools/codectest.cpp $(LIBRARY)
 codecfuzz: tools/codecfuzz.cpp src/vertexcodec.cpp src/indexcodec.cpp
 	$(CXX) $^ -fsanitize=fuzzer,address,undefined -O1 -g -o $@
 
+clusterfuzz: tools/clusterfuzz.cpp src/clusterizer.cpp
+	$(CXX) $^ -fsanitize=fuzzer,address,undefined -O1 -g -o $@
+
 simplifyfuzz: tools/simplifyfuzz.cpp src/simplifier.cpp
 	$(CXX) $^ -fsanitize=fuzzer,address,undefined -O1 -g -o $@
 

--- a/demo/main.cpp
+++ b/demo/main.cpp
@@ -996,7 +996,7 @@ void meshlets(const Mesh& mesh, bool scan = false, bool uniform = false, bool fl
 	// alternatively we also test uniform configuration with 64/64 which is better for AMD
 	const size_t max_vertices = 64;
 	const size_t max_triangles = uniform ? 64 : 124;
-	const size_t min_triangles = uniform && !split ? 24 : 32; // only used in flex/split modes
+	const size_t min_triangles = split ? 16 : (uniform ? 24 : 32); // only used in flex/split modes
 
 	// note: should be set to 0 unless cone culling is used at runtime!
 	const float cone_weight = flex ? -1.0f : 0.25f;
@@ -1078,7 +1078,7 @@ void meshlets(const Mesh& mesh, bool scan = false, bool uniform = false, bool fl
 				avg_boundary += 1;
 
 		// union-find vertices to check if the meshlet is connected
-		int parents[max_vertices];
+		int parents[256];
 		for (unsigned int j = 0; j < m.vertex_count; ++j)
 			parents[j] = int(j);
 

--- a/demo/main.cpp
+++ b/demo/main.cpp
@@ -990,13 +990,13 @@ static int follow(int* parents, int index)
 	return index;
 }
 
-void meshlets(const Mesh& mesh, bool scan = false, bool uniform = false, bool flex = false, bool dump = false)
+void meshlets(const Mesh& mesh, bool scan = false, bool uniform = false, bool flex = false, bool split = false, bool dump = false)
 {
 	// NVidia-recommends 64/126; we round 126 down to a multiple of 4
 	// alternatively we also test uniform configuration with 64/64 which is better for AMD
 	const size_t max_vertices = 64;
 	const size_t max_triangles = uniform ? 64 : 124;
-	const size_t min_triangles = uniform ? 24 : 32; // only used in flex mode
+	const size_t min_triangles = uniform && !split ? 24 : 32; // only used in flex/split modes
 
 	// note: should be set to 0 unless cone culling is used at runtime!
 	const float cone_weight = flex ? -1.0f : 0.25f;
@@ -1013,6 +1013,8 @@ void meshlets(const Mesh& mesh, bool scan = false, bool uniform = false, bool fl
 		meshlets.resize(meshopt_buildMeshletsScan(&meshlets[0], &meshlet_vertices[0], &meshlet_triangles[0], &mesh.indices[0], mesh.indices.size(), mesh.vertices.size(), max_vertices, max_triangles));
 	else if (flex)
 		meshlets.resize(meshopt_buildMeshletsFlex(&meshlets[0], &meshlet_vertices[0], &meshlet_triangles[0], &mesh.indices[0], mesh.indices.size(), &mesh.vertices[0].px, mesh.vertices.size(), sizeof(Vertex), max_vertices, min_triangles, max_triangles, cone_weight, split_factor));
+	else if (split)
+		meshlets.resize(meshopt_buildMeshletsSplit(&meshlets[0], &meshlet_vertices[0], &meshlet_triangles[0], &mesh.indices[0], mesh.indices.size(), &mesh.vertices[0].px, mesh.vertices.size(), sizeof(Vertex), max_vertices, min_triangles, max_triangles));
 	else // note: equivalent to the call of buildMeshletsFlex() with non-negative cone_weight and split_factor = 0
 		meshlets.resize(meshopt_buildMeshlets(&meshlets[0], &meshlet_vertices[0], &meshlet_triangles[0], &mesh.indices[0], mesh.indices.size(), &mesh.vertices[0].px, mesh.vertices.size(), sizeof(Vertex), max_vertices, max_triangles, cone_weight));
 
@@ -1105,7 +1107,7 @@ void meshlets(const Mesh& mesh, bool scan = false, bool uniform = false, bool fl
 	avg_connected /= double(meshlets.size());
 
 	printf("Meshlets%c: %d meshlets (avg vertices %.1f, avg triangles %.1f, avg boundary %.1f, avg connected %.2f, not full %d) in %.2f msec\n",
-	    scan ? 'S' : (flex ? 'F' : (uniform ? 'U' : ' ')),
+	    scan ? 'S' : (flex ? 'F' : (split ? 'X' : (uniform ? 'U' : ' '))),
 	    int(meshlets.size()), avg_vertices, avg_triangles, avg_boundary, avg_connected, int(not_full), (end - start) * 1000);
 
 	float camera[3] = {100, 100, 100};
@@ -1490,6 +1492,7 @@ void process(const char* path)
 	meshlets(copy, /* scan= */ false);
 	meshlets(copy, /* scan= */ false, /* uniform= */ true);
 	meshlets(copy, /* scan= */ false, /* uniform= */ false, /* flex= */ true);
+	meshlets(copy, /* scan= */ false, /* uniform= */ true, /* flex= */ false, /* split= */ true);
 
 	shadow(copy);
 	tessellationAdjacency(copy);
@@ -1539,7 +1542,7 @@ void processDev(const char* path)
 
 	meshlets(mesh, /* scan= */ false, /* uniform= */ false, /* flex= */ false);
 	meshlets(mesh, /* scan= */ false, /* uniform= */ true, /* flex= */ false);
-	meshlets(mesh, /* scan= */ false, /* uniform= */ true, /* flex= */ true, dump);
+	meshlets(mesh, /* scan= */ false, /* uniform= */ true, /* flex= */ false, /* split= */ true, dump);
 }
 
 void processNanite(const char* path)

--- a/demo/nanite.cpp
+++ b/demo/nanite.cpp
@@ -919,6 +919,7 @@ void clrt(const std::vector<Vertex>& vertices, const std::vector<unsigned int>& 
 
 	double middle = timestamp();
 
+	const bool use_splitalgo = true;
 	const size_t max_vertices = 64;
 	const size_t min_triangles = 16;
 	const size_t max_triangles = 64;
@@ -931,7 +932,10 @@ void clrt(const std::vector<Vertex>& vertices, const std::vector<unsigned int>& 
 	std::vector<unsigned int> meshlet_vertices(max_meshlets * max_vertices);
 	std::vector<unsigned char> meshlet_triangles(max_meshlets * max_triangles * 3);
 
-	meshlets.resize(meshopt_buildMeshletsFlex(&meshlets[0], &meshlet_vertices[0], &meshlet_triangles[0], &indices[0], indices.size(), &vertices[0].px, vertices.size(), sizeof(Vertex), max_vertices, min_triangles, max_triangles, cone_weight, split_factor));
+	if (use_splitalgo)
+		meshlets.resize(meshopt_buildMeshletsSplit(&meshlets[0], &meshlet_vertices[0], &meshlet_triangles[0], &indices[0], indices.size(), &vertices[0].px, vertices.size(), sizeof(Vertex), max_vertices, min_triangles, max_triangles));
+	else
+		meshlets.resize(meshopt_buildMeshletsFlex(&meshlets[0], &meshlet_vertices[0], &meshlet_triangles[0], &indices[0], indices.size(), &vertices[0].px, vertices.size(), sizeof(Vertex), max_vertices, min_triangles, max_triangles, cone_weight, split_factor));
 
 	double end = timestamp();
 
@@ -985,14 +989,7 @@ void clrt(const std::vector<Vertex>& vertices, const std::vector<unsigned int>& 
 		sahc += sahCost(&cluster_tris[0], meshlet.triangle_count);
 		sahc -= surface(meshlet_boxes[i]); // box will be accounted for in tlas
 
-		bool used[256] = {};
-		for (size_t j = 0; j < meshlet.triangle_count * 3; ++j)
-		{
-			unsigned char v = meshlet_triangles[meshlet.triangle_offset + j];
-
-			xformed += !used[v];
-			used[v] = true;
-		}
+		xformed += meshlet.vertex_count;
 	}
 
 	sahc += sahCost(&meshlet_boxes[0], meshlet_boxes.size());

--- a/src/clusterizer.cpp
+++ b/src/clusterizer.cpp
@@ -707,7 +707,7 @@ struct BVHBox
 	float max[3];
 };
 
-static void mergeBox(BVHBox& box, const BVHBox& other)
+static void boxMerge(BVHBox& box, const BVHBox& other)
 {
 	for (int k = 0; k < 3; ++k)
 	{
@@ -716,7 +716,7 @@ static void mergeBox(BVHBox& box, const BVHBox& other)
 	}
 }
 
-inline float surface(const BVHBox& box)
+inline float boxSurface(const BVHBox& box)
 {
 	float sx = box.max[0] - box.min[0], sy = box.max[1] - box.min[1], sz = box.max[2] - box.min[2];
 	return sx * sy + sx * sz + sy * sz;
@@ -859,11 +859,11 @@ static void bvhSplit(const BVHBox* boxes, unsigned int* orderx, unsigned int* or
 
 		for (size_t i = 0; i < count; ++i)
 		{
-			mergeBox(accuml, boxes[axis[i]]);
-			mergeBox(accumr, boxes[axis[count - 1 - i]]);
+			boxMerge(accuml, boxes[axis[i]]);
+			boxMerge(accumr, boxes[axis[count - 1 - i]]);
 
-			costs[i + (2 * k + 0) * count] = surface(accuml);
-			costs[i + (2 * k + 1) * count] = surface(accumr);
+			costs[i + (2 * k + 0) * count] = boxSurface(accuml);
+			costs[i + (2 * k + 1) * count] = boxSurface(accumr);
 		}
 	}
 

--- a/src/clusterizer.cpp
+++ b/src/clusterizer.cpp
@@ -813,12 +813,15 @@ static size_t bvhSplit(const BVHBox* boxes, unsigned int* orderx, unsigned int* 
 		}
 	}
 
+	// if we could not pack the meshlet, we must be vertex bound
+	size_t step = count <= max_triangles && max_vertices / 3 < min_triangles ? max_vertices / 3 : min_triangles;
+
 	// find best split that minimizes SAH
 	int bestk = -1;
 	size_t bestsplit = 0;
 	float bestcost = FLT_MAX;
 
-	for (size_t i = 0; i < count - 1; ++i)
+	for (size_t i = step - 1; i < count - 1; i += step)
 		for (int k = 0; k < 3; ++k)
 		{
 			// costs[x] = inclusive cost of boxes[0..x]

--- a/src/meshoptimizer.h
+++ b/src/meshoptimizer.h
@@ -595,6 +595,18 @@ MESHOPTIMIZER_API size_t meshopt_buildMeshletsBound(size_t index_count, size_t m
 MESHOPTIMIZER_EXPERIMENTAL size_t meshopt_buildMeshletsFlex(struct meshopt_Meshlet* meshlets, unsigned int* meshlet_vertices, unsigned char* meshlet_triangles, const unsigned int* indices, size_t index_count, const float* vertex_positions, size_t vertex_count, size_t vertex_positions_stride, size_t max_vertices, size_t min_triangles, size_t max_triangles, float cone_weight, float split_factor);
 
 /**
+ * Experimental: Meshlet builder that produces clusters optimized for raytracing
+ * Splits the mesh into a set of meshlets, similarly to meshopt_buildMeshlets, but optimizes cluster subdivision for raytracing and allows to specify minimum and maximum number of triangles per meshlet.
+ *
+ * meshlets must contain enough space for all meshlets, worst case size can be computed with meshopt_buildMeshletsBound using min_triangles (not max!)
+ * meshlet_vertices must contain enough space for all meshlets, worst case size is equal to max_meshlets * max_vertices
+ * meshlet_triangles must contain enough space for all meshlets, worst case size is equal to max_meshlets * max_triangles * 3
+ * vertex_positions should have float3 position in the first 12 bytes of each vertex
+ * max_vertices, min_triangles and max_triangles must not exceed implementation limits (max_vertices <= 256, max_triangles <= 512; min_triangles <= max_triangles; both min_triangles and max_triangles must be divisible by 4)
+ */
+MESHOPTIMIZER_EXPERIMENTAL size_t meshopt_buildMeshletsSplit(struct meshopt_Meshlet* meshlets, unsigned int* meshlet_vertices, unsigned char* meshlet_triangles, const unsigned int* indices, size_t index_count, const float* vertex_positions, size_t vertex_count, size_t vertex_positions_stride, size_t max_vertices, size_t min_triangles, size_t max_triangles);
+
+/**
  * Meshlet optimizer
  * Reorders meshlet vertices and triangles to maximize locality to improve rasterizer throughput
  *

--- a/src/meshoptimizer.h
+++ b/src/meshoptimizer.h
@@ -822,6 +822,8 @@ inline size_t meshopt_buildMeshletsScan(meshopt_Meshlet* meshlets, unsigned int*
 template <typename T>
 inline size_t meshopt_buildMeshletsFlex(meshopt_Meshlet* meshlets, unsigned int* meshlet_vertices, unsigned char* meshlet_triangles, const T* indices, size_t index_count, const float* vertex_positions, size_t vertex_count, size_t vertex_positions_stride, size_t max_vertices, size_t min_triangles, size_t max_triangles, float cone_weight, float split_factor);
 template <typename T>
+inline size_t meshopt_buildMeshletsSplit(meshopt_Meshlet* meshlets, unsigned int* meshlet_vertices, unsigned char* meshlet_triangles, const T* indices, size_t index_count, const float* vertex_positions, size_t vertex_count, size_t vertex_positions_stride, size_t max_vertices, size_t min_triangles, size_t max_triangles);
+template <typename T>
 inline meshopt_Bounds meshopt_computeClusterBounds(const T* indices, size_t index_count, const float* vertex_positions, size_t vertex_count, size_t vertex_positions_stride);
 template <typename T>
 inline size_t meshopt_partitionClusters(unsigned int* destination, const T* cluster_indices, size_t total_index_count, const unsigned int* cluster_index_counts, size_t cluster_count, size_t vertex_count, size_t target_partition_size);
@@ -1242,6 +1244,14 @@ inline size_t meshopt_buildMeshletsFlex(meshopt_Meshlet* meshlets, unsigned int*
 	meshopt_IndexAdapter<T> in(NULL, indices, index_count);
 
 	return meshopt_buildMeshletsFlex(meshlets, meshlet_vertices, meshlet_triangles, in.data, index_count, vertex_positions, vertex_count, vertex_positions_stride, max_vertices, min_triangles, max_triangles, cone_weight, split_factor);
+}
+
+template <typename T>
+inline size_t meshopt_buildMeshletsSplit(meshopt_Meshlet* meshlets, unsigned int* meshlet_vertices, unsigned char* meshlet_triangles, const T* indices, size_t index_count, const float* vertex_positions, size_t vertex_count, size_t vertex_positions_stride, size_t max_vertices, size_t min_triangles, size_t max_triangles)
+{
+	meshopt_IndexAdapter<T> in(NULL, indices, index_count);
+
+	return meshopt_buildMeshletsSplit(meshlets, meshlet_vertices, meshlet_triangles, in.data, index_count, vertex_positions, vertex_count, vertex_positions_stride, max_vertices, min_triangles, max_triangles);
 }
 
 template <typename T>

--- a/tools/clusterfuzz.cpp
+++ b/tools/clusterfuzz.cpp
@@ -1,0 +1,52 @@
+#include "../src/meshoptimizer.h"
+
+#include <float.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* buffer, size_t size)
+{
+	if (size == 0)
+		return 0;
+
+	srand(buffer[0]);
+
+	float vb[100][4];
+
+	for (int i = 0; i < 100; ++i)
+	{
+		vb[i][0] = rand() % 10;
+		vb[i][1] = rand() % 10;
+		vb[i][2] = rand() % 10;
+		vb[i][3] = rand() % 10;
+	}
+
+	unsigned int ib[999];
+	int indices = (size - 1) < 999 ? (size - 1) / 3 * 3 : 999;
+
+	for (int i = 0; i < indices; ++i)
+		ib[i] = buffer[1 + i] % 100;
+
+	meshopt_Meshlet ml[333];
+	unsigned int mv[333 * 3];
+	unsigned char mt[333 * 4];
+
+	meshopt_buildMeshlets(ml, mv, mt, ib, indices, vb[0], 100, sizeof(float) * 4, /* max_vertices= */ 4, /* max_triangles= */ 4, 0.f);
+
+	meshopt_buildMeshletsScan(ml, mv, mt, ib, indices, 100, /* max_vertices= */ 4, /* max_triangles= */ 4);
+	meshopt_buildMeshletsScan(ml, mv, mt, ib, indices, 100, /* max_vertices= */ 4, /* max_triangles= */ 8);
+
+	meshopt_buildMeshletsFlex(ml, mv, mt, ib, indices, vb[0], 100, sizeof(float) * 4, /* max_vertices= */ 4, /* min_triangles= */ 4, /* max_triangles= */ 8, 0.f, 2.f);
+	meshopt_buildMeshletsFlex(ml, mv, mt, ib, indices, vb[0], 100, sizeof(float) * 4, /* max_vertices= */ 8, /* min_triangles= */ 8, /* max_triangles= */ 16, 0.f, 2.f);
+	meshopt_buildMeshletsFlex(ml, mv, mt, ib, indices, vb[0], 100, sizeof(float) * 4, /* max_vertices= */ 16, /* min_triangles= */ 8, /* max_triangles= */ 32, 0.f, 2.f);
+	meshopt_buildMeshletsFlex(ml, mv, mt, ib, indices, vb[0], 100, sizeof(float) * 4, /* max_vertices= */ 16, /* min_triangles= */ 16, /* max_triangles= */ 32, 0.f, 2.f);
+
+	meshopt_buildMeshletsSplit(ml, mv, mt, ib, indices, vb[0], 100, sizeof(float) * 4, /* max_vertices= */ 4, /* min_triangles= */ 4, /* max_triangles= */ 8);
+	meshopt_buildMeshletsSplit(ml, mv, mt, ib, indices, vb[0], 100, sizeof(float) * 4, /* max_vertices= */ 8, /* min_triangles= */ 4, /* max_triangles= */ 32);
+	meshopt_buildMeshletsSplit(ml, mv, mt, ib, indices, vb[0], 100, sizeof(float) * 4, /* max_vertices= */ 8, /* min_triangles= */ 8, /* max_triangles= */ 32);
+	meshopt_buildMeshletsSplit(ml, mv, mt, ib, indices, vb[0], 100, sizeof(float) * 4, /* max_vertices= */ 8, /* min_triangles= */ 12, /* max_triangles= */ 32);
+	meshopt_buildMeshletsSplit(ml, mv, mt, ib, indices, vb[0], 100, sizeof(float) * 4, /* max_vertices= */ 16, /* min_triangles= */ 16, /* max_triangles= */ 32);
+	meshopt_buildMeshletsSplit(ml, mv, mt, ib, indices, vb[0], 100, sizeof(float) * 4, /* max_vertices= */ 16, /* min_triangles= */ 32, /* max_triangles= */ 32);
+
+	return 0;
+}


### PR DESCRIPTION
In order to improve performance of clusters used for raytracing, we need
to generate clusters in a SAH optimal manner; the best approach seems to
be to build a BVH and extract subtrees into clusters.

This change implements the initial version of this algorithm; for now, the
control over the cluster sizes is a little too strict (clusters will be
generated in multiples of `min_triangles` triangles which is not strictly
required; that results in reduction of SAH quality).

No attempt to control for cluster overlap or underfill is made atm; this will
be improved in subsequent PRs and may require additional parameters to the
function.

The name is also potentially temporary; I'm not sure that `buildMeshletsSplit`
will be the final name. All of these details will stabilize before any versioned
release of course.

During implementation, an alternative approach with agglomerative clustering
(similar to PLOC et al) was explored, but it provides significantly worse SAH
metrics for a number of dense meshes, so it was rejected in favor of this approach.

*This contribution is sponsored by Valve.*