### PR TITLE
Rework meshopt_Allocator callback storage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,6 +104,8 @@ if(MESHOPT_BUILD_SHARED_LIBS)
         target_compile_definitions(meshoptimizer PUBLIC "MESHOPTIMIZER_API=__attribute__((visibility(\"default\")))")
     endif()
 
+    target_compile_definitions(meshoptimizer PUBLIC MESHOPTIMIZER_ALLOC_EXPORT)
+
     if(MESHOPT_STABLE_EXPORTS)
 		target_compile_definitions(meshoptimizer PUBLIC "MESHOPTIMIZER_EXPERIMENTAL=")
     endif()

--- a/src/allocator.cpp
+++ b/src/allocator.cpp
@@ -3,6 +3,7 @@
 
 void meshopt_setAllocator(void* (MESHOPTIMIZER_ALLOC_CALLCONV* allocate)(size_t), void (MESHOPTIMIZER_ALLOC_CALLCONV* deallocate)(void*))
 {
-	meshopt_Allocator::Storage::allocate = allocate;
-	meshopt_Allocator::Storage::deallocate = deallocate;
+	meshopt_Allocator::Storage& s = meshopt_Allocator::storage();
+	s.allocate = allocate;
+	s.deallocate = deallocate;
 }

--- a/src/allocator.cpp
+++ b/src/allocator.cpp
@@ -1,6 +1,14 @@
 // This file is part of meshoptimizer library; see meshoptimizer.h for version/license details
 #include "meshoptimizer.h"
 
+#ifdef MESHOPTIMIZER_ALLOC_EXPORT
+meshopt_Allocator::Storage& meshopt_Allocator::storage()
+{
+	static Storage s = {::operator new, ::operator delete };
+	return s;
+}
+#endif
+
 void meshopt_setAllocator(void* (MESHOPTIMIZER_ALLOC_CALLCONV* allocate)(size_t), void (MESHOPTIMIZER_ALLOC_CALLCONV* deallocate)(void*))
 {
 	meshopt_Allocator::Storage& s = meshopt_Allocator::storage();

--- a/src/meshoptimizer.h
+++ b/src/meshoptimizer.h
@@ -896,11 +896,15 @@ public:
 		void (MESHOPTIMIZER_ALLOC_CALLCONV* deallocate)(void*);
 	};
 
+#ifdef MESHOPTIMIZER_ALLOC_EXPORT
+	MESHOPTIMIZER_API static Storage& storage();
+#else
 	static Storage& storage()
 	{
 		static Storage s = {::operator new, ::operator delete };
 		return s;
 	}
+#endif
 
 	meshopt_Allocator()
 	    : blocks()


### PR DESCRIPTION
Using templated class static allowed us to avoid function calls even in
unoptimized builds, but results in conflicts with Clang's C++20 module
implementation when meshoptimizer.h is included in global module
fragment. Instead, we now use a function static to store this state and
require a function call to get access to it.

Additionally, while allocator callbacks were deduplicated by the linker
within an individual module, when meshoptimizer was compiled as a
shared library the library code and the calling code would get
separate configuration, and allocator overrides would not affect temporary
allocations done by meshopt_IndexAdapter. To fix that, this PR introduces
a separate configuration option, `MESHOPTIMIZER_ALLOC_EXPORT`,
which can be used to declare the allocator storage function in the library
once.

Fixes #895.

*This contribution is sponsored by Valve.*