### PR TITLE
partition: Use cluster bounds to bias merging closer groups

### DIFF
--- a/demo/main.cpp
+++ b/demo/main.cpp
@@ -692,7 +692,7 @@ void simplifyClusters(const Mesh& mesh, float threshold = 0.2f)
 	meshopt_generateShadowIndexBuffer(&cluster_indices[0], &cluster_indices[0], cluster_indices.size(), &mesh.vertices[0].px, mesh.vertices.size(), sizeof(float) * 3, sizeof(Vertex));
 
 	std::vector<unsigned int> partition(meshlets.size());
-	size_t partition_count = meshopt_partitionClusters(&partition[0], &cluster_indices[0], cluster_indices.size(), &cluster_sizes[0], cluster_sizes.size(), mesh.vertices.size(), target_group_size);
+	size_t partition_count = meshopt_partitionClusters(&partition[0], &cluster_indices[0], cluster_indices.size(), &cluster_sizes[0], cluster_sizes.size(), NULL, mesh.vertices.size(), 0, target_group_size);
 
 	// convert partitions to linked lists to make it easier to iterate over (vectors of vectors would work too)
 	std::vector<int> partnext(meshlets.size(), -1);

--- a/demo/main.cpp
+++ b/demo/main.cpp
@@ -692,7 +692,7 @@ void simplifyClusters(const Mesh& mesh, float threshold = 0.2f)
 	meshopt_generateShadowIndexBuffer(&cluster_indices[0], &cluster_indices[0], cluster_indices.size(), &mesh.vertices[0].px, mesh.vertices.size(), sizeof(float) * 3, sizeof(Vertex));
 
 	std::vector<unsigned int> partition(meshlets.size());
-	size_t partition_count = meshopt_partitionClusters(&partition[0], &cluster_indices[0], cluster_indices.size(), &cluster_sizes[0], cluster_sizes.size(), NULL, mesh.vertices.size(), 0, target_group_size);
+	size_t partition_count = meshopt_partitionClusters(&partition[0], &cluster_indices[0], cluster_indices.size(), &cluster_sizes[0], cluster_sizes.size(), &mesh.vertices[0].px, mesh.vertices.size(), sizeof(Vertex), target_group_size);
 
 	// convert partitions to linked lists to make it easier to iterate over (vectors of vectors would work too)
 	std::vector<int> partnext(meshlets.size(), -1);
@@ -1539,15 +1539,7 @@ void processDev(const char* path)
 	if (!loadMesh(mesh, path))
 		return;
 
-#ifdef _MSC_VER
-#pragma warning(disable : 4996)
-#endif
-
-	bool dump = getenv("DUMP") && atoi(getenv("DUMP"));
-
-	meshlets(mesh, /* scan= */ false, /* uniform= */ false, /* flex= */ false);
-	meshlets(mesh, /* scan= */ false, /* uniform= */ true, /* flex= */ false);
-	meshlets(mesh, /* scan= */ false, /* uniform= */ true, /* flex= */ false, /* split= */ true, dump);
+	simplifyClusters(mesh);
 }
 
 void processNanite(const char* path)

--- a/demo/nanite.cpp
+++ b/demo/nanite.cpp
@@ -68,6 +68,7 @@ const size_t kGroupSize = 8;
 const bool kUseLocks = true;
 const bool kUseNormals = true;
 const bool kUseRetry = true;
+const bool kUseSplit = false;
 const int kMetisSlop = 2;
 const float kSimplifyThreshold = 0.85f;
 
