### PR TITLE
gltfpack: Refactor instance data handling

### DIFF
--- a/gltf/README.md
+++ b/gltf/README.md
@@ -100,6 +100,18 @@ Even if the source file does not use extensions, gltfpack may use some extension
 
 gltfpack does not support vendor-specific extensions or custom extensions, including ones defined in [Khronos glTF repository](https://github.com/KhronosGroup/glTF/tree/main/extensions/2.0/Vendor). Unknown extension nodes are discarded from the output.
 
+## Custom data
+
+glTF files may contain custom application-specific data stored outside of custom extensions. gltfpack has limited support for preserving this data.
+
+Unknown vertex or instance attributes are generally discarded. While it would be possible to preserve them in theory, many scene transformations and analyses require a full understanding of the attribute semantics - some attributes need to be transformed with the mesh transformation matrix, some need to be adjusted when meshes are merged, some influence how meshes are rendered, etc. However, gltfpack supports some specific attributes that are commonly used in the ecosystem:
+
+- Vertex attributes that store integer IDs with names `_ID`, `_BATCHID` or `_FEATURE_ID_n` are preserved as-is. These can be used to identify objects.
+
+Additional application-specific data can be stored via the glTF `extras` property. While extras (outside of `asset`) are discarded by default, using the `-ke` option preserves extras in materials, nodes, primitives and scenes.
+
+In addition to `asset` extras, gltfpack unconditionally preserves morph target names specified via the `targetNames` property inside `extras` on meshes.
+
 ## Building
 
 gltfpack can be built from source using CMake or Make. To build a full version of gltfpack that supports texture compression, CMake configuration needs to specify the path to https://github.com/zeux/basis_universal fork (branch gltfpack) via `MESHOPT_GLTFPACK_BASISU_PATH` variable, as well as libwebp path via `MESHOPT_GLTFPACK_LIBWEBP_PATH` variable:

--- a/gltf/gltfpack.cpp
+++ b/gltf/gltfpack.cpp
@@ -310,7 +310,7 @@ static void detachMesh(Mesh& mesh, cgltf_data* data, const std::vector<NodeInfo>
 		mesh.instances.resize(mesh.nodes.size());
 
 		for (size_t j = 0; j < mesh.nodes.size(); ++j)
-			cgltf_node_transform_world(mesh.nodes[j], mesh.instances[j].data);
+			cgltf_node_transform_world(mesh.nodes[j], mesh.instances[j].transform);
 
 		mesh.nodes.clear();
 		mesh.scene = scene;

--- a/gltf/gltfpack.h
+++ b/gltf/gltfpack.h
@@ -39,16 +39,16 @@ struct Stream
 	std::vector<Attr> data;
 };
 
-struct Transform
+struct Instance
 {
-	float data[16];
+	float transform[16];
 };
 
 struct Mesh
 {
 	int scene;
 	std::vector<cgltf_node*> nodes;
-	std::vector<Transform> instances;
+	std::vector<Instance> instances;
 
 	cgltf_material* material;
 	cgltf_skin* skin;
@@ -403,7 +403,7 @@ void writeMeshAttributes(std::string& json, std::vector<BufferView>& views, std:
 size_t writeMeshIndices(std::vector<BufferView>& views, std::string& json_accessors, size_t& accr_offset, const std::vector<unsigned int>& indices, cgltf_primitive_type type, const Settings& settings);
 void writeMeshGeometry(std::string& json, std::vector<BufferView>& views, std::string& json_accessors, size_t& accr_offset, const Mesh& mesh, const QuantizationPosition& qp, const QuantizationTexture& qt, const Settings& settings);
 size_t writeJointBindMatrices(std::vector<BufferView>& views, std::string& json_accessors, size_t& accr_offset, const cgltf_skin& skin, const QuantizationPosition& qp, const Settings& settings);
-size_t writeInstances(std::vector<BufferView>& views, std::string& json_accessors, size_t& accr_offset, const std::vector<Transform>& transforms, const QuantizationPosition& qp, const Settings& settings);
+size_t writeInstances(std::vector<BufferView>& views, std::string& json_accessors, size_t& accr_offset, const std::vector<Instance>& instances, const QuantizationPosition& qp, const Settings& settings);
 void writeMeshNode(std::string& json, size_t mesh_offset, cgltf_node* node, cgltf_skin* skin, cgltf_data* data, const QuantizationPosition* qp);
 void writeMeshNodeInstanced(std::string& json, size_t mesh_offset, size_t accr_offset);
 void writeSkin(std::string& json, const cgltf_skin& skin, size_t matrix_accr, const std::vector<NodeInfo>& nodes, cgltf_data* data);

--- a/gltf/mesh.cpp
+++ b/gltf/mesh.cpp
@@ -174,9 +174,9 @@ bool compareMeshNodes(const Mesh& lhs, const Mesh& rhs)
 	return true;
 }
 
-static bool compareTransforms(const Transform& lhs, const Transform& rhs)
+static bool compareInstances(const Instance& lhs, const Instance& rhs)
 {
-	return memcmp(&lhs, &rhs, sizeof(Transform)) == 0;
+	return memcmp(&lhs, &rhs, sizeof(Instance)) == 0;
 }
 
 static bool canMergeMeshNodes(cgltf_node* lhs, cgltf_node* rhs, const Settings& settings)
@@ -223,7 +223,7 @@ static bool canMergeMeshes(const Mesh& lhs, const Mesh& rhs, const Settings& set
 		return false;
 
 	for (size_t i = 0; i < lhs.instances.size(); ++i)
-		if (!compareTransforms(lhs.instances[i], rhs.instances[i]))
+		if (!compareInstances(lhs.instances[i], rhs.instances[i]))
 			return false;
 
 	if (lhs.material != rhs.material)
@@ -1208,8 +1208,8 @@ void computeMeshQuality(std::vector<Mesh>& meshes)
 			node_maxscale = std::max(node_maxscale, getScale(transform));
 		}
 
-		for (const Transform& xf : mesh.instances)
-			node_maxscale = std::max(node_maxscale, getScale(xf.data));
+		for (const Instance& xf : mesh.instances)
+			node_maxscale = std::max(node_maxscale, getScale(xf.transform));
 
 		scales[i] = node_maxscale == 0.f ? geometry_scale : node_maxscale * geometry_scale;
 		maxscale = std::max(maxscale, scales[i]);

--- a/gltf/parsegltf.cpp
+++ b/gltf/parsegltf.cpp
@@ -301,7 +301,7 @@ static void parseMeshesGltf(cgltf_data* data, std::vector<Mesh>& meshes, std::ve
 	}
 }
 
-static void parseMeshInstancesGltf(std::vector<Transform>& instances, cgltf_node* node, size_t ni)
+static void parseMeshInstancesGltf(std::vector<Instance>& instances, cgltf_node* node, size_t ni)
 {
 	cgltf_accessor* translation = NULL;
 	cgltf_accessor* rotation = NULL;
@@ -344,10 +344,10 @@ static void parseMeshInstancesGltf(std::vector<Transform>& instances, cgltf_node
 		if (scale)
 			cgltf_accessor_read_float(scale, i, instance.scale, 4);
 
-		Transform xf;
-		cgltf_node_transform_world(&instance, xf.data);
+		Instance obj = {};
+		cgltf_node_transform_world(&instance, obj.transform);
 
-		instances.push_back(xf);
+		instances.push_back(obj);
 	}
 }
 

--- a/gltf/parsegltf.cpp
+++ b/gltf/parsegltf.cpp
@@ -301,7 +301,7 @@ static void parseMeshesGltf(cgltf_data* data, std::vector<Mesh>& meshes, std::ve
 	}
 }
 
-static void parseMeshInstancesGltf(std::vector<Transform>& instances, cgltf_node* node)
+static void parseMeshInstancesGltf(std::vector<Transform>& instances, cgltf_node* node, size_t ni)
 {
 	cgltf_accessor* translation = NULL;
 	cgltf_accessor* rotation = NULL;
@@ -309,7 +309,7 @@ static void parseMeshInstancesGltf(std::vector<Transform>& instances, cgltf_node
 
 	for (size_t i = 0; i < node->mesh_gpu_instancing.attributes_count; ++i)
 	{
-		cgltf_attribute& attr = node->mesh_gpu_instancing.attributes[i];
+		const cgltf_attribute& attr = node->mesh_gpu_instancing.attributes[i];
 
 		if (strcmp(attr.name, "TRANSLATION") == 0 && attr.data->type == cgltf_type_vec3)
 			translation = attr.data;
@@ -317,6 +317,8 @@ static void parseMeshInstancesGltf(std::vector<Transform>& instances, cgltf_node
 			rotation = attr.data;
 		else if (strcmp(attr.name, "SCALE") == 0 && attr.data->type == cgltf_type_vec3)
 			scale = attr.data;
+		else
+			fprintf(stderr, "Warning: ignoring %s instance attribute %s in node %d\n", *attr.name == '_' ? "custom" : "unknown", attr.name, int(ni));
 	}
 
 	size_t count = node->mesh_gpu_instancing.attributes[0].data->count;
@@ -375,7 +377,7 @@ static void parseMeshNodesGltf(cgltf_data* data, std::vector<Mesh>& meshes, cons
 			if (node.has_mesh_gpu_instancing)
 			{
 				mesh->scene = 0; // we need to assign scene index since instances are attached to a scene; for now we assume 0
-				parseMeshInstancesGltf(mesh->instances, &node);
+				parseMeshInstancesGltf(mesh->instances, &node, i);
 			}
 			else
 			{

--- a/gltf/write.cpp
+++ b/gltf/write.cpp
@@ -1254,20 +1254,20 @@ static void writeInstanceData(std::vector<BufferView>& views, std::string& json_
 	writeAccessor(json_accessors, view, offset, format.type, format.component_type, format.normalized, data.size());
 }
 
-size_t writeInstances(std::vector<BufferView>& views, std::string& json_accessors, size_t& accr_offset, const std::vector<Transform>& transforms, const QuantizationPosition& qp, const Settings& settings)
+size_t writeInstances(std::vector<BufferView>& views, std::string& json_accessors, size_t& accr_offset, const std::vector<Instance>& instances, const QuantizationPosition& qp, const Settings& settings)
 {
 	std::vector<Attr> position, rotation, scale;
-	position.resize(transforms.size());
-	rotation.resize(transforms.size());
-	scale.resize(transforms.size());
+	position.resize(instances.size());
+	rotation.resize(instances.size());
+	scale.resize(instances.size());
 
-	for (size_t i = 0; i < transforms.size(); ++i)
+	for (size_t i = 0; i < instances.size(); ++i)
 	{
-		decomposeTransform(position[i].f, rotation[i].f, scale[i].f, transforms[i].data);
+		decomposeTransform(position[i].f, rotation[i].f, scale[i].f, instances[i].transform);
 
 		if (settings.quantize && !settings.pos_float)
 		{
-			const float* transform = transforms[i].data;
+			const float* transform = instances[i].transform;
 
 			// pos_offset has to be applied first, thus it results in an offset rotated by the instance matrix
 			position[i].f[0] += qp.offset[0] * transform[0] + qp.offset[1] * transform[4] + qp.offset[2] * transform[8];


### PR DESCRIPTION
This change extracts unrelated commits from #950, so that that PR can be smaller. This also documents handling of custom glTF data that's not covered by extensions.