### PR TITLE
spatialorder: Introduce experimental point clusterizer

### DIFF
--- a/src/meshoptimizer.h
+++ b/src/meshoptimizer.h
@@ -715,15 +715,14 @@ MESHOPTIMIZER_API void meshopt_spatialSortRemap(unsigned int* destination, const
 MESHOPTIMIZER_EXPERIMENTAL void meshopt_spatialSortTriangles(unsigned int* destination, const unsigned int* indices, size_t index_count, const float* vertex_positions, size_t vertex_count, size_t vertex_positions_stride);
 
 /**
- * Experimental: Spatial sorter
- * Reorders points for spatial locality, and generates a new index buffer.
- * Ensures the output can be split into block_size chunks where each chunk has good positional locality.
+ * Experimental: Spatial clusterizer
+ * Reorders points into clusters optimized for spatial locality, and generates a new index buffer.
+ * Ensures the output can be split into cluster_size chunks where each chunk has good positional locality. Only the last chunk will be smaller than cluster_size.
  *
  * destination must contain enough space for the resulting index buffer (vertex_count elements)
  * vertex_positions should have float3 position in the first 12 bytes of each vertex
- * chunk_size ??
  */
-MESHOPTIMIZER_EXPERIMENTAL void meshopt_spatialSortPoints(unsigned int* destination, const float* vertex_positions, size_t vertex_count, size_t vertex_positions_stride, size_t chunk_size);
+MESHOPTIMIZER_EXPERIMENTAL void meshopt_spatialClusterPoints(unsigned int* destination, const float* vertex_positions, size_t vertex_count, size_t vertex_positions_stride, size_t cluster_size);
 
 /**
  * Quantize a float into half-precision (as defined by IEEE-754 fp16) floating point value

--- a/src/meshoptimizer.h
+++ b/src/meshoptimizer.h
@@ -715,6 +715,17 @@ MESHOPTIMIZER_API void meshopt_spatialSortRemap(unsigned int* destination, const
 MESHOPTIMIZER_EXPERIMENTAL void meshopt_spatialSortTriangles(unsigned int* destination, const unsigned int* indices, size_t index_count, const float* vertex_positions, size_t vertex_count, size_t vertex_positions_stride);
 
 /**
+ * Experimental: Spatial sorter
+ * Reorders points for spatial locality, and generates a new index buffer.
+ * Ensures the output can be split into block_size chunks where each chunk has good positional locality.
+ *
+ * destination must contain enough space for the resulting index buffer (vertex_count elements)
+ * vertex_positions should have float3 position in the first 12 bytes of each vertex
+ * chunk_size ??
+ */
+MESHOPTIMIZER_EXPERIMENTAL void meshopt_spatialSortPoints(unsigned int* destination, const float* vertex_positions, size_t vertex_count, size_t vertex_positions_stride, size_t chunk_size);
+
+/**
  * Quantize a float into half-precision (as defined by IEEE-754 fp16) floating point value
  * Generates +-inf for overflow, preserves NaN, flushes denormals to zero, rounds to nearest
  * Representable magnitude range: [6e-5; 65504]


### PR DESCRIPTION
Instead of a global Morton sort, we use hierarchical axis subdivision that ensures that all splits are aligned to a given boundary, leaving leaves unsorted. This is a good fit when the resulting point cloud needs to be processed in parallel, similarly to meshlets. Compared to Morton sort followed by a naive bucketed split, this results in consistently smaller bounds at some extra processing cost.

Unlike spatialSortRemap, this generates an index buffer - not a remap table. Naturally, a new set of points can be constructed without the use of indexing.

This PR also optimizes spatialSort* functions to reduce cache pressure on large meshes.

Fixes #642.

*This contribution is sponsored by Valve.*