### PR TITLE
gltfpack: Implement support for interleaved vertices

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -174,6 +174,7 @@ jobs:
           ./gltfpack -test demo/pirate.obj -noq
           ./gltfpack -test demo/pirate.obj -vp 16 -vt 16 -vn 16 -vc 16
           ./gltfpack -test demo/pirate.obj -vpf -vtf -vnf
+          ./gltfpack -test demo/pirate.obj -vi -c
           ./gltfpack -test glTF-Sample-Assets/Models/ABeautifulGame/glTF/ABeautifulGame.gltf -mi -c
           ./gltfpack -test glTF-Sample-Assets/Models/ABeautifulGame/glTF/ABeautifulGame.gltf -kn -km -ke
           ./gltfpack -test glTF-Sample-Assets/Models/BoxTextured/glTF/BoxTextured.gltf -vpf -vtf -c

--- a/gltf/gltfpack.cpp
+++ b/gltf/gltfpack.cpp
@@ -1312,6 +1312,10 @@ int main(int argc, char** argv)
 		{
 			settings.nrm_float = true;
 		}
+		else if (strcmp(arg, "-vi") == 0)
+		{
+			settings.mesh_interleaved = true;
+		}
 		else if (strcmp(arg, "-at") == 0 && i + 1 < argc && isdigit(argv[i + 1][0]))
 		{
 			settings.trn_bits = clamp(atoi(argv[++i]), 1, 24);
@@ -1612,6 +1616,7 @@ int main(int argc, char** argv)
 			fprintf(stderr, "\nVertex attributes:\n");
 			fprintf(stderr, "\t-vtf: use floating point attributes for texture coordinates\n");
 			fprintf(stderr, "\t-vnf: use floating point attributes for normals\n");
+			fprintf(stderr, "\t-vi: use interleaved vertex attributes (reduces compression efficiency)\n");
 			fprintf(stderr, "\t-kv: keep source vertex attributes even if they aren't used\n");
 			fprintf(stderr, "\nAnimations:\n");
 			fprintf(stderr, "\t-at N: use N-bit quantization for translations (default: 16; N should be between 1 and 24)\n");

--- a/gltf/gltfpack.h
+++ b/gltf/gltfpack.h
@@ -142,6 +142,7 @@ struct Settings
 	bool mesh_dedup;
 	bool mesh_merge;
 	bool mesh_instancing;
+	bool mesh_interleaved;
 
 	float simplify_ratio;
 	float simplify_error;

--- a/gltf/gltfpack.h
+++ b/gltf/gltfpack.h
@@ -364,7 +364,7 @@ QuantizationPosition prepareQuantizationPosition(const std::vector<Mesh>& meshes
 void prepareQuantizationTexture(cgltf_data* data, std::vector<QuantizationTexture>& result, std::vector<size_t>& indices, const std::vector<Mesh>& meshes, const Settings& settings);
 void getPositionBounds(float min[3], float max[3], const Stream& stream, const QuantizationPosition& qp, const Settings& settings);
 
-StreamFormat writeVertexStream(std::string& bin, const Stream& stream, const QuantizationPosition& qp, const QuantizationTexture& qt, const Settings& settings);
+StreamFormat writeVertexStream(std::string& bin, const Stream& stream, const QuantizationPosition& qp, const QuantizationTexture& qt, const Settings& settings, bool filters = true);
 StreamFormat writeIndexStream(std::string& bin, const std::vector<unsigned int>& stream);
 StreamFormat writeTimeStream(std::string& bin, const std::vector<float>& data);
 StreamFormat writeKeyframeStream(std::string& bin, cgltf_animation_path_type type, const std::vector<Attr>& data, const Settings& settings, bool has_tangents = false);


### PR DESCRIPTION
When a new command line argument `-vi` is used, gltfpack now produces
interleaved vertex streams instead of deinterleaving per attribute. This
can be helpful for some native renderers and may improve rendering
efficiency on some GPUs.

Interleaving is not compatible with vertex filters, so they are disabled
in this mode. This reduces compression efficiency when options like `-cc`
or `-vpf` together with `-c` are used. Filters can still be used on
animation data.

When the mesh is using morph targets, each morph target is interleaved
separately. This prevents vertices from having very large strides on
meshes with many targets, and results in more efficient access patterns
if a small subset of morph targets is used at runtime.

Fixes #924.