### PR TITLE
simplifier: Classify half-seams as seams instead of borders

### DIFF
--- a/src/simplifier.cpp
+++ b/src/simplifier.cpp
@@ -394,6 +394,13 @@ static void classifyVertices(unsigned char* result, unsigned int* loop, unsigned
 				{
 					result[i] = Kind_Manifold;
 				}
+				else if (openi != ~0u && openo != ~0u && remap[openi] == remap[openo] && openi != i)
+				{
+					// classify half-seams as seams (the branch below would mis-classify them as borders)
+					// half-seam is a single vertex that connects to both vertices of a potential seam
+					// treating these as seams allows collapsing the "full" seam vertex onto them
+					result[i] = Kind_Seam;
+				}
 				else if (openi != i && openo != i)
 				{
 					result[i] = Kind_Border;
@@ -1111,7 +1118,7 @@ static void rankEdgeCollapses(Collapse* collapses, size_t collapse_count, const 
 				unsigned int s0 = wedge[i0];
 				unsigned int s1 = loop[i0] == i1 ? loopback[s0] : loop[s0];
 
-				assert(s0 != i0 && wedge[s0] == i0);
+				assert(wedge[s0] == i0); // s0 may be equal to i0 for half-seams
 				assert(s1 != ~0u && remap[s1] == remap[i1]);
 
 				// note: this should never happen due to the assertion above, but when disabled if we ever hit this case we'll get a memory safety issue; for now play it safe
@@ -1277,7 +1284,7 @@ static size_t performEdgeCollapses(unsigned int* collapse_remap, unsigned char* 
 			// for seam collapses we need to move the seam pair together; this is a bit tricky since we need to rely on edge loops as target vertex may be locked (and thus have more than two wedges)
 			unsigned int s0 = wedge[i0];
 			unsigned int s1 = loop[i0] == i1 ? loopback[s0] : loop[s0];
-			assert(s0 != i0 && wedge[s0] == i0);
+			assert(wedge[s0] == i0); // s0 may be equal to i0 for half-seams
 			assert(s1 != ~0u && remap[s1] == r1);
 
 			// additional asserts to verify that the seam pair is consistent


### PR DESCRIPTION
In complex meshes it's possible to encounter a somewhat unusual type of vertex: one that only has a single copy (wedge), and that has one incoming and one outgoing open edge, but both edges connect to vertices with the same position.

Previously, we classified vertices like this as border, because border classification ignored this possibility. This created cases where a border vertex is adjacent to a seam vertex, but neither can be collapsed onto each other because of collapse restrictions.

Doing the right thing here is somewhat complicated. Locking vertices like this to avoid misleading classification regresses cases where a half-seam vertex like this is connected to a locked vertex; these are the cases that in theory may lead to issues on discontinuities but in practice we don't seem to observe them. Classifying this as a new type does not solve that either, as deciding that this vertex can move leads to similar issues in theory.

For now we re-classify vertices like this as seams. The seam handling logic is already safe in case a seam vertex only has a single copy, modulo an assertion that this change adjusts. If this leads to problems down the line, the next best thing is to lock these, at least until we have new complex collapse rules in place.

*This contribution is sponsored by Valve.*