### PR TITLE
gltfpack: Deindex meshes with abnormally large vertex accessors

### DIFF
--- a/extern/cgltf.h
+++ b/extern/cgltf.h
@@ -2352,11 +2352,46 @@ const cgltf_accessor* cgltf_find_accessor(const cgltf_primitive* prim, cgltf_att
 	return NULL;
 }
 
+static const uint8_t* cgltf_find_sparse_index(const cgltf_accessor* accessor, cgltf_size needle)
+{
+	const cgltf_accessor_sparse* sparse = &accessor->sparse;
+	const uint8_t* index_data = cgltf_buffer_view_data(sparse->indices_buffer_view);
+	const uint8_t* value_data = cgltf_buffer_view_data(sparse->values_buffer_view);
+
+	if (index_data == NULL || value_data == NULL)
+		return NULL;
+
+	index_data += sparse->indices_byte_offset;
+	value_data += sparse->values_byte_offset;
+
+	cgltf_size index_stride = cgltf_component_size(sparse->indices_component_type);
+
+	cgltf_size offset = 0;
+	cgltf_size length = sparse->count;
+
+	while (length)
+	{
+		cgltf_size rem = length % 2;
+		length /= 2;
+
+		cgltf_size index = cgltf_component_read_index(index_data + (offset + length) * index_stride, sparse->indices_component_type);
+		offset += index < needle ? length + rem : 0;
+	}
+
+	if (offset == sparse->count)
+		return NULL;
+
+	cgltf_size index = offset < sparse->count ? cgltf_component_read_index(index_data + offset * index_stride, sparse->indices_component_type) : (cgltf_size)-1;
+	return index == needle ? value_data + offset * accessor->stride : NULL;
+}
+
 cgltf_bool cgltf_accessor_read_float(const cgltf_accessor* accessor, cgltf_size index, cgltf_float* out, cgltf_size element_size)
 {
 	if (accessor->is_sparse)
 	{
-		return 0;
+		const uint8_t* element = cgltf_find_sparse_index(accessor, index);
+		if (element)
+			return cgltf_element_read_float(element, accessor->type, accessor->component_type, accessor->normalized, out, element_size);
 	}
 	if (accessor->buffer_view == NULL)
 	{
@@ -2500,11 +2535,13 @@ cgltf_bool cgltf_accessor_read_uint(const cgltf_accessor* accessor, cgltf_size i
 {
 	if (accessor->is_sparse)
 	{
-		return 0;
+		const uint8_t* element = cgltf_find_sparse_index(accessor, index);
+		if (element)
+			return cgltf_element_read_uint(element, accessor->type, accessor->component_type, out, element_size);
 	}
 	if (accessor->buffer_view == NULL)
 	{
-		memset(out, 0, element_size * sizeof( cgltf_uint ));
+		memset(out, 0, element_size * sizeof(cgltf_uint));
 		return 1;
 	}
 	const uint8_t* element = cgltf_buffer_view_data(accessor->buffer_view);
@@ -2520,7 +2557,9 @@ cgltf_size cgltf_accessor_read_index(const cgltf_accessor* accessor, cgltf_size 
 {
 	if (accessor->is_sparse)
 	{
-		return 0; // This is an error case, but we can't communicate the error with existing interface.
+		const uint8_t* element = cgltf_find_sparse_index(accessor, index);
+		if (element)
+			return cgltf_component_read_index(element, accessor->component_type);
 	}
 	if (accessor->buffer_view == NULL)
 	{

--- a/gltf/parsegltf.cpp
+++ b/gltf/parsegltf.cpp
@@ -216,7 +216,7 @@ static void parseMeshesGltf(cgltf_data* data, std::vector<Mesh>& meshes, std::ve
 			std::vector<unsigned int> sparse;
 
 			// if the index data is very sparse, switch to deindexing on the fly to avoid the excessive cost of reading large accessors
-			if (result.indices.size() < vertex_count / 2)
+			if (!result.indices.empty() && result.indices.size() < vertex_count / 2)
 			{
 				sparse = result.indices;
 

--- a/gltf/parsegltf.cpp
+++ b/gltf/parsegltf.cpp
@@ -177,11 +177,8 @@ static void parseMeshesGltf(cgltf_data* data, std::vector<Mesh>& meshes, std::ve
 			Mesh& result = meshes.back();
 
 			result.scene = -1;
-
 			result.material = primitive.material;
-
 			result.extras = primitive.extras;
-
 			result.type = primitive.type;
 
 			result.streams.reserve(primitive.attributes_count);
@@ -312,11 +309,11 @@ static void parseMeshInstancesGltf(std::vector<Transform>& instances, cgltf_node
 	for (size_t i = 0; i < count; ++i)
 	{
 		if (translation)
-			cgltf_accessor_read_float(translation, i, instance.translation, sizeof(float));
+			cgltf_accessor_read_float(translation, i, instance.translation, 4);
 		if (rotation)
-			cgltf_accessor_read_float(rotation, i, instance.rotation, sizeof(float));
+			cgltf_accessor_read_float(rotation, i, instance.rotation, 4);
 		if (scale)
-			cgltf_accessor_read_float(scale, i, instance.scale, sizeof(float));
+			cgltf_accessor_read_float(scale, i, instance.scale, 4);
 
 		Transform xf;
 		cgltf_node_transform_world(&instance, xf.data);


### PR DESCRIPTION
If the index buffer is much smaller than vertex accessors, and vertex accessors
are shared, we end up re-unpacking the accessors repeatedly and producing huge
meshes that are inefficient for the rest of the processing pipeline.

This change detects these cases and switches to reading the individual elements
according to the index buffer, producing an unindexed mesh; the rest of the
processing will re-index it again.

For some extreme cases this may result in significant improvements in parsing and
processing time; the mesh from #884 could not be converted before this change,
and with this change it takes just 0.3s to do so.

Before settling on the approach here, I've also tried trimming the index buffers to
their min..max range and extracting an associated subrange from the accessors;
this worked but only got the problematic model down to 30s of conversion time
because many indices spanned a large range. Doing an early reindexing in this case
got this down to ~3s, but it still felt too long and too complicated, whereas this
approach generically solves this issue.

This relies on support for sparse accessors in cgltf_accessor_read functions,
which also fixes interaction between sparse accessors and parsing files with GPU
instancing extension; the patch has been submitted separately as https://github.com/jkuhlmann/cgltf/pull/273.

Fixes #884.