### PR TITLE
simplifier: Improve performance of SimplifySparse on very sparse subsets

### DIFF
--- a/src/simplifier.cpp
+++ b/src/simplifier.cpp
@@ -243,14 +243,18 @@ static unsigned int* buildSparseRemap(unsigned int* indices, size_t index_count,
 {
 	// use a bit set to compute the precise number of unique vertices
 	unsigned char* filter = allocator.allocate<unsigned char>((vertex_count + 7) / 8);
-	memset(filter, 0, (vertex_count + 7) / 8);
+
+	for (size_t i = 0; i < index_count; ++i)
+	{
+		unsigned int index = indices[i];
+		assert(index < vertex_count);
+		filter[index / 8] = 0;
+	}
 
 	size_t unique = 0;
 	for (size_t i = 0; i < index_count; ++i)
 	{
 		unsigned int index = indices[i];
-		assert(index < vertex_count);
-
 		unique += (filter[index / 8] & (1 << (index % 8))) == 0;
 		filter[index / 8] |= 1 << (index % 8);
 	}
@@ -269,7 +273,6 @@ static unsigned int* buildSparseRemap(unsigned int* indices, size_t index_count,
 	for (size_t i = 0; i < index_count; ++i)
 	{
 		unsigned int index = indices[i];
-
 		unsigned int* entry = hashLookup2(revremap, revremap_size, hasher, index, ~0u);
 
 		if (*entry == ~0u)


### PR DESCRIPTION
In some rare cases of extremely large meshes, e.g. 90M vertices, even setting a bit per vertex can limit simplification throughput considerably when simplifying individual clusters in a larger subdivision.

There is no need to zero out the entire array: we can instead just clear the bit groups that are referenced by the indices. This should not change the performance of sparse simplification in general, as the bit setting loop is more expensive than a sparse clear.

The uncached allocation of a large bit array may still be an issue as we'd need to pagefault on the indices that *are* referenced - however, this can be fixed by the caller by providing a per-thread arena that's sufficiently large to accomodate the bitset.

*This contribution is sponsored by Valve.*