### PR TITLE
indexgenerator: Implement experimental meshopt_generatePositionRemap

### DIFF
--- a/src/indexgenerator.cpp
+++ b/src/indexgenerator.cpp
@@ -439,6 +439,31 @@ void meshopt_generateShadowIndexBufferMulti(unsigned int* destination, const uns
 	generateShadowBuffer(destination, indices, index_count, vertex_count, hasher, allocator);
 }
 
+void meshopt_generatePositionRemap(unsigned int* destination, const float* vertex_positions, size_t vertex_count, size_t vertex_positions_stride)
+{
+	using namespace meshopt;
+
+	assert(vertex_positions_stride >= 12 && vertex_positions_stride <= 256);
+	assert(vertex_positions_stride % sizeof(float) == 0);
+
+	meshopt_Allocator allocator;
+	VertexCustomHasher hasher = {vertex_positions, vertex_positions_stride / sizeof(float), NULL, NULL};
+
+	size_t table_size = hashBuckets(vertex_count);
+	unsigned int* table = allocator.allocate<unsigned int>(table_size);
+	memset(table, -1, table_size * sizeof(unsigned int));
+
+	for (size_t i = 0; i < vertex_count; ++i)
+	{
+		unsigned int* entry = hashLookup(table, table_size, hasher, unsigned(i), ~0u);
+
+		if (*entry == ~0u)
+			*entry = unsigned(i);
+
+		destination[i] = *entry;
+	}
+}
+
 void meshopt_generateAdjacencyIndexBuffer(unsigned int* destination, const unsigned int* indices, size_t index_count, const float* vertex_positions, size_t vertex_count, size_t vertex_positions_stride)
 {
 	using namespace meshopt;

--- a/src/meshoptimizer.h
+++ b/src/meshoptimizer.h
@@ -125,6 +125,16 @@ MESHOPTIMIZER_API void meshopt_generateShadowIndexBuffer(unsigned int* destinati
 MESHOPTIMIZER_API void meshopt_generateShadowIndexBufferMulti(unsigned int* destination, const unsigned int* indices, size_t index_count, size_t vertex_count, const struct meshopt_Stream* streams, size_t stream_count);
 
 /**
+ * Experimental: Generates a remap table that maps all vertices with the same position to the same (existing) index.
+ * Similarly to meshopt_generateShadowIndexBuffer, this can be helpful to pre-process meshes for position-only rendering.
+ * This can also be used to implement algorithms that require positional-only connectivity, such as hierarchical simplification.
+ *
+ * destination must contain enough space for the resulting remap table (vertex_count elements)
+ * vertex_positions should have float3 position in the first 12 bytes of each vertex
+ */
+MESHOPTIMIZER_EXPERIMENTAL void meshopt_generatePositionRemap(unsigned int* destination, const float* vertex_positions, size_t vertex_count, size_t vertex_positions_stride);
+
+/**
  * Generate index buffer that can be used as a geometry shader input with triangle adjacency topology
  * Each triangle is converted into a 6-vertex patch with the following layout:
  * - 0, 2, 4: original triangle vertices


### PR DESCRIPTION
In several algorithms, it's useful to have a position remap that maps
vertices to the "canonical" (first) vertex with the same position. This
is somewhat similar to shadow indexing, and indeed such a remap can be
used to reindex buffers for shadow rendering, but this is also useful
for simplification to compute protection or lock bits, and for cluster
partitioning.

It's almost possible to use meshopt_generateVertexRemap for this, but in
addition to requiring that the input count is divisible by 3, this
function doesn't handle negative zeroes; this is fine for remaps wrt
efficiency but can lead to rare issues where vertices with the same
position aren't protected for simplification which could lead to
geometry or attribute artifacts.

A new dedicated function solves both cases cleanly. It uses the same
hasher we use for generateVertexRemapCustom, just without the callback.

This PR also updates hierarchical simplification example to use this function;
the resulting code for establishing protect bits for permissive mode is now much
simpler and harder to get wrong.

*This contribution is sponsored by Valve.*