### PR TITLE
 gltfpack: Preserve material alpha mode for meshes with vertex alpha

### DIFF
--- a/gltf/gltfpack.h
+++ b/gltf/gltfpack.h
@@ -234,6 +234,7 @@ struct MaterialInfo
 	bool uses_texture_transform;
 	bool needs_tangents;
 	bool unlit;
+	bool mesh_alpha;
 
 	unsigned int texture_set_mask;
 
@@ -339,7 +340,7 @@ void mergeTextures(cgltf_data* data, std::vector<TextureInfo>& textures);
 bool hasValidTransform(const cgltf_texture_view& view);
 
 void analyzeMaterials(cgltf_data* data, std::vector<MaterialInfo>& materials, std::vector<TextureInfo>& textures, std::vector<ImageInfo>& images);
-void optimizeMaterials(cgltf_data* data, const char* input_path, std::vector<ImageInfo>& images);
+void optimizeMaterials(cgltf_data* data, std::vector<MaterialInfo>& materials, std::vector<ImageInfo>& images, const char* input_path);
 
 bool readImage(const cgltf_image& image, const char* input_path, std::string& data, std::string& mime_type);
 bool hasAlpha(const std::string& data, const char* mime_type);
@@ -358,6 +359,8 @@ void remapNodes(cgltf_data* data, std::vector<NodeInfo>& nodes, size_t& node_off
 void decomposeTransform(float translation[3], float rotation[4], float scale[3], const float* transform);
 
 void computeMeshQuality(std::vector<Mesh>& meshes);
+
+bool hasAlpha(const Mesh& mesh);
 
 QuantizationPosition prepareQuantizationPosition(const std::vector<Mesh>& meshes, const Settings& settings);
 void prepareQuantizationTexture(cgltf_data* data, std::vector<QuantizationTexture>& result, std::vector<size_t>& indices, const std::vector<Mesh>& meshes, const Settings& settings);

--- a/gltf/material.cpp
+++ b/gltf/material.cpp
@@ -597,14 +597,14 @@ static bool shouldKeepAlpha(const cgltf_texture_view& color, float alpha, cgltf_
 	return image && getChannels(*image, images[image - data->images], input_path) == 4;
 }
 
-void optimizeMaterials(cgltf_data* data, const char* input_path, std::vector<ImageInfo>& images)
+void optimizeMaterials(cgltf_data* data, std::vector<MaterialInfo>& materials, std::vector<ImageInfo>& images, const char* input_path)
 {
 	for (size_t i = 0; i < data->materials_count; ++i)
 	{
 		// remove BLEND/MASK from materials that don't have alpha information
 		cgltf_material& material = data->materials[i];
 
-		if (material.alpha_mode != cgltf_alpha_mode_opaque)
+		if (material.alpha_mode != cgltf_alpha_mode_opaque && !materials[i].mesh_alpha)
 		{
 			if (material.has_pbr_metallic_roughness && shouldKeepAlpha(material.pbr_metallic_roughness.base_color_texture, material.pbr_metallic_roughness.base_color_factor[3], data, input_path, images))
 				continue;

--- a/gltf/material.cpp
+++ b/gltf/material.cpp
@@ -613,6 +613,7 @@ void optimizeMaterials(cgltf_data* data, std::vector<MaterialInfo>& materials, s
 				continue;
 
 			material.alpha_mode = cgltf_alpha_mode_opaque;
+			material.alpha_cutoff = 0.5f; // reset to default to avoid writing it to output
 		}
 	}
 }

--- a/gltf/mesh.cpp
+++ b/gltf/mesh.cpp
@@ -1249,3 +1249,16 @@ void computeMeshQuality(std::vector<Mesh>& meshes)
 	for (size_t i = 0; i < meshes.size(); ++i)
 		meshes[i].quality = (scales[i] == 0.f || maxscale == 0.f) ? 1.f : scales[i] / maxscale;
 }
+
+bool hasAlpha(const Mesh& mesh)
+{
+	const Stream* color = getStream(const_cast<Mesh&>(mesh), cgltf_attribute_type_color);
+	if (!color)
+		return false;
+
+	for (size_t i = 0; i < color->data.size(); ++i)
+		if (color->data[i].f[3] < 1.f)
+			return true;
+
+	return false;
+}


### PR DESCRIPTION
If mesh has a vertex color stream with some transparent colors, we can't
change material blending mode, as both MASK and BLEND will affect
rendering behavior. This requires an extra analysis step before we
optimize materials.

Fixes #909.