### PR TITLE
clusterizer: Remove negative cone_weight from buildMeshletsFlex

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ meshlets.resize(meshlet_count);
 
 Depending on the application, other strategies of storing the data can be useful; for example, `meshlet_vertices` serves as indices into the original vertex buffer but it might be worthwhile to generate a mini vertex buffer for each meshlet to remove the extra indirection when accessing vertex data, or it might be desirable to compress vertex data as vertices in each meshlet are likely to be very spatially coherent.
 
-For optimal performance, it is recommended to further optimize each meshlet in isolation for better triangle and vertex locality by calling `meshopt_optimizeMeshlet` on vertex and index data like so:
+For optimal rasterization performance, it is recommended to further optimize each meshlet in isolation for better triangle and vertex locality by calling `meshopt_optimizeMeshlet` on vertex and index data like so:
 
 ```c++
 meshopt_optimizeMeshlet(&meshlet_vertices[m.vertex_offset], &meshlet_triangles[m.triangle_offset], m.triangle_count, m.vertex_count);
@@ -255,6 +255,8 @@ if (dot(normalize(cone_apex - camera_position), cone_axis) >= cone_cutoff) rejec
 ```
 
 Cluster culling should ideally run at a lower frequency than mesh shading, either using amplification/task shaders, or using a separate compute dispatch.
+
+By default, the meshlet builder tries to form complete meshlets even if that requires merging disconnected regions of the mesh into a single meshlet. In some cases, such as hierarchical level of detail, or when advanced culling is used, it may be beneficial to prioritize spatial locality of triangles in a meshlet even if that results in partially filled meshlets. To that end, `meshopt_buildMeshletsFlex` function can be used instead of `meshopt_buildMeshlets`; it provides two triangle limits, `min_triangles` and `max_triangles`, and uses an additional configuration parameter, `split_factor` (recommended value is 2.0), to decide whether increasing the meshlet radius is worth it to fit more triangles in the meshlet. When using this function, the worst case bound for the number of meshlets has to be computed using `meshopt_buildMeshletsBound` with `min_triangles` parameter instead of `max_triangles`.
 
 ### Clustered raytracing
 

