### PR TITLE
 clusterizer: Iteratively cut KD branches to speed up traversal

### DIFF
--- a/src/clusterizer.cpp
+++ b/src/clusterizer.cpp
@@ -576,7 +576,7 @@ struct KDNode
 		unsigned int index;
 	};
 
-	// leaves: axis = 3, children = number of extra points after this one (0 if 'index' is the only point)
+	// leaves: axis = 3, children = number of points including this one
 	// branches: axis != 3, left subtree = skip 1, right subtree = skip 1+children
 	unsigned int axis : 2;
 	unsigned int children : 30;
@@ -612,7 +612,7 @@ static size_t kdtreeBuildLeaf(size_t offset, KDNode* nodes, size_t node_count, u
 
 	result.index = indices[0];
 	result.axis = 3;
-	result.children = unsigned(count - 1);
+	result.children = unsigned(count);
 
 	// all remaining points are stored in nodes immediately following the leaf
 	for (size_t i = 1; i < count; ++i)
@@ -671,6 +671,7 @@ static size_t kdtreeBuild(size_t offset, KDNode* nodes, size_t node_count, const
 	size_t next_offset = kdtreeBuild(offset + 1, nodes, node_count, points, stride, indices, middle, leaf_size);
 
 	// distance to the right subtree is represented explicitly
+	assert(next_offset - offset > 1);
 	result.children = unsigned(next_offset - offset - 1);
 
 	return kdtreeBuild(next_offset, nodes, node_count, points, stride, indices + middle, count - middle, leaf_size);
@@ -683,7 +684,7 @@ static void kdtreeNearest(KDNode* nodes, unsigned int root, const float* points,
 	if (node.axis == 3)
 	{
 		// leaf
-		for (unsigned int i = 0; i <= node.children; ++i)
+		for (unsigned int i = 0; i < node.children; ++i)
 		{
 			unsigned int index = nodes[root + i].index;
 


### PR DESCRIPTION
On meshes with many topologically disjoint clusters, kdtreeNearest
spends an increasing amount of time going over already emitted
triangles. To fix this, we can detect leaves that have all triangles
already emitted and flag them as inactive using children=0. This, then,
can be propagated to branch nodes using children=0 as a flag as well.

For branches, we do this *before* visiting either node. This makes
deactivation lazier than it strictly speaking needs to be, but it keeps
the existing recursive traversal structure where the second call is a
tail call, which on some models results in extra speedup.

Overall, while on some meshes this is neutral because the KD tree search
is used rarely, on meshes with more seams this can improve the meshlet
building time anywhere from 15% to 40%:

Mesh | Before | After | Speedup
--------|-----------|---------|------------
buddha.obj | 415 ms | 385 ms | 7%
bistro_exterior.obj | 1080 ms | 780 ms | 28%
bistro_interior.obj | 310 ms | 260 ms | 16%
powerplant.obj | 7400 ms | 4170 ms | 43%
rungholt.obj | 3800 ms | 2630 ms | 31%
sanMiguel.obj | 4200 ms | 2600 ms | 38%
thai_buddha.obj | 2750 ms | 2660 ms | 3%
Bistro GLB + lods | 1080 ms | 940 ms | 13%

*This contribution is sponsored by Valve.*