@@ -129,6 +130,7 @@ static std::vector<Cluster> clusterize(const std::vector<Vertex>& vertices, cons
 	const size_t max_triangles = kClusterSize;
 	const size_t min_triangles = (kClusterSize / 3) & ~3;
 	const float split_factor = 2.0f;
+	const float fill_weight = 0.75f;
 
 	size_t max_meshlets = meshopt_buildMeshletsBound(indices.size(), max_vertices, min_triangles);
 
@@ -136,7 +138,10 @@ static std::vector<Cluster> clusterize(const std::vector<Vertex>& vertices, cons
 	std::vector<unsigned int> meshlet_vertices(max_meshlets * max_vertices);
 	std::vector<unsigned char> meshlet_triangles(max_meshlets * max_triangles * 3);
 
-	meshlets.resize(meshopt_buildMeshletsFlex(&meshlets[0], &meshlet_vertices[0], &meshlet_triangles[0], &indices[0], indices.size(), &vertices[0].px, vertices.size(), sizeof(Vertex), max_vertices, min_triangles, max_triangles, 0.f, split_factor));
+	if (kUseSplit)
+		meshlets.resize(meshopt_buildMeshletsSplit(&meshlets[0], &meshlet_vertices[0], &meshlet_triangles[0], &indices[0], indices.size(), &vertices[0].px, vertices.size(), sizeof(Vertex), max_vertices, min_triangles, max_triangles, fill_weight));
+	else
+		meshlets.resize(meshopt_buildMeshletsFlex(&meshlets[0], &meshlet_vertices[0], &meshlet_triangles[0], &indices[0], indices.size(), &vertices[0].px, vertices.size(), sizeof(Vertex), max_vertices, min_triangles, max_triangles, 0.f, split_factor));
 
 	std::vector<Cluster> clusters(meshlets.size());
 

--- a/demo/nanite.cpp
+++ b/demo/nanite.cpp
@@ -182,7 +182,7 @@ static std::vector<std::vector<int> > partition(const std::vector<Cluster>& clus
 	}
 
 	std::vector<unsigned int> cluster_part(pending.size());
-	size_t partition_count = meshopt_partitionClusters(&cluster_part[0], &cluster_indices[0], cluster_indices.size(), &cluster_counts[0], cluster_counts.size(), remap.size(), kGroupSize);
+	size_t partition_count = meshopt_partitionClusters(&cluster_part[0], &cluster_indices[0], cluster_indices.size(), &cluster_counts[0], cluster_counts.size(), NULL, remap.size(), 0, kGroupSize);
 
 	std::vector<std::vector<int> > partitions(partition_count);
 	for (size_t i = 0; i < partition_count; ++i)

--- a/demo/nanite.cpp
+++ b/demo/nanite.cpp
@@ -692,6 +692,7 @@ static void dumpMetrics(int level, const std::vector<Cluster>& queue, const std:
 	int components = 0;
 	int xformed = 0;
 	int boundary = 0;
+	float radius = 0;
 
 	for (size_t i = 0; i < groups.size(); ++i)
 	{
@@ -705,6 +706,7 @@ static void dumpMetrics(int level, const std::vector<Cluster>& queue, const std:
 			components += measureComponents(parents, cluster.indices, remap);
 			xformed += measureUnique(parents, cluster.indices);
 			boundary += kUseLocks ? measureUnique(parents, cluster.indices, &locks) : 0;
+			radius += cluster.self.radius;
 		}
 	}
 
@@ -722,9 +724,9 @@ static void dumpMetrics(int level, const std::vector<Cluster>& queue, const std:
 	double avg_group = double(clusters) / double(groups.size());
 	double inv_clusters = 1.0 / double(clusters);
 
-	printf("lod %d: %d clusters (%.1f%% full, %.1f tri/cl, %.1f vtx/cl, %.2f connected, %.1f boundary, %.1f partition), %d triangles",
+	printf("lod %d: %d clusters (%.1f%% full, %.1f tri/cl, %.1f vtx/cl, %.2f connected, %.1f boundary, %.1f partition, %f radius), %d triangles",
 	    level, clusters,
-	    double(full_clusters) * inv_clusters * 100, double(triangles) * inv_clusters, double(xformed) * inv_clusters, double(components) * inv_clusters, double(boundary) * inv_clusters, avg_group,
+	    double(full_clusters) * inv_clusters * 100, double(triangles) * inv_clusters, double(xformed) * inv_clusters, double(components) * inv_clusters, double(boundary) * inv_clusters, avg_group, radius * inv_clusters,
 	    int(triangles));
 	if (stuck_clusters)
 		printf("; stuck %d clusters (%d triangles)", stuck_clusters, stuck_triangles);

--- a/demo/nanite.cpp
+++ b/demo/nanite.cpp
@@ -157,7 +157,7 @@ static std::vector<Cluster> clusterize(const std::vector<Vertex>& vertices, cons
 	return clusters;
 }
 
-static std::vector<std::vector<int> > partition(const std::vector<Cluster>& clusters, const std::vector<int>& pending, const std::vector<unsigned int>& remap)
+static std::vector<std::vector<int> > partition(const std::vector<Cluster>& clusters, const std::vector<int>& pending, const std::vector<unsigned int>& remap, const std::vector<Vertex>& vertices)
 {
 	if (METIS & 1)
 		return partitionMetis(clusters, pending, remap);
@@ -182,7 +182,7 @@ static std::vector<std::vector<int> > partition(const std::vector<Cluster>& clus
 	}
 
 	std::vector<unsigned int> cluster_part(pending.size());
-	size_t partition_count = meshopt_partitionClusters(&cluster_part[0], &cluster_indices[0], cluster_indices.size(), &cluster_counts[0], cluster_counts.size(), NULL, remap.size(), 0, kGroupSize);
+	size_t partition_count = meshopt_partitionClusters(&cluster_part[0], &cluster_indices[0], cluster_indices.size(), &cluster_counts[0], cluster_counts.size(), &vertices[0].px, remap.size(), sizeof(Vertex), kGroupSize);
 
 	std::vector<std::vector<int> > partitions(partition_count);
 	for (size_t i = 0; i < partition_count; ++i)
@@ -294,7 +294,7 @@ void nanite(const std::vector<Vertex>& vertices, const std::vector<unsigned int>
 	// merge and simplify clusters until we can't merge anymore
 	while (pending.size() > 1)
 	{
-		std::vector<std::vector<int> > groups = partition(clusters, pending, remap);
+		std::vector<std::vector<int> > groups = partition(clusters, pending, remap, vertices);
 
 		if (kUseLocks)
 			lockBoundary(locks, groups, clusters, remap);

--- a/demo/tests.cpp
+++ b/demo/tests.cpp
@@ -1405,13 +1405,13 @@ static void partitionBasic()
 	const unsigned int cc[4] = {6, 6, 6, 6};
 	unsigned int part[4];
 
-	assert(meshopt_partitionClusters(part, ci, sizeof(ci) / sizeof(ci[0]), cc, 4, 13, 1) == 4);
+	assert(meshopt_partitionClusters(part, ci, sizeof(ci) / sizeof(ci[0]), cc, 4, NULL, 13, 0, 1) == 4);
 	assert(part[0] == 0 && part[1] == 1 && part[2] == 2 && part[3] == 3);
 
-	assert(meshopt_partitionClusters(part, ci, sizeof(ci) / sizeof(ci[0]), cc, 4, 13, 2) == 2);
+	assert(meshopt_partitionClusters(part, ci, sizeof(ci) / sizeof(ci[0]), cc, 4, NULL, 13, 0, 2) == 2);
 	assert(part[0] == 0 && part[1] == 0 && part[2] == 1 && part[3] == 1);
 
-	assert(meshopt_partitionClusters(part, ci, sizeof(ci) / sizeof(ci[0]), cc, 4, 13, 4) == 1);
+	assert(meshopt_partitionClusters(part, ci, sizeof(ci) / sizeof(ci[0]), cc, 4, NULL, 13, 0, 4) == 1);
 	assert(part[0] == 0 && part[1] == 0 && part[2] == 0 && part[3] == 0);
 }
 

--- a/src/meshoptimizer.h
+++ b/src/meshoptimizer.h
@@ -684,15 +684,16 @@ MESHOPTIMIZER_EXPERIMENTAL struct meshopt_Bounds meshopt_computeSphereBounds(con
 
 /**
  * Experimental: Cluster partitioner
- * Partitions clusters into groups of similar size, prioritizing grouping clusters that share vertices.
+ * Partitions clusters into groups of similar size, prioritizing grouping clusters that share vertices or are close to each other.
  *
  * destination must contain enough space for the resulting partiotion data (cluster_count elements)
  * destination[i] will contain the partition id for cluster i, with the total number of partitions returned by the function
  * cluster_indices should have the vertex indices referenced by each cluster, stored sequentially
  * cluster_index_counts should have the number of indices in each cluster; sum of all cluster_index_counts must be equal to total_index_count
+ * vertex_positions should have float3 position in the first 12 bytes of each vertex (or can be NULL if not used)
  * target_partition_size is a target size for each partition, in clusters; the resulting partitions may be smaller or larger
  */
-MESHOPTIMIZER_EXPERIMENTAL size_t meshopt_partitionClusters(unsigned int* destination, const unsigned int* cluster_indices, size_t total_index_count, const unsigned int* cluster_index_counts, size_t cluster_count, size_t vertex_count, size_t target_partition_size);
+MESHOPTIMIZER_EXPERIMENTAL size_t meshopt_partitionClusters(unsigned int* destination, const unsigned int* cluster_indices, size_t total_index_count, const unsigned int* cluster_index_counts, size_t cluster_count, const float* vertex_positions, size_t vertex_count, size_t vertex_positions_stride, size_t target_partition_size);
 
 /**
  * Spatial sorter
@@ -841,7 +842,7 @@ inline size_t meshopt_buildMeshletsSplit(meshopt_Meshlet* meshlets, unsigned int
 template <typename T>
 inline meshopt_Bounds meshopt_computeClusterBounds(const T* indices, size_t index_count, const float* vertex_positions, size_t vertex_count, size_t vertex_positions_stride);
 template <typename T>
-inline size_t meshopt_partitionClusters(unsigned int* destination, const T* cluster_indices, size_t total_index_count, const unsigned int* cluster_index_counts, size_t cluster_count, size_t vertex_count, size_t target_partition_size);
+inline size_t meshopt_partitionClusters(unsigned int* destination, const T* cluster_indices, size_t total_index_count, const unsigned int* cluster_index_counts, size_t cluster_count, const float* vertex_positions, size_t vertex_count, size_t vertex_positions_stride, size_t target_partition_size);
 template <typename T>
 inline void meshopt_spatialSortTriangles(T* destination, const T* indices, size_t index_count, const float* vertex_positions, size_t vertex_count, size_t vertex_positions_stride);
 #endif
@@ -1278,11 +1279,11 @@ inline meshopt_Bounds meshopt_computeClusterBounds(const T* indices, size_t inde
 }
 
 template <typename T>
-inline size_t meshopt_partitionClusters(unsigned int* destination, const T* cluster_indices, size_t total_index_count, const unsigned int* cluster_index_counts, size_t cluster_count, size_t vertex_count, size_t target_partition_size)
+inline size_t meshopt_partitionClusters(unsigned int* destination, const T* cluster_indices, size_t total_index_count, const unsigned int* cluster_index_counts, size_t cluster_count, const float* vertex_positions, size_t vertex_count, size_t vertex_positions_stride, size_t target_partition_size)
 {
 	meshopt_IndexAdapter<T> in(NULL, cluster_indices, total_index_count);
 
-	return meshopt_partitionClusters(destination, in.data, total_index_count, cluster_index_counts, cluster_count, vertex_count, target_partition_size);
+	return meshopt_partitionClusters(destination, in.data, total_index_count, cluster_index_counts, cluster_count, vertex_positions, vertex_count, vertex_positions_stride, target_partition_size);
 }
 
 template <typename T>

--- a/src/partition.cpp
+++ b/src/partition.cpp
@@ -278,11 +278,16 @@ static int pickGroupToMerge(const ClusterGroup* groups, int id, const ClusterAdj
 
 } // namespace meshopt
 
-size_t meshopt_partitionClusters(unsigned int* destination, const unsigned int* cluster_indices, size_t total_index_count, const unsigned int* cluster_index_counts, size_t cluster_count, size_t vertex_count, size_t target_partition_size)
+size_t meshopt_partitionClusters(unsigned int* destination, const unsigned int* cluster_indices, size_t total_index_count, const unsigned int* cluster_index_counts, size_t cluster_count, const float* vertex_positions, size_t vertex_count, size_t vertex_positions_stride, size_t target_partition_size)
 {
 	using namespace meshopt;
 
+	assert((vertex_positions == NULL || vertex_positions_stride >= 12) && vertex_positions_stride <= 256);
+	assert(vertex_positions_stride % sizeof(float) == 0);
 	assert(target_partition_size > 0);
+
+	(void)vertex_positions;
+	(void)vertex_positions_stride;
 
 	size_t max_partition_size = target_partition_size + target_partition_size * 3 / 8;
 

--- a/src/partition.cpp
+++ b/src/partition.cpp
@@ -50,24 +50,18 @@ static void filterClusterIndices(unsigned int* data, unsigned int* offsets, cons
 	offsets[cluster_count] = unsigned(cluster_write);
 }
 
-static void computeClusterBounds(float* cluster_bounds, const unsigned int* cluster_indices, const unsigned int* cluster_index_counts, size_t cluster_count, const float* vertex_positions, size_t vertex_count, size_t vertex_positions_stride)
+static void computeClusterBounds(float* cluster_bounds, const unsigned int* cluster_indices, const unsigned int* cluster_offsets, size_t cluster_count, const float* vertex_positions, size_t vertex_positions_stride)
 {
-	(void)vertex_count;
-
 	size_t vertex_stride_float = vertex_positions_stride / sizeof(float);
-	size_t cluster_start = 0;
 
 	for (size_t i = 0; i < cluster_count; ++i)
 	{
 		float center[3] = {0, 0, 0};
 
 		// approximate center of the cluster by averaging all vertex positions
-		for (size_t j = 0; j < cluster_index_counts[i]; ++j)
+		for (size_t j = cluster_offsets[i]; j < cluster_offsets[i + 1]; ++j)
 		{
-			unsigned int v = cluster_indices[cluster_start + j];
-			assert(v < vertex_count);
-
-			const float* p = vertex_positions + v * vertex_stride_float;
+			const float* p = vertex_positions + cluster_indices[j] * vertex_stride_float;
 
 			center[0] += p[0];
 			center[1] += p[1];
@@ -75,20 +69,19 @@ static void computeClusterBounds(float* cluster_bounds, const unsigned int* clus
 		}
 
 		// note: technically clusters can't be empty per meshopt_partitionCluster but we check for a division by zero in case that changes
-		if (cluster_index_counts[i])
+		if (size_t cluster_size = cluster_offsets[i + 1] - cluster_offsets[i])
 		{
-			center[0] /= float(cluster_index_counts[i]);
-			center[1] /= float(cluster_index_counts[i]);
-			center[2] /= float(cluster_index_counts[i]);
+			center[0] /= float(cluster_size);
+			center[1] /= float(cluster_size);
+			center[2] /= float(cluster_size);
 		}
 
 		// compute radius of the bounding sphere for each cluster
 		float radiussq = 0;
 
-		for (size_t j = 0; j < cluster_index_counts[i]; ++j)
+		for (size_t j = cluster_offsets[i]; j < cluster_offsets[i + 1]; ++j)
 		{
-			unsigned int v = cluster_indices[cluster_start + j];
-			const float* p = vertex_positions + v * vertex_stride_float;
+			const float* p = vertex_positions + cluster_indices[j] * vertex_stride_float;
 
 			float d2 = (p[0] - center[0]) * (p[0] - center[0]) + (p[1] - center[1]) * (p[1] - center[1]) + (p[2] - center[2]) * (p[2] - center[2]);
 
@@ -99,8 +92,6 @@ static void computeClusterBounds(float* cluster_bounds, const unsigned int* clus
 		cluster_bounds[i * 4 + 1] = center[1];
 		cluster_bounds[i * 4 + 2] = center[2];
 		cluster_bounds[i * 4 + 3] = sqrtf(radiussq);
-
-		cluster_start += cluster_index_counts[i];
 	}
 }
 
@@ -344,15 +335,6 @@ size_t meshopt_partitionClusters(unsigned int* destination, const unsigned int* 
 
 	meshopt_Allocator allocator;
 
-	// compute bounding sphere for each cluster if positions are provided
-	float* cluster_bounds = NULL;
-
-	if (vertex_positions)
-	{
-		cluster_bounds = allocator.allocate<float>(cluster_count * 4);
-		computeClusterBounds(cluster_bounds, cluster_indices, cluster_index_counts, cluster_count, vertex_positions, vertex_count, vertex_positions_stride);
-	}
-
 	unsigned char* used = allocator.allocate<unsigned char>(vertex_count);
 	memset(used, 0, vertex_count);
 
@@ -362,6 +344,15 @@ size_t meshopt_partitionClusters(unsigned int* destination, const unsigned int* 
 	// make new cluster index list that filters out duplicate indices
 	filterClusterIndices(cluster_newindices, cluster_offsets, cluster_indices, cluster_index_counts, cluster_count, used, vertex_count, total_index_count);
 	cluster_indices = cluster_newindices;
+
+	// compute bounding sphere for each cluster if positions are provided
+	float* cluster_bounds = NULL;
+
+	if (vertex_positions)
+	{
+		cluster_bounds = allocator.allocate<float>(cluster_count * 4);
+		computeClusterBounds(cluster_bounds, cluster_indices, cluster_offsets, cluster_count, vertex_positions, vertex_positions_stride);
+	}
 
 	// build cluster adjacency along with edge weights (shared vertex count)
 	ClusterAdjacency adjacency = {};


### PR DESCRIPTION
When using `meshopt_partitionClusters`, vertex positions can now be optionally provided. When positions are specified, we compute approximate cluster bounds from the cluster indices, and use these bounds to influence group merge selection to produce slightly smaller partitions spatially.

The algorithm is still primarily guided by the shared boundary size, and the bounds based selection does not change that significantly but can help to slightly lower the partition volumes and to bias the selection when the ties need to be broken. For now, since the groups are still sorted by vertex count, there are cases when the resulting partitions are larger (spatially) than possible in areas with uneven vertex density.

To preserve previous (topology only) behavior, it's sufficient to pass `NULL` as vertex_positions. Because the impact here is not very significant and the scoring function is subject to change, for now no additional tuning mechanism is provided.

*This contribution is sponsored by Valve.*