--- a/demo/main.cpp
+++ b/demo/main.cpp
@@ -893,7 +893,7 @@ void meshlets(const Mesh& mesh, bool scan = false, bool uniform = false, bool fl
 	const size_t min_triangles = spatial ? 16 : (uniform ? 24 : 32); // only used in flex/spatial modes
 
 	// note: should be set to 0 unless cone culling is used at runtime!
-	const float cone_weight = flex ? -1.0f : 0.25f;
+	const float cone_weight = 0.25f;
 	const float split_factor = flex ? 2.0f : 0.0f;
 
 	// note: input mesh is assumed to be optimized for vertex cache and vertex fetch
@@ -909,7 +909,7 @@ void meshlets(const Mesh& mesh, bool scan = false, bool uniform = false, bool fl
 		meshlets.resize(meshopt_buildMeshletsFlex(&meshlets[0], &meshlet_vertices[0], &meshlet_triangles[0], &mesh.indices[0], mesh.indices.size(), &mesh.vertices[0].px, mesh.vertices.size(), sizeof(Vertex), max_vertices, min_triangles, max_triangles, cone_weight, split_factor));
 	else if (spatial)
 		meshlets.resize(meshopt_buildMeshletsSpatial(&meshlets[0], &meshlet_vertices[0], &meshlet_triangles[0], &mesh.indices[0], mesh.indices.size(), &mesh.vertices[0].px, mesh.vertices.size(), sizeof(Vertex), max_vertices, min_triangles, max_triangles, 0.f));
-	else // note: equivalent to the call of buildMeshletsFlex() with non-negative cone_weight and split_factor = 0
+	else // note: equivalent to the call of buildMeshletsFlex() with split_factor = 0 and min_triangles = max_triangles
 		meshlets.resize(meshopt_buildMeshlets(&meshlets[0], &meshlet_vertices[0], &meshlet_triangles[0], &mesh.indices[0], mesh.indices.size(), &mesh.vertices[0].px, mesh.vertices.size(), sizeof(Vertex), max_vertices, max_triangles, cone_weight));
 
 	if (!dump)

--- a/demo/nanite.cpp
+++ b/demo/nanite.cpp
@@ -945,7 +945,6 @@ void clrt(const std::vector<Vertex>& vertices, const std::vector<unsigned int>& 
 	const size_t max_vertices = 64;
 	const size_t min_triangles = 16;
 	const size_t max_triangles = 64;
-	const float cone_weight = -0.25f;
 	const float split_factor = 2.0f;
 	const float fill_weight = 0.5f;
 
@@ -958,7 +957,7 @@ void clrt(const std::vector<Vertex>& vertices, const std::vector<unsigned int>& 
 	if (use_spatial)
 		meshlets.resize(meshopt_buildMeshletsSpatial(&meshlets[0], &meshlet_vertices[0], &meshlet_triangles[0], &indices[0], indices.size(), &vertices[0].px, vertices.size(), sizeof(Vertex), max_vertices, min_triangles, max_triangles, fill_weight));
 	else
-		meshlets.resize(meshopt_buildMeshletsFlex(&meshlets[0], &meshlet_vertices[0], &meshlet_triangles[0], &indices[0], indices.size(), &vertices[0].px, vertices.size(), sizeof(Vertex), max_vertices, min_triangles, max_triangles, cone_weight, split_factor));
+		meshlets.resize(meshopt_buildMeshletsFlex(&meshlets[0], &meshlet_vertices[0], &meshlet_triangles[0], &indices[0], indices.size(), &vertices[0].px, vertices.size(), sizeof(Vertex), max_vertices, min_triangles, max_triangles, 0.f, split_factor));
 
 	double end = timestamp();
 

--- a/demo/tests.cpp
+++ b/demo/tests.cpp
@@ -1326,17 +1326,6 @@ static void meshletsFlex()
 	assert(ml[0].vertex_count == 4);
 	assert(ml[1].triangle_count == 4);
 	assert(ml[1].vertex_count == 4);
-
-	// this should hold when using axis-aligned metric as well (negative cone weight)
-	assert(meshopt_buildMeshletsFlex(ml, mv, mt, ib, sizeof(ib) / sizeof(ib[0]), vb, 8, sizeof(float) * 3, 16, 4, 8, -1.f, 10.f) == 1);
-	assert(ml[0].triangle_count == 8);
-	assert(ml[0].vertex_count == 8);
-
-	assert(meshopt_buildMeshletsFlex(ml, mv, mt, ib, sizeof(ib) / sizeof(ib[0]), vb, 8, sizeof(float) * 3, 16, 4, 8, -1.f, 1.f) == 2);
-	assert(ml[0].triangle_count == 4);
-	assert(ml[0].vertex_count == 4);
-	assert(ml[1].triangle_count == 4);
-	assert(ml[1].vertex_count == 4);
 }
 
 static void meshletsMax()

--- a/src/clusterizer.cpp
+++ b/src/clusterizer.cpp
@@ -265,21 +265,8 @@ struct Cone
 	float nx, ny, nz;
 };
 
-static float getDistance(float dx, float dy, float dz, bool aa)
-{
-	if (!aa)
-		return sqrtf(dx * dx + dy * dy + dz * dz);
-
-	float rx = fabsf(dx), ry = fabsf(dy), rz = fabsf(dz);
-	float rxy = rx > ry ? rx : ry;
-	return rxy > rz ? rxy : rz;
-}
-
 static float getMeshletScore(float distance, float spread, float cone_weight, float expected_radius)
 {
-	if (cone_weight < 0)
-		return 1 + distance / expected_radius;
-
 	float cone = 1.f - spread * cone_weight;
 	float cone_clamped = cone < 1e-3f ? 1e-3f : cone;
 
@@ -453,7 +440,7 @@ static unsigned int getNeighborTriangle(const meshopt_Meshlet& meshlet, const Co
 			const Cone& tri_cone = triangles[triangle];
 
 			float dx = tri_cone.px - meshlet_cone.px, dy = tri_cone.py - meshlet_cone.py, dz = tri_cone.pz - meshlet_cone.pz;
-			float distance = getDistance(dx, dy, dz, cone_weight < 0);
+			float distance = sqrtf(dx * dx + dy * dy + dz * dz);
 			float spread = tri_cone.nx * meshlet_cone.nx + tri_cone.ny * meshlet_cone.ny + tri_cone.nz * meshlet_cone.nz;
 
 			float score = getMeshletScore(distance, spread, cone_weight, meshlet_expected_radius);
@@ -514,7 +501,8 @@ static size_t appendSeedTriangles(unsigned int* seeds, const meshopt_Meshlet& me
 		if (best_neighbor == ~0u)
 			continue;
 
-		float best_neighbor_score = getDistance(triangles[best_neighbor].px - cornerx, triangles[best_neighbor].py - cornery, triangles[best_neighbor].pz - cornerz, false);
+		float dx = triangles[best_neighbor].px - cornerx, dy = triangles[best_neighbor].py - cornery, dz = triangles[best_neighbor].pz - cornerz;
+		float best_neighbor_score = sqrtf(dx * dx + dy * dy + dz * dz);
 
 		for (size_t j = 0; j < kMeshletAddSeeds; ++j)
 		{
@@ -566,7 +554,8 @@ static unsigned int selectSeedTriangle(const unsigned int* seeds, size_t seed_co
 		unsigned int a = indices[index * 3 + 0], b = indices[index * 3 + 1], c = indices[index * 3 + 2];
 
 		unsigned int live = live_triangles[a] + live_triangles[b] + live_triangles[c];
-		float score = getDistance(triangles[index].px - cornerx, triangles[index].py - cornery, triangles[index].pz - cornerz, false);
+		float dx = triangles[index].px - cornerx, dy = triangles[index].py - cornery, dz = triangles[index].pz - cornerz;
+		float score = sqrtf(dx * dx + dy * dy + dz * dz);
 
 		if (live < best_live || (live == best_live && score < best_score))
 		{
@@ -687,7 +676,7 @@ static size_t kdtreeBuild(size_t offset, KDNode* nodes, size_t node_count, const
 	return kdtreeBuild(next_offset, nodes, node_count, points, stride, indices + middle, count - middle, leaf_size);
 }
 
-static void kdtreeNearest(KDNode* nodes, unsigned int root, const float* points, size_t stride, const unsigned char* emitted_flags, const float* position, bool aa, unsigned int& result, float& limit)
+static void kdtreeNearest(KDNode* nodes, unsigned int root, const float* points, size_t stride, const unsigned char* emitted_flags, const float* position, unsigned int& result, float& limit)
 {
 	const KDNode& node = nodes[root];
 
@@ -704,7 +693,7 @@ static void kdtreeNearest(KDNode* nodes, unsigned int root, const float* points,
 			const float* point = points + index * stride;
 
 			float dx = point[0] - position[0], dy = point[1] - position[1], dz = point[2] - position[2];
-			float distance = getDistance(dx, dy, dz, aa);
+			float distance = sqrtf(dx * dx + dy * dy + dz * dz);
 
 			if (distance < limit)
 			{
@@ -720,11 +709,11 @@ static void kdtreeNearest(KDNode* nodes, unsigned int root, const float* points,
 		unsigned int first = (delta <= 0) ? 0 : node.children;
 		unsigned int second = first ^ node.children;
 
-		kdtreeNearest(nodes, root + 1 + first, points, stride, emitted_flags, position, aa, result, limit);
+		kdtreeNearest(nodes, root + 1 + first, points, stride, emitted_flags, position, result, limit);
 
 		// only process the other node if it can have a match based on closest distance so far
 		if (fabsf(delta) <= limit)
-			kdtreeNearest(nodes, root + 1 + second, points, stride, emitted_flags, position, aa, result, limit);
+			kdtreeNearest(nodes, root + 1 + second, points, stride, emitted_flags, position, result, limit);
 	}
 }
 
@@ -1072,7 +1061,7 @@ size_t meshopt_buildMeshletsFlex(meshopt_Meshlet* meshlets, unsigned int* meshle
 	assert(min_triangles >= 1 && min_triangles <= max_triangles && max_triangles <= kMeshletMaxTriangles);
 	assert(min_triangles % 4 == 0 && max_triangles % 4 == 0); // ensures the caller will compute output space properly as index data is 4b aligned
 
-	assert(cone_weight <= 1); // negative cone weight switches metric to optimize for axis-aligned meshlets
+	assert(cone_weight >= 0 && cone_weight <= 1);
 	assert(split_factor >= 0);
 
 	if (index_count == 0)
@@ -1134,7 +1123,8 @@ size_t meshopt_buildMeshletsFlex(meshopt_Meshlet* meshlets, unsigned int* meshle
 	{
 		const Cone& tri = triangles[i];
 
-		float score = getDistance(tri.px - cornerx, tri.py - cornery, tri.pz - cornerz, false);
+		float dx = tri.px - cornerx, dy = tri.py - cornery, dz = tri.pz - cornerz;
+		float score = sqrtf(dx * dx + dy * dy + dz * dz);
 
 		if (initial_seed == ~0u || score < initial_score)
 		{
@@ -1174,7 +1164,7 @@ size_t meshopt_buildMeshletsFlex(meshopt_Meshlet* meshlets, unsigned int* meshle
 			unsigned int index = ~0u;
 			float distance = FLT_MAX;
 
-			kdtreeNearest(nodes, 0, &triangles[0].px, sizeof(Cone) / sizeof(float), emitted_flags, position, cone_weight < 0.f, index, distance);
+			kdtreeNearest(nodes, 0, &triangles[0].px, sizeof(Cone) / sizeof(float), emitted_flags, position, index, distance);
 
 			best_triangle = index;
 			split = meshlet.triangle_count >= min_triangles && split_factor > 0 && distance > meshlet_expected_radius * split_factor;
@@ -1256,8 +1246,6 @@ size_t meshopt_buildMeshletsFlex(meshopt_Meshlet* meshlets, unsigned int* meshle
 
 size_t meshopt_buildMeshlets(meshopt_Meshlet* meshlets, unsigned int* meshlet_vertices, unsigned char* meshlet_triangles, const unsigned int* indices, size_t index_count, const float* vertex_positions, size_t vertex_count, size_t vertex_positions_stride, size_t max_vertices, size_t max_triangles, float cone_weight)
 {
-	assert(cone_weight >= 0); // to use negative cone weight, use meshopt_buildMeshletsFlex
-
 	return meshopt_buildMeshletsFlex(meshlets, meshlet_vertices, meshlet_triangles, indices, index_count, vertex_positions, vertex_count, vertex_positions_stride, max_vertices, max_triangles, max_triangles, cone_weight, 0.0f);
 }
 

--- a/src/meshoptimizer.h
+++ b/src/meshoptimizer.h
@@ -667,14 +667,13 @@ MESHOPTIMIZER_API size_t meshopt_buildMeshletsBound(size_t index_count, size_t m
  * Experimental: Meshlet builder with flexible cluster sizes
  * Splits the mesh into a set of meshlets, similarly to meshopt_buildMeshlets, but allows to specify minimum and maximum number of triangles per meshlet.
  * Clusters between min and max triangle counts are split when the cluster size would have exceeded the expected cluster size by more than split_factor.
- * Additionally, allows to switch to axis aligned clusters by setting cone_weight to a negative value.
  *
  * meshlets must contain enough space for all meshlets, worst case size can be computed with meshopt_buildMeshletsBound using min_triangles (not max!)
  * meshlet_vertices must contain enough space for all meshlets, worst case size is equal to max_meshlets * max_vertices
  * meshlet_triangles must contain enough space for all meshlets, worst case size is equal to max_meshlets * max_triangles * 3
  * vertex_positions should have float3 position in the first 12 bytes of each vertex
  * max_vertices, min_triangles and max_triangles must not exceed implementation limits (max_vertices <= 256, max_triangles <= 512; min_triangles <= max_triangles; both min_triangles and max_triangles must be divisible by 4)
- * cone_weight should be set to 0 when cone culling is not used, and a value between 0 and 1 otherwise to balance between cluster size and cone culling efficiency; additionally, cone_weight can be set to a negative value to prioritize axis aligned clusters (for raytracing) instead
+ * cone_weight should be set to 0 when cone culling is not used, and a value between 0 and 1 otherwise to balance between cluster size and cone culling efficiency
  * split_factor should be set to a non-negative value; when greater than 0, clusters that have large bounds may be split unless they are under the min_triangles threshold
  */
 MESHOPTIMIZER_EXPERIMENTAL size_t meshopt_buildMeshletsFlex(struct meshopt_Meshlet* meshlets, unsigned int* meshlet_vertices, unsigned char* meshlet_triangles, const unsigned int* indices, size_t index_count, const float* vertex_positions, size_t vertex_count, size_t vertex_positions_stride, size_t max_vertices, size_t min_triangles, size_t max_triangles, float cone_weight, float split_factor);


### PR DESCRIPTION
The original idea has been to change the heuristic to produce higher
quality splits for raytracing focused workflows. Unfortunately, this
doesn't *really* work: the impact on RT efficiency is, on average, net
negative, and in general this doesn't solve the problem very well even
for meshes where it is an improvement. Since a new algorithm,
buildMeshletsSpatial, solves that use case much better, we don't need
this feature anymore.

Since buildMeshletsFlex is experimental, this can be done without
additional versioning. If we need some sort of adjustment like this in
the future, we can still use negative cone_weight as a flag, it's just
that this specific heuristic does not work very well.

While buildMeshletsFlex itself is still useful as it provides better control
over spatial locality, and it is used by some applications, negative cone
weight is not used by any application I'm aware of so the removal should
hopefully go unnoticed.

*This contribution is sponsored by Valve.*