### PR TITLE
gltfpack: Introduce an option for permissive simplification

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -177,6 +177,7 @@ jobs:
           ./gltfpack -test demo/pirate.obj -vi -c
           ./gltfpack -test glTF-Sample-Assets/Models/ABeautifulGame/glTF/ABeautifulGame.gltf -mi -c
           ./gltfpack -test glTF-Sample-Assets/Models/ABeautifulGame/glTF/ABeautifulGame.gltf -kn -km -ke
+          ./gltfpack -test glTF-Sample-Assets/Models/ABeautifulGame/glTF/ABeautifulGame.gltf -si 0.1 -sp
           ./gltfpack -test glTF-Sample-Assets/Models/BoxTextured/glTF/BoxTextured.gltf -vpf -vtf -c
           ./gltfpack -test glTF-Sample-Assets/Models/BoxTextured/glTF/BoxTextured.gltf -vpf -vtf -cc
           ./gltfpack -test glTF-Sample-Assets/Models/BoxTextured/glTF/BoxTextured.gltf -tc

--- a/gltf/gltfpack.cpp
+++ b/gltf/gltfpack.cpp
@@ -1399,6 +1399,10 @@ int main(int argc, char** argv)
 			fprintf(stderr, "Warning: option -ssd disables scaled simplification error and is temporary; avoid production usage\n");
 			settings.simplify_scaled = false;
 		}
+		else if (strcmp(arg, "-sp") == 0)
+		{
+			settings.simplify_permissive = true;
+		}
 		else if (strcmp(arg, "-tu") == 0)
 		{
 			settings.texture_ktx2 = true;
@@ -1606,6 +1610,7 @@ int main(int argc, char** argv)
 			fprintf(stderr, "\nSimplification:\n");
 			fprintf(stderr, "\t-si R: simplify meshes targeting triangle/point count ratio R (default: 1; R should be between 0 and 1)\n");
 			fprintf(stderr, "\t-se E: limit simplification error to E (default: 0.01 = 1%% deviation; E should be between 0 and 1)\n");
+			fprintf(stderr, "\t-sp: use permissive simplification mode to allow simplification across attribute discontinuities\n");
 			fprintf(stderr, "\t-sa: aggressively simplify to the target ratio disregarding quality\n");
 			fprintf(stderr, "\t-slb: lock border vertices during simplification to avoid gaps on connected meshes\n");
 			fprintf(stderr, "\nVertex precision:\n");

--- a/gltf/gltfpack.h
+++ b/gltf/gltfpack.h
@@ -150,6 +150,7 @@ struct Settings
 	bool simplify_lock_borders;
 	bool simplify_attributes;
 	bool simplify_scaled;
+	bool simplify_permissive;
 
 	bool texture_ktx2;
 	bool texture_embed;


### PR DESCRIPTION
Using `-sp` now enables permissive simplification, which allows the
simplifier to simplify across normal discontinuities; UV discontinuities
are protected and should simplify similarly to how the regular mode
works.

This is meant as an alternative to aggressive mode, which is using
sloppy simplification as a fallback. Sloppy simplification doesn't
preserve attributes and doesn't support attribute weighting, and has
issues with volume and shape conservation.

Permissive mode has quality limitations and is not always maximally
effective; this will be improved in the future.