### PR TITLE
 vertexcodec: Encode using vertex version 1 by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,7 +356,7 @@ For optimal compression results, the values should be quantized to small integer
 For single-precision floating-point data, it's recommended to use `meshopt_quantizeFloat` to remove entropy from the lower bits of the mantissa; for best results, consider using 15 bits or 7 bits for extreme compression.
 For normal or tangent vectors, using octahedral encoding is recommended over three components as it reduces redundancy; similarly, consider using 10-12 bits per component instead of 16.
 
-When data is bit packed, using v1 vertex codec and specifying compression level 3 (`meshopt_encodeVertexBufferLevel` with level 3 and version 1) can improve the compression further by redistributing bits between components. Note that v1 vertex codec (`meshopt_encodeVertexVersion(1)`) is recommended regardless, as it improves compression ratios and decoding performance even absent bit packing.
+When data is bit packed, specifying compression level 3 (via `meshopt_encodeVertexBufferLevel`) can improve the compression further by redistributing bits between components.
 
 ### Index compression
 
@@ -424,7 +424,7 @@ The following guarantees on data compatibility are provided for point releases (
 - Data encoded with older versions of the library can always be decoded with newer versions;
 - Data encoded with newer versions of the library can be decoded with older versions, provided that encoding versions are set correctly; if binary stability of encoded data is important, use `meshopt_encodeVertexVersion` and `meshopt_encodeIndexVersion` to 'pin' the data versions (or `version` argument of `meshopt_encodeVertexBufferLevel`).
 
-By default, vertex data is encoded for format version 0 (compatible with meshoptimizer v0.8+), and index data is encoded for format version 1 (compatible with meshoptimizer v0.14+). When decoding the data, the decoder will automatically detect the version from the data header.
+By default, vertex data is encoded for format version 1 (compatible with meshoptimizer v0.23+), and index data is encoded for format version 1 (compatible with meshoptimizer v0.14+). When decoding the data, the decoder will automatically detect the version from the data header.
 
 ## Simplification
 

--- a/demo/main.cpp
+++ b/demo/main.cpp
@@ -1469,9 +1469,6 @@ int main(int argc, char** argv)
 {
 	void runTests();
 
-	meshopt_encodeVertexVersion(1);
-	meshopt_encodeIndexVersion(1);
-
 	if (argc == 1)
 	{
 		runTests();

--- a/js/README.md
+++ b/js/README.md
@@ -126,7 +126,7 @@ Note that the source is specified as byte arrays; for example, to quantize a pos
 
 When interleaved vertex data is compressed, `encodeVertexBuffer` can be called with the full size of a single interleaved vertex; however, when compressing deinterleaved data, note that `encodeVertexBuffer` should be called on each component individually if the strides of different streams are different.
 
-By default, `encodeVertexBuffer` uses v0 version of the encoding; this encoding is compatible with `EXT_meshopt_compression` glTF extension but results in lower compression ratios. For better compression, `encodeVertexBufferLevel` can be used to specify encoding version 1; the `level` parameter controls the compression ratio and can be set to 2 (default), 3 for higher compression, or 0/1 for lower. The higher the level, the better the compression ratio, but also the slower the encoding process. When version is set to 0, `level` does not have any effect and the encoding is equivalent to `encodeVertexBuffer`.
+By default, `encodeVertexBuffer` uses v1 version of the encoding; this encoding is *not* compatible with `EXT_meshopt_compression` glTF extension but results in higher compression ratios. To encode data compatible with `EXT_meshopt_compression`, use `encodeVertexBufferLevel` with version=0, or - preferably - `encodeGltfBuffer`, which defaults to v0 (but can also be used to encode v1 content by passing version=1).
 
 ## Simplifier
 

--- a/js/meshopt_encoder.js
+++ b/js/meshopt_encoder.js
@@ -23,7 +23,7 @@ var MeshoptEncoder = (function () {
 	var ready = WebAssembly.instantiate(unpack(wasm), {}).then(function (result) {
 		instance = result.instance;
 		instance.exports.__wasm_call_ctors();
-		instance.exports.meshopt_encodeVertexVersion(0);
+		instance.exports.meshopt_encodeVertexVersion(1);
 		instance.exports.meshopt_encodeIndexVersion(1);
 	});
 
@@ -162,7 +162,7 @@ var MeshoptEncoder = (function () {
 			assert(level >= 0 && level <= 3);
 			assert(version === undefined || version == 0 || version == 1);
 			var bound = instance.exports.meshopt_encodeVertexBufferBound(count, size);
-			return encode(instance.exports.meshopt_encodeVertexBufferLevel, bound, source, count, size, level, version || 0);
+			return encode(instance.exports.meshopt_encodeVertexBufferLevel, bound, source, count, size, level, version === undefined ? -1 : version);
 		},
 		encodeIndexBuffer: function (source, count, size) {
 			assert(size == 2 || size == 4);
@@ -177,14 +177,14 @@ var MeshoptEncoder = (function () {
 			var bound = instance.exports.meshopt_encodeIndexSequenceBound(count, maxindex(indices) + 1);
 			return encode(instance.exports.meshopt_encodeIndexSequence, bound, indices, count, 4);
 		},
-		encodeGltfBuffer: function (source, count, size, mode) {
+		encodeGltfBuffer: function (source, count, size, mode, version) {
 			var table = {
-				ATTRIBUTES: this.encodeVertexBuffer,
+				ATTRIBUTES: this.encodeVertexBufferLevel,
 				TRIANGLES: this.encodeIndexBuffer,
 				INDICES: this.encodeIndexSequence,
 			};
 			assert(table[mode]);
-			return table[mode](source, count, size);
+			return table[mode](source, count, size, /* level= */ 2, version === undefined ? 0 : version);
 		},
 		encodeFilterOct: function (source, count, stride, bits) {
 			assert(stride == 4 || stride == 8);

--- a/js/meshopt_encoder.module.d.ts
+++ b/js/meshopt_encoder.module.d.ts
@@ -14,7 +14,7 @@ export const MeshoptEncoder: {
 	encodeIndexBuffer: (source: Uint8Array, count: number, size: number) => Uint8Array;
 	encodeIndexSequence: (source: Uint8Array, count: number, size: number) => Uint8Array;
 
-	encodeGltfBuffer: (source: Uint8Array, count: number, size: number, mode: string) => Uint8Array;
+	encodeGltfBuffer: (source: Uint8Array, count: number, size: number, mode: string, version?: number) => Uint8Array;
 
 	encodeFilterOct: (source: Float32Array, count: number, stride: number, bits: number) => Uint8Array;
 	encodeFilterQuat: (source: Float32Array, count: number, stride: number, bits: number) => Uint8Array;

--- a/js/meshopt_encoder.module.js
+++ b/js/meshopt_encoder.module.js
@@ -22,7 +22,7 @@ var MeshoptEncoder = (function () {
 	var ready = WebAssembly.instantiate(unpack(wasm), {}).then(function (result) {
 		instance = result.instance;
 		instance.exports.__wasm_call_ctors();
-		instance.exports.meshopt_encodeVertexVersion(0);
+		instance.exports.meshopt_encodeVertexVersion(1);
 		instance.exports.meshopt_encodeIndexVersion(1);
 	});
 
@@ -161,7 +161,7 @@ var MeshoptEncoder = (function () {
 			assert(level >= 0 && level <= 3);
 			assert(version === undefined || version == 0 || version == 1);
 			var bound = instance.exports.meshopt_encodeVertexBufferBound(count, size);
-			return encode(instance.exports.meshopt_encodeVertexBufferLevel, bound, source, count, size, level, version || 0);
+			return encode(instance.exports.meshopt_encodeVertexBufferLevel, bound, source, count, size, level, version === undefined ? -1 : version);
 		},
 		encodeIndexBuffer: function (source, count, size) {
 			assert(size == 2 || size == 4);
@@ -176,14 +176,14 @@ var MeshoptEncoder = (function () {
 			var bound = instance.exports.meshopt_encodeIndexSequenceBound(count, maxindex(indices) + 1);
 			return encode(instance.exports.meshopt_encodeIndexSequence, bound, indices, count, 4);
 		},
-		encodeGltfBuffer: function (source, count, size, mode) {
+		encodeGltfBuffer: function (source, count, size, mode, version) {
 			var table = {
-				ATTRIBUTES: this.encodeVertexBuffer,
+				ATTRIBUTES: this.encodeVertexBufferLevel,
 				TRIANGLES: this.encodeIndexBuffer,
 				INDICES: this.encodeIndexSequence,
 			};
 			assert(table[mode]);
-			return table[mode](source, count, size);
+			return table[mode](source, count, size, /* level= */ 2, version === undefined ? 0 : version);
 		},
 		encodeFilterOct: function (source, count, stride, bits) {
 			assert(stride == 4 || stride == 8);

--- a/js/meshopt_encoder.test.js
+++ b/js/meshopt_encoder.test.js
@@ -46,7 +46,7 @@ var tests = {
 		}
 
 		var encoded = encoder.encodeVertexBuffer(data, 16, 4);
-		assert.equal(encoded[0], 0xa0);
+		assert.equal(encoded[0], 0xa1);
 
 		var decoded = new Uint8Array(16 * 4);
 		decoder.decodeVertexBuffer(decoded, 16, 4, encoded);
@@ -204,6 +204,29 @@ var tests = {
 		var decoded = new Uint32Array(data.length);
 		decoder.decodeGltfBuffer(bytes(decoded), data.length, 4, encoded, 'TRIANGLES');
 
+		assert.equal(encoded[0], 0xe1);
+		assert.deepEqual(decoded, data);
+	},
+
+	encodeGltfBufferAttribute: function () {
+		var data = new Uint32Array([0, 1, 2, 2, 1, 3, 4, 6, 5, 7, 8, 9]);
+
+		var encoded = encoder.encodeGltfBuffer(bytes(data), data.length, 4, 'ATTRIBUTES');
+		var decoded = new Uint32Array(data.length);
+		decoder.decodeGltfBuffer(bytes(decoded), data.length, 4, encoded, 'ATTRIBUTES');
+
+		assert.equal(encoded[0], 0xa0);
+		assert.deepEqual(decoded, data);
+	},
+
+	encodeGltfBufferAttributeV1: function () {
+		var data = new Uint32Array([0, 1, 2, 2, 1, 3, 4, 6, 5, 7, 8, 9]);
+
+		var encoded = encoder.encodeGltfBuffer(bytes(data), data.length, 4, 'ATTRIBUTES', 1);
+		var decoded = new Uint32Array(data.length);
+		decoder.decodeGltfBuffer(bytes(decoded), data.length, 4, encoded, 'ATTRIBUTES');
+
+		assert.equal(encoded[0], 0xa1);
 		assert.deepEqual(decoded, data);
 	},
 };

--- a/src/meshoptimizer.h
+++ b/src/meshoptimizer.h
@@ -251,7 +251,8 @@ MESHOPTIMIZER_API size_t meshopt_encodeIndexBuffer(unsigned char* buffer, size_t
 MESHOPTIMIZER_API size_t meshopt_encodeIndexBufferBound(size_t index_count, size_t vertex_count);
 
 /**
- * Set index encoder format version
+ * Set index encoder format version (defaults to 1)
+ *
  * version must specify the data format version to encode; valid values are 0 (decodable by all library versions) and 1 (decodable by 0.14+)
  */
 MESHOPTIMIZER_API void meshopt_encodeIndexVersion(int version);
@@ -303,6 +304,7 @@ MESHOPTIMIZER_API int meshopt_decodeIndexSequence(void* destination, size_t inde
  * For maximum efficiency the vertex buffer being encoded has to be quantized and optimized for locality of reference (cache/fetch) first.
  *
  * buffer must contain enough space for the encoded vertex buffer (use meshopt_encodeVertexBufferBound to compute worst case size)
+ * vertex_size must be a multiple of 4 (and <= 256)
  */
 MESHOPTIMIZER_API size_t meshopt_encodeVertexBuffer(unsigned char* buffer, size_t buffer_size, const void* vertices, size_t vertex_count, size_t vertex_size);
 MESHOPTIMIZER_API size_t meshopt_encodeVertexBufferBound(size_t vertex_count, size_t vertex_size);
@@ -313,13 +315,16 @@ MESHOPTIMIZER_API size_t meshopt_encodeVertexBufferBound(size_t vertex_count, si
  * For compression level to take effect, the vertex encoding version must be set to 1.
  * The default compression level implied by meshopt_encodeVertexBuffer is 2.
  *
+ * buffer must contain enough space for the encoded vertex buffer (use meshopt_encodeVertexBufferBound to compute worst case size)
+ * vertex_size must be a multiple of 4 (and <= 256)
  * level should be in the range [0, 3] with 0 being the fastest and 3 being the slowest and producing the best compression ratio.
  * version should be -1 to use the default version (specified via meshopt_encodeVertexVersion), or 0/1 to override the version; per above, level won't take effect if version is 0.
  */
 MESHOPTIMIZER_API size_t meshopt_encodeVertexBufferLevel(unsigned char* buffer, size_t buffer_size, const void* vertices, size_t vertex_count, size_t vertex_size, int level, int version);
 
 /**
- * Set vertex encoder format version
+ * Set vertex encoder format version (defaults to 1)
+ *
  * version must specify the data format version to encode; valid values are 0 (decodable by all library versions) and 1 (decodable by 0.23+)
  */
 MESHOPTIMIZER_API void meshopt_encodeVertexVersion(int version);
@@ -331,6 +336,7 @@ MESHOPTIMIZER_API void meshopt_encodeVertexVersion(int version);
  * The decoder is safe to use for untrusted input, but it may produce garbage data.
  *
  * destination must contain enough space for the resulting vertex buffer (vertex_count * vertex_size bytes)
+ * vertex_size must be a multiple of 4 (and <= 256)
  */
 MESHOPTIMIZER_API int meshopt_decodeVertexBuffer(void* destination, size_t vertex_count, size_t vertex_size, const unsigned char* buffer, size_t buffer_size);
 

--- a/src/vertexcodec.cpp
+++ b/src/vertexcodec.cpp
@@ -122,7 +122,7 @@ namespace meshopt
 
 const unsigned char kVertexHeader = 0xa0;
 
-static int gEncodeVertexVersion = 0;
+static int gEncodeVertexVersion = 1;
 const int kDecodeVertexVersion = 1;
 
 const size_t kVertexBlockSizeBytes = 8192;

--- a/tools/codectest.cpp
+++ b/tools/codectest.cpp
@@ -53,15 +53,13 @@ struct Stats
 	double count;
 	double size;
 
-	double ratio_v0;
-	double ratio_v1;
-	double ratio_v1_lz4;
-	double ratio_v1_zstd;
+	double ratio;
+	double ratio_lz4;
+	double ratio_zstd;
 
-	double total_v0;
-	double total_v1;
-	double total_v1_lz4;
-	double total_v1_zstd;
+	double total;
+	double total_lz4;
+	double total_zstd;
 };
 
 void testFile(FILE* file, size_t count, size_t stride, int level, Stats* stats = 0)
@@ -77,11 +75,8 @@ void testFile(FILE* file, size_t count, size_t stride, int level, Stats* stats =
 	int res = meshopt_decodeVertexBuffer(&decoded[0], count, stride, &input[0], input.size());
 	if (res != 0 && input.size() == decoded.size())
 	{
-		// some files are not encoded; encode them with v0 to let the rest of the flow proceed as is
+		// some files are not encoded
 		memcpy(decoded.data(), input.data(), decoded.size());
-		input.resize(meshopt_encodeVertexBufferBound(count, stride));
-		meshopt_encodeVertexVersion(0);
-		input.resize(meshopt_encodeVertexBuffer(input.data(), input.size(), decoded.data(), count, stride));
 	}
 	else if (res != 0)
 	{
@@ -90,23 +85,18 @@ void testFile(FILE* file, size_t count, size_t stride, int level, Stats* stats =
 	}
 
 	std::vector<unsigned char> output(meshopt_encodeVertexBufferBound(count, stride));
-	meshopt_encodeVertexVersion(1);
 	output.resize(meshopt_encodeVertexBufferLevel(output.data(), output.size(), decoded.data(), count, stride, level, -1));
 
 	printf(" raw %zu KB\t", decoded.size() / 1024);
-	printf(" v0 %.3f", double(input.size()) / double(decoded.size()));
-	printf(" v1 %.3f", double(output.size()) / double(decoded.size()));
+	printf(" vtx %.3f", double(output.size()) / double(decoded.size()));
 
 	if (stats)
 	{
 		stats->count++;
 		stats->size += double(decoded.size());
 
-		stats->total_v0 += double(input.size());
-		stats->total_v1 += double(output.size());
-
-		stats->ratio_v0 += log(double(input.size()) / double(decoded.size()));
-		stats->ratio_v1 += log(double(output.size()) / double(decoded.size()));
+		stats->total += double(output.size());
+		stats->ratio += log(double(output.size()) / double(decoded.size()));
 	}
 
 	if (stats && stats->testz)
@@ -116,17 +106,17 @@ void testFile(FILE* file, size_t count, size_t stride, int level, Stats* stats =
 		size_t decoded_zstd = measure_zstd(decoded);
 		size_t output_zstd = measure_zstd(output);
 
-		stats->total_v1_lz4 += output_lz4;
-		stats->total_v1_zstd += output_zstd;
+		stats->total_lz4 += output_lz4;
+		stats->total_zstd += output_zstd;
 
-		stats->ratio_v1_lz4 += log(double(output_lz4) / double(decoded.size()));
-		stats->ratio_v1_zstd += log(double(output_zstd) / double(decoded.size()));
+		stats->ratio_lz4 += log(double(output_lz4) / double(decoded.size()));
+		stats->ratio_zstd += log(double(output_zstd) / double(decoded.size()));
 
 		printf("\tlz4 %.3f", double(decoded_lz4) / double(decoded.size()));
-		printf(" v1+lz4 %.3f", double(output_lz4) / double(decoded.size()));
+		printf(" vtx+lz4 %.3f", double(output_lz4) / double(decoded.size()));
 
 		printf("\tzstd %.3f", double(decoded_zstd) / double(decoded.size()));
-		printf(" v1+zstd %.3f", double(output_zstd) / double(decoded.size()));
+		printf(" vtx+zstd %.3f", double(output_zstd) / double(decoded.size()));
 	}
 }
 
@@ -179,19 +169,17 @@ int main(int argc, char** argv)
 			testFile(argv[i], level < 0 ? 2 : level, &stats);
 
 		printf("---\n");
-		printf("%d files: v0 %.3f, v1 %.3f",
-		    int(stats.count),
-		    exp(stats.ratio_v0 / stats.count), exp(stats.ratio_v1 / stats.count));
+		printf("%d files: vtx %.3f", int(stats.count), exp(stats.ratio / stats.count));
 		if (stats.testz)
-			printf(", v1+lz4 %.3f, v1+zstd %.3f\n", exp(stats.ratio_v1_lz4 / stats.count), exp(stats.ratio_v1_zstd / stats.count));
+			printf(", vtx+lz4 %.3f, vtx+zstd %.3f\n", exp(stats.ratio_lz4 / stats.count), exp(stats.ratio_zstd / stats.count));
 		else
 			printf("\n");
 
-		printf("total: %d files, raw %.2f MB, v0 %.2f MB, v1 %.2f MB",
+		printf("total: %d files, raw %.2f MB, vtx %.2f MB",
 		    int(stats.count),
-		    stats.size / 1024 / 1024, stats.total_v0 / 1024 / 1024, stats.total_v1 / 1024 / 1024);
+		    stats.size / 1024 / 1024, stats.total / 1024 / 1024);
 		if (stats.testz)
-			printf(", v1+lz4 %.2f MB, v1+zstd %.2f MB\n", stats.total_v1_lz4 / 1024 / 1024, stats.total_v1_zstd / 1024 / 1024);
+			printf(", vtx+lz4 %.2f MB, vtx+zstd %.2f MB\n", stats.total_lz4 / 1024 / 1024, stats.total_zstd / 1024 / 1024);
 		else
 			printf("\n");
 
@@ -231,7 +219,6 @@ int main(int argc, char** argv)
 	}
 	else
 	{
-		meshopt_encodeVertexVersion(1);
 		size_t vertex_count = input.size() / stride;
 		std::vector<unsigned char> output(meshopt_encodeVertexBufferBound(vertex_count, stride));
 		size_t output_size = meshopt_encodeVertexBuffer(output.data(), output.size(), input.data(), vertex_count, stride);


### PR DESCRIPTION
`meshopt_encodeVertexBuffer` will now produce v1 streams instead of v0.
This can be overridden using `meshopt_encodeVertexVersion(0)` or by
passing `version=0` to `meshopt_encodeVertexBufferLevel`.

There should not be any reasons to use version 0 format other than for
compatibility with older builds of the applications that predate v1
support, or for glTF encoding. Applications that encode data for glTF
extension `EXT_meshopt_compression` should use one of the above methods
for changing the version to 0.

For JavaScript MeshoptEncoder interface, similarly, `encodeVertexBuffer*` now
default to version 1. The existing function `MeshoptEncoder.encodeGltfBuffer`
still encodes version 0 by default, but gains a `version` parameter to make it easy
to switch to version 1 - assuming this gets added to glTF specification in the future.

It looks like existing JS/TS codebases (based on GitHub search) use `encodeGltfBuffer`
already, which is great - there should not be any compatibility risk here.

*This contribution is sponsored by Valve.*