### PR TITLE
clusterizer: Improve cluster sizing criteria for min<max

### DIFF
--- a/src/clusterizer.cpp
+++ b/src/clusterizer.cpp
@@ -891,16 +891,18 @@ static size_t bvhPivot(const BVHBox* boxes, const unsigned int* order, size_t co
 
 	for (size_t i = step - 1; i < count - 1; i += step)
 	{
-		if (!bvhDivisible(i + 1, min, max))
+		size_t lsplit = i + 1, rsplit = count - (i + 1);
+
+		if (!bvhDivisible(lsplit, min, max))
 			continue;
-		if (aligned && !bvhDivisible(count - (i + 1), min, max))
+		if (aligned && !bvhDivisible(rsplit, min, max))
 			continue;
 
-		// costs[x] = inclusive cost of boxes[0..x]
-		float costl = costs[i] * (i + 1);
-		// costs[count-1-x] = inclusive cost of boxes[x..count-1]
-		float costr = costs[(count - 1 - (i + 1)) + count] * (count - (i + 1));
-		float cost = costl + costr;
+		// costs[x] = inclusive surface area of boxes[0..x]
+		// costs[count-1-x] = inclusive surface area of boxes[x..count-1]
+		float larea = costs[i], rarea = costs[(count - 1 - (i + 1)) + count];
+
+		float cost = larea * float(lsplit) + rarea * float(rsplit);
 
 		if (cost < bestcost)
 		{

--- a/src/clusterizer.cpp
+++ b/src/clusterizer.cpp
@@ -945,7 +945,9 @@ static void bvhSplit(const BVHBox* boxes, unsigned int* orderx, unsigned int* or
 		}
 	}
 
-	assert(bestk >= 0);
+	// this may happen if SAH costs along the admissible splits are NaN
+	if (bestk < 0)
+		return bvhPackTail(boundary, orderx, count, used, indices, max_vertices, max_triangles);
 
 	// mark sides of split for partitioning
 	unsigned char* sides = static_cast<unsigned char*>(scratch) + count * sizeof(unsigned int);

--- a/src/clusterizer.cpp
+++ b/src/clusterizer.cpp
@@ -884,12 +884,13 @@ static size_t bvhPivot(const BVHBox* boxes, const unsigned int* order, size_t co
 	}
 
 	bool aligned = count > max && bvhDivisible(count, min, max);
+	size_t end = aligned ? count - min : count - 1;
 
 	// find best split that minimizes SAH
 	size_t bestsplit = 0;
 	float bestcost = FLT_MAX;
 
-	for (size_t i = step - 1; i < count - 1; i += step)
+	for (size_t i = min - 1; i < end; i += step)
 	{
 		size_t lsplit = i + 1, rsplit = count - (i + 1);
 


### PR DESCRIPTION
For the new experimental clusterizer introduced in #871, when
`min_triangles < max_triangles`, we used to step in units of
`min_triangles` which resulted in much fewer valid splits being
evaluated.

While we need to restrict the splits to conform to `min..max` range, what
we actually need here is to check if the split sequence can be
representable as a sum of numbers between `min` and `max`. When the initial
sequence is divisible like that, we'd like both splits to be; otherwise
we opt for just one being representable.

This change also improves the vertex bound splits as a byproduct:
instead of forcing an even split in `count/3` chunks, our splits are more
adaptive and as such more likely to produce higher quality SAH nodes.

Additionally, this change fixes some corner cases when degenerate trees
could have led to an assertion as no split could be selected, and adds tests.

*This contribution is sponsored by Valve.*