### PR TITLE
gltfpack: Scale simplification error with mesh extents

### DIFF
--- a/gltf/gltfpack.cpp
+++ b/gltf/gltfpack.cpp
@@ -402,6 +402,9 @@ static size_t process(cgltf_data* data, const char* input_path, const char* outp
 	markNeededNodes(data, nodes, meshes, animations, settings);
 	markNeededMaterials(data, materials, meshes, settings);
 
+	if (settings.simplify_scaled && (settings.simplify_ratio < 1 || settings.simplify_debug > 0))
+		computeMeshQuality(meshes);
+
 #ifndef NDEBUG
 	std::vector<Mesh> debug_meshes;
 
@@ -416,7 +419,8 @@ static size_t process(cgltf_data* data, const char* input_path, const char* outp
 		{
 			Mesh kinds = {};
 			Mesh loops = {};
-			debugSimplify(mesh, kinds, loops, settings.simplify_debug, settings.simplify_error, settings.simplify_attributes, settings.quantize && !settings.nrm_float);
+			float error = settings.simplify_scaled ? settings.simplify_error / mesh.quality : settings.simplify_error;
+			debugSimplify(mesh, kinds, loops, settings.simplify_debug, error, settings.simplify_attributes, settings.quantize && !settings.nrm_float);
 			debug_meshes.push_back(kinds);
 			debug_meshes.push_back(loops);
 		}
@@ -1200,6 +1204,7 @@ Settings defaults()
 	settings.mesh_dedup = true;
 	settings.simplify_ratio = 1.f;
 	settings.simplify_error = 1e-2f;
+	settings.simplify_scaled = true;
 
 	for (int kind = 0; kind < TextureKind__Count; ++kind)
 	{
@@ -1380,6 +1385,11 @@ int main(int argc, char** argv)
 		else if (strcmp(arg, "-sv") == 0)
 		{
 			settings.simplify_attributes = true;
+		}
+		else if (strcmp(arg, "-ssd") == 0)
+		{
+			fprintf(stderr, "Warning: option -ssd disables scaled simplification error and is only provided as a safety measure; it will be removed in the future\n");
+			settings.simplify_scaled = false;
 		}
 #ifndef NDEBUG
 		else if (strcmp(arg, "-sd") == 0 && i + 1 < argc && isdigit(argv[i + 1][0]))

--- a/gltf/gltfpack.h
+++ b/gltf/gltfpack.h
@@ -68,6 +68,8 @@ struct Mesh
 	std::vector<const char*> target_names;
 
 	std::vector<cgltf_material_mapping> variants;
+
+	float quality;
 };
 
 struct Track
@@ -146,6 +148,7 @@ struct Settings
 	bool simplify_aggressive;
 	bool simplify_lock_borders;
 	bool simplify_attributes;
+	bool simplify_scaled;
 	float simplify_debug;
 
 	bool texture_ktx2;
@@ -353,6 +356,8 @@ void markAnimated(cgltf_data* data, std::vector<NodeInfo>& nodes, const std::vec
 void markNeededNodes(cgltf_data* data, std::vector<NodeInfo>& nodes, const std::vector<Mesh>& meshes, const std::vector<Animation>& animations, const Settings& settings);
 void remapNodes(cgltf_data* data, std::vector<NodeInfo>& nodes, size_t& node_offset);
 void decomposeTransform(float translation[3], float rotation[4], float scale[3], const float* transform);
+
+void computeMeshQuality(std::vector<Mesh>& meshes);
 
 QuantizationPosition prepareQuantizationPosition(const std::vector<Mesh>& meshes, const Settings& settings);
 void prepareQuantizationTexture(cgltf_data* data, std::vector<QuantizationTexture>& result, std::vector<size_t>& indices, const std::vector<Mesh>& meshes, const Settings& settings);


### PR DESCRIPTION
Instead of using the same target error for each mesh, we now use a factor derived from the ratio of mesh extent to the largest mesh extent to ensure that meshes of different sizes get roughly the same visual degradation.

When meshes are instanced, we take the largest possible scale as a factor; smaller instances will retain more detail.

While we could use the ratio of mesh bounds to scene bounds instead of a ratio to max mesh bounds, there's cases where the input is a collection of objects that are intended to be moved around in space, and the scene bounds is not necessarily representative. With this the simplification behavior is roughly similar to quantization behavior (modulo scale treatment).

Note that we still use the same ratio to simplify every mesh in isolation; this doesn't always work very well, e.g. a 10k triangle mesh with 10 tiny 1k triangle objects attached to it might benefit from removing the tiny objects first for a 50% reduction, but instead we will simplify every mesh to 50% if `-si 0.5` is specified. This is harder to solve well but might be improved in the future.