### PR TITLE
Link Threads::Threads instead of pthread

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -144,10 +144,9 @@ if(MESHOPT_BUILD_GLTFPACK)
             set_source_files_properties(gltf/basislib.cpp PROPERTIES COMPILE_OPTIONS -msse4.1)
         endif()
 
-        if(UNIX)
-            target_link_libraries(gltfpack pthread)
-        endif()
-    endif()
+		find_package(Threads REQUIRED)
+		target_link_libraries(gltfpack Threads::Threads)
+	endif()
 endif()
 
 if(MESHOPT_INSTALL)


### PR DESCRIPTION
There is another improvement I'd like to see in CMakeLists.txt.

Even on UNIX systems, some environments don't provide pthreads, so I would prefer using Threads::Threads instead of pthreads.
This allows linking with C++11+ Threads in a platform-independent manner, supporting a broader range of environments. (ex. Android NDK)
