### PR TITLE
simplifier: Improve robustness of position update

### DIFF
--- a/src/simplifier.cpp
+++ b/src/simplifier.cpp
@@ -904,7 +904,7 @@ static bool quadricSolve(Vector3& p, const Quadric& Q, const QuadricGrad& GV)
 	float a10 = Q.a10, a20 = Q.a20, a21 = Q.a21;
 	float x0 = -Q.b0, x1 = -Q.b1, x2 = -Q.b2;
 
-	float eps = 1e-7f * Q.w;
+	float eps = 1e-6f * Q.w;
 
 	// LDL decomposition: A = LDL^T
 	float d0 = a00;

--- a/src/simplifier.cpp
+++ b/src/simplifier.cpp
@@ -1606,6 +1606,11 @@ static void solveQuadrics(Vector3* vertex_positions, float* vertex_attributes, s
 		Quadric Q = vertex_quadrics[i];
 		QuadricGrad GV = {};
 
+		// add a point quadric for regularization to stabilize the solution
+		Quadric R;
+		quadricFromPoint(R, vp.x, vp.y, vp.z, Q.w * 1e-4f);
+		quadricAdd(Q, R);
+
 		if (attribute_count)
 		{
 			// optimal point simultaneously minimizes attribute quadrics for all wedges


### PR DESCRIPTION
While position update implemented previously was mostly stable given careful setup (use of attribute weights, topology restriction, and flip prevention together made it work), it could still sometimes create invalid positions when regularization wasn't used. This implements a series of changes aimed at detecting and improving this:

- In addition to a triangle flip check, positions that move outside of the vertex neighborhood get rejected
- Quadric solve will fail cleanly when the condition number is too small
- Additional just-in-time weak regularization mostly stabilizes the solve by itself

Some of these measures are redundant wrt others, which hopefully will ensure the computation remains stable in all cases.

*This contribution is sponsored by Valve.*