### PR TITLE
Validate output extension up front to prevent late failure and unnecessary work

### DIFF
--- a/gltf/gltfpack.cpp
+++ b/gltf/gltfpack.cpp
@@ -1010,6 +1010,15 @@ int gltfpack(const char* input, const char* output, const char* report, Settings
 	std::string iext = getExtension(input);
 	std::string oext = output ? getExtension(output) : "";
 
+	if (output)
+	{
+		if (oext != ".gltf" && oext != ".glb")
+		{
+			fprintf(stderr, "Error: unsupported output extension '%s' (expected .gltf or .glb)\n", oext.c_str());
+			return 4;
+		}
+	}
+
 	if (iext == ".gltf" || iext == ".glb")
 	{
 		const char* error = NULL;


### PR DESCRIPTION
This PR to solve #943  adds an early validation of the output filename extension in gltfpack(). 
If -o is provided and the extension isn’t .gltf or .glb, the tool now exits immediately with the same non-zero code used by the current late check. 

This avoids:
- running the full processing pipeline on an output that will be rejected,
- encoding/copying textures into the target directory,
- confusing partial side-effects followed by a late error.

Tests (-test) that call gltfpack(path, NULL, …) continue to work as before. 

Fixes #943.