### PR TITLE
Make CMake integration a little cleaner

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -204,9 +204,9 @@ if(MESHOPT_INSTALL)
 
 	include(CMakePackageConfigHelpers)
 
-	configure_package_config_file(config.cmake.in
-	    ${CMAKE_CURRENT_BINARY_DIR}/meshoptimizerConfig.cmake
-	    INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/meshoptimizer NO_SET_AND_CHECK_MACRO)
+	# CMake 3.18+ supports file(CONFIGURE OUTPUT file CONTENT content @ONLY) but we only require 3.5+
+	file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/meshoptimizerConfig.cmake
+		"include(\"\${CMAKE_CURRENT_LIST_DIR}/meshoptimizerTargets.cmake\")\n")
 
 	write_basic_package_version_file(${CMAKE_CURRENT_BINARY_DIR}/meshoptimizerConfigVersion.cmake COMPATIBILITY ExactVersion)
 

--- a/config.cmake.in
+++ b/config.cmake.in
@@ -1,4 +1,0 @@
-@PACKAGE_INIT@
-
-include("${CMAKE_CURRENT_LIST_DIR}/meshoptimizerTargets.cmake")
-check_required_components(meshoptimizer)


### PR DESCRIPTION
- Remove gltfpack from the list of exported targets; this mirrors a similar change from Debian distribution and the target can not be linked to when using meshoptimizer as a CMake module.
- Remove config.cmake.in in favor of generating the relevant file during the build; using `configure_package_config_file` seems to be overkill (see https://blog.vito.nyc/posts/cmake-pkg/ for details) and I've had my eyes on removing this top-level file to simplify the file structure for some time.