### PR TITLE
demo: Rework clustered LOD code

### DIFF
--- a/demo/clusterlod.h
+++ b/demo/clusterlod.h
@@ -127,7 +127,7 @@ struct clodGroup
 
 // gets called for each group in sequence
 // returned value gets saved for clusters emitted from this group (clodCluster::refined)
-typedef int (*clodOutput)(void* context, clodGroup group, const clodCluster* clusters, size_t cluster_count);
+typedef int (*clodOutput)(void* output_context, clodGroup group, const clodCluster* clusters, size_t cluster_count);
 
 #ifdef __cplusplus
 extern "C"
@@ -150,7 +150,10 @@ size_t clodBuild(clodConfig config, clodMesh mesh, Output output)
 {
 	struct Call
 	{
-		static int output(void* context, clodGroup group, const clodCluster* clusters, size_t cluster_count) { return (*static_cast<Output*>(context))(group, clusters, cluster_count); }
+		static int output(void* output_context, clodGroup group, const clodCluster* clusters, size_t cluster_count)
+		{
+			return (*static_cast<Output*>(output_context))(group, clusters, cluster_count);
+		}
 	};
 
 	return clodBuild(config, mesh, &output, &Call::output);
@@ -249,7 +252,7 @@ static std::vector<Cluster> clusterize(const clodConfig& config, const clodMesh&
 
 		clusters[i].vertices = meshlet.vertex_count;
 
-		// note: for now we discard meshlet-local indices; they are valuable for shader code so in the future we should bring them back
+		// note: we discard meshlet-local indices; they can be recovered by the caller using meshopt_buildMeshletsScan
 		clusters[i].indices.resize(meshlet.triangle_count * 3);
 		for (size_t j = 0; j < meshlet.triangle_count * 3; ++j)
 			clusters[i].indices[j] = meshlet_vertices[meshlet.vertex_offset + meshlet_triangles[meshlet.triangle_offset + j]];

--- a/demo/main.cpp
+++ b/demo/main.cpp
@@ -617,7 +617,7 @@ void simplifyClusters(const Mesh& mesh, float threshold = 0.2f)
 		size_t group_triangles = (lod.size() - group_offset) / 3;
 
 		// simplify the group, preserving the border vertices
-		// note: this technically also locks the exterior border; a full mesh analysis (see nanite.cpp / lockBoundary) would work better for some meshes
+		// note: this technically also locks the exterior border; a full mesh analysis (see clusterlod.h / lockBoundary) would work better for some meshes
 		unsigned int options = meshopt_SimplifyLockBorder | meshopt_SimplifySparse | meshopt_SimplifyErrorAbsolute;
 
 		float group_target_error = 1e-2f * scale;
@@ -634,7 +634,7 @@ void simplifyClusters(const Mesh& mesh, float threshold = 0.2f)
 	double end = timestamp();
 
 	printf("%-9s: %d triangles => %d triangles (%.2f%% deviation) in %.2f msec, clusterized in %.2f msec, partitioned in %.2f msec (%d clusters in %d groups)\n",
-	    "SimplifyN", // N for Nanite
+	    "SimplifyG",
 	    int(mesh.indices.size() / 3), int(lod.size() / 3),
 	    error / scale * 100,
 	    (end - parttime) * 1000, (middle - start) * 1000, (parttime - middle) * 1000,

--- a/demo/nanite.cpp
+++ b/demo/nanite.cpp
@@ -107,7 +107,7 @@ void nanite(const std::vector<Vertex>& vertices, const std::vector<unsigned int>
 	float znear = 1e-2f;
 	float proj = 1.f / tanf(fovy * 3.1415926f / 180.f * 0.5f);
 
-	size_t lowest = clodBuild(config, mesh, [&](clodGroup group, const clodCluster* clusters, size_t cluster_count) -> int { // clang-format!
+	clodBuild(config, mesh, [&](clodGroup group, const clodCluster* clusters, size_t cluster_count) -> int { // clang-format!
 		if (stats.size() <= size_t(group.depth))
 			stats.push_back({});
 
@@ -153,9 +153,15 @@ void nanite(const std::vector<Vertex>& vertices, const std::vector<unsigned int>
 
 	std::vector<int> used(vertices.size());
 
+	size_t lowest_clusters = 0;
+	size_t lowest_triangles = 0;
+
 	for (size_t i = 0; i < stats.size(); ++i)
 	{
 		Stats& level = stats[i];
+
+		lowest_clusters += level.stuck_clusters;
+		lowest_triangles += level.stuck_triangles;
 
 		size_t connected = 0;
 		for (const auto& cluster : level.indices)
@@ -173,12 +179,12 @@ void nanite(const std::vector<Vertex>& vertices, const std::vector<unsigned int>
 		    double(level.clusters) / double(level.groups),
 		    saho, level.radius * inv_clusters,
 		    int(level.triangles));
-		if (level.stuck_clusters)
+		if (level.stuck_clusters && level.clusters > 1)
 			printf("; stuck %d clusters (%d triangles)", int(level.stuck_clusters), int(level.stuck_triangles));
 		printf("\n");
 	}
 
-	printf("lod %d: (lowest) %d clusters, %d triangles\n", int(stats.size() - 1), int(stats.back().clusters), int(lowest));
+	printf("lowest lod: %d clusters, %d triangles\n", int(lowest_clusters), int(lowest_triangles));
 
 	if (cut_level >= -1)
 	{

--- a/demo/nanite.cpp
+++ b/demo/nanite.cpp
@@ -10,6 +10,9 @@
 #include <algorithm>
 #include <vector>
 
+#define CLUSTERLOD_IMPLEMENTATION
+#include "clusterlod.h"
+
 struct Vertex
 {
 	float px, py, pz;
@@ -17,257 +20,20 @@ struct Vertex
 	float tx, ty;
 };
 
-struct LODBounds
-{
-	float center[3];
-	float radius;
-	float error;
-};
-
-struct Cluster
-{
-	std::vector<unsigned int> indices;
-
-	LODBounds self;
-	LODBounds parent;
-};
-
-const size_t kClusterSize = 128;
-const size_t kClusterVertices = 192;
-const size_t kGroupSize = 16;
-
-const bool kUseLocks = true;
-const bool kUseNormals = true;
-const bool kUseRetry = true;
-const bool kOptimizeMeshlets = true; // raster-specific
-
-const bool kClusterSpatial = false;
-const float kClusterSplitFactor = 2.0f;
-const float kClusterFillWeight = 0.75f;
-
-const bool kSimplifyPermissive = true;
-const bool kSimplifyFallbackPermissive = false;
-const bool kSimplifyFallbackSloppy = true;
-const float kSimplifySloppyErrorFactor = 2.0f;
-const float kSimplifyRatio = 0.5f;
-const float kSimplifyThreshold = 0.85f;
-
-static LODBounds bounds(const std::vector<Vertex>& vertices, const std::vector<unsigned int>& indices, float error)
-{
-	meshopt_Bounds bounds = meshopt_computeClusterBounds(&indices[0], indices.size(), &vertices[0].px, vertices.size(), sizeof(Vertex));
-
-	LODBounds result;
-	result.center[0] = bounds.center[0];
-	result.center[1] = bounds.center[1];
-	result.center[2] = bounds.center[2];
-	result.radius = bounds.radius;
-	result.error = error;
-	return result;
-}
-
-static LODBounds boundsMerge(const std::vector<Cluster>& clusters, const std::vector<int>& group)
-{
-	std::vector<LODBounds> bounds(group.size());
-	for (size_t j = 0; j < group.size(); ++j)
-		bounds[j] = clusters[group[j]].self;
-
-	meshopt_Bounds merged = meshopt_computeSphereBounds(&bounds[0].center[0], bounds.size(), sizeof(LODBounds), &bounds[0].radius, sizeof(LODBounds));
-
-	LODBounds result = {};
-	result.center[0] = merged.center[0];
-	result.center[1] = merged.center[1];
-	result.center[2] = merged.center[2];
-	result.radius = merged.radius;
-
-	// merged bounds error must be conservative wrt cluster errors
-	result.error = 0.f;
-	for (size_t j = 0; j < group.size(); ++j)
-		result.error = std::max(result.error, clusters[group[j]].self.error);
-
-	return result;
-}
-
 // computes approximate (perspective) projection error of a cluster in screen space (0..1; multiply by screen height to get pixels)
 // camera_proj is projection[1][1], or cot(fovy/2); camera_znear is *positive* near plane distance
 // for DAG cut to be valid, boundsError must be monotonic: it must return a larger error for parent cluster
 // for simplicity, we ignore perspective distortion and use rotationally invariant projection size estimation
-static float boundsError(const LODBounds& bounds, float camera_x, float camera_y, float camera_z, float camera_proj, float camera_znear)
+static float boundsError(const clodBounds& bounds, float camera_x, float camera_y, float camera_z, float camera_proj, float camera_znear)
 {
 	float dx = bounds.center[0] - camera_x, dy = bounds.center[1] - camera_y, dz = bounds.center[2] - camera_z;
 	float d = sqrtf(dx * dx + dy * dy + dz * dz) - bounds.radius;
 	return bounds.error / (d > camera_znear ? d : camera_znear) * (camera_proj * 0.5f);
 }
 
-static std::vector<Cluster> clusterize(const std::vector<Vertex>& vertices, const std::vector<unsigned int>& indices)
-{
-	const size_t max_vertices = kClusterVertices;
-	const size_t max_triangles = kClusterSize;
-	const size_t min_triangles = kClusterSize / 3;
-
-	size_t max_meshlets = meshopt_buildMeshletsBound(indices.size(), max_vertices, min_triangles);
-
-	std::vector<meshopt_Meshlet> meshlets(max_meshlets);
-	std::vector<unsigned int> meshlet_vertices(indices.size());
-	std::vector<unsigned char> meshlet_triangles(indices.size());
-
-	if (kClusterSpatial)
-		meshlets.resize(meshopt_buildMeshletsSpatial(&meshlets[0], &meshlet_vertices[0], &meshlet_triangles[0], &indices[0], indices.size(), &vertices[0].px, vertices.size(), sizeof(Vertex), max_vertices, min_triangles, max_triangles, kClusterFillWeight));
-	else
-		meshlets.resize(meshopt_buildMeshletsFlex(&meshlets[0], &meshlet_vertices[0], &meshlet_triangles[0], &indices[0], indices.size(), &vertices[0].px, vertices.size(), sizeof(Vertex), max_vertices, min_triangles, max_triangles, 0.f, kClusterSplitFactor));
-
-	std::vector<Cluster> clusters(meshlets.size());
-
-	for (size_t i = 0; i < meshlets.size(); ++i)
-	{
-		const meshopt_Meshlet& meshlet = meshlets[i];
-
-		if (kOptimizeMeshlets)
-			meshopt_optimizeMeshlet(&meshlet_vertices[meshlet.vertex_offset], &meshlet_triangles[meshlet.triangle_offset], meshlet.triangle_count, meshlet.vertex_count);
-
-		// note: for now we discard meshlet-local indices; they are valuable for shader code so in the future we should bring them back
-		clusters[i].indices.resize(meshlet.triangle_count * 3);
-		for (size_t j = 0; j < meshlet.triangle_count * 3; ++j)
-			clusters[i].indices[j] = meshlet_vertices[meshlet.vertex_offset + meshlet_triangles[meshlet.triangle_offset + j]];
-
-		clusters[i].parent.error = FLT_MAX;
-	}
-
-	return clusters;
-}
-
-static std::vector<std::vector<int> > partition(const std::vector<Cluster>& clusters, const std::vector<int>& pending, const std::vector<unsigned int>& remap, const std::vector<Vertex>& vertices)
-{
-	if (pending.size() <= kGroupSize)
-		return {pending};
-
-	std::vector<unsigned int> cluster_indices;
-	std::vector<unsigned int> cluster_counts(pending.size());
-
-	size_t total_index_count = 0;
-	for (size_t i = 0; i < pending.size(); ++i)
-		total_index_count += clusters[pending[i]].indices.size();
-
-	cluster_indices.reserve(total_index_count);
-
-	for (size_t i = 0; i < pending.size(); ++i)
-	{
-		const Cluster& cluster = clusters[pending[i]];
-
-		cluster_counts[i] = unsigned(cluster.indices.size());
-
-		for (size_t j = 0; j < cluster.indices.size(); ++j)
-			cluster_indices.push_back(remap[cluster.indices[j]]);
-	}
-
-	std::vector<unsigned int> cluster_part(pending.size());
-	size_t partition_count = meshopt_partitionClusters(&cluster_part[0], &cluster_indices[0], cluster_indices.size(), &cluster_counts[0], cluster_counts.size(), &vertices[0].px, remap.size(), sizeof(Vertex), kGroupSize);
-
-	std::vector<std::vector<int> > partitions(partition_count);
-	for (size_t i = 0; i < partition_count; ++i)
-		partitions[i].reserve(kGroupSize + kGroupSize / 2);
-
-	for (size_t i = 0; i < pending.size(); ++i)
-		partitions[cluster_part[i]].push_back(pending[i]);
-
-	return partitions;
-}
-
-static void lockBoundary(std::vector<unsigned char>& locks, const std::vector<std::vector<int> >& groups, const std::vector<Cluster>& clusters, const std::vector<unsigned int>& remap)
-{
-	// for each remapped vertex, keep track of index of the group it's in (or -2 if it's in multiple groups)
-	std::vector<int> groupmap(locks.size(), -1);
-
-	for (size_t i = 0; i < groups.size(); ++i)
-		for (size_t j = 0; j < groups[i].size(); ++j)
-		{
-			const Cluster& cluster = clusters[groups[i][j]];
-
-			for (size_t k = 0; k < cluster.indices.size(); ++k)
-			{
-				unsigned int v = cluster.indices[k];
-				unsigned int r = remap[v];
-
-				if (groupmap[r] == -1 || groupmap[r] == int(i))
-					groupmap[r] = int(i);
-				else
-					groupmap[r] = -2;
-			}
-		}
-
-	for (size_t i = 0; i < locks.size(); ++i)
-	{
-		unsigned int r = remap[i];
-
-		// keep protect bit if set
-		locks[i] = (groupmap[r] == -2) | (locks[i] & meshopt_SimplifyVertex_Protect);
-	}
-}
-
-struct SloppyVertex
-{
-	float x, y, z;
-	unsigned int id;
-};
-
-static void simplifyFallback(std::vector<unsigned int>& lod, const std::vector<Vertex>& vertices, const std::vector<unsigned int>& indices, const std::vector<unsigned char>* locks, size_t target_count, float* error)
-{
-	std::vector<SloppyVertex> subset(indices.size());
-	std::vector<unsigned char> subset_locks(indices.size());
-
-	lod.resize(indices.size());
-
-	// deindex the mesh subset to avoid calling simplifySloppy on the entire vertex buffer (which is prohibitively expensive without sparsity)
-	for (size_t i = 0; i < indices.size(); ++i)
-	{
-		unsigned int v = indices[i];
-		assert(v < vertices.size());
-
-		subset[i].x = vertices[v].px;
-		subset[i].y = vertices[v].py;
-		subset[i].z = vertices[v].pz;
-		subset[i].id = v;
-
-		if (locks)
-			subset_locks[i] = (*locks)[v];
-		lod[i] = unsigned(i);
-	}
-
-	lod.resize(meshopt_simplifySloppy(&lod[0], &lod[0], lod.size(), &subset[0].x, subset.size(), sizeof(SloppyVertex), subset_locks.data(), target_count, FLT_MAX, error));
-
-	// convert error to absolute and scale it up to account for extra visual quality degradation
-	if (error)
-		*error *= meshopt_simplifyScale(&subset[0].x, subset.size(), sizeof(SloppyVertex)) * kSimplifySloppyErrorFactor;
-
-	// restore original vertex indices
-	for (size_t i = 0; i < lod.size(); ++i)
-		lod[i] = subset[lod[i]].id;
-}
-
-static std::vector<unsigned int> simplify(const std::vector<Vertex>& vertices, const std::vector<unsigned int>& indices, const std::vector<unsigned char>* locks, size_t target_count, float* error = NULL)
-{
-	assert(target_count <= indices.size());
-
-	std::vector<unsigned int> lod(indices.size());
-
-	unsigned int options = meshopt_SimplifySparse | meshopt_SimplifyErrorAbsolute | (locks ? 0 : meshopt_SimplifyLockBorder) | (kSimplifyPermissive ? meshopt_SimplifyPermissive : 0);
-
-	float normal_weight = kUseNormals ? 0.5f : 0.0f;
-	float normal_weights[3] = {normal_weight, normal_weight, normal_weight};
-
-	lod.resize(meshopt_simplifyWithAttributes(&lod[0], &indices[0], indices.size(), &vertices[0].px, vertices.size(), sizeof(Vertex), &vertices[0].nx, sizeof(Vertex), normal_weights, 3, locks ? &(*locks)[0] : NULL, target_count, FLT_MAX, options, error));
-
-	if (lod.size() > target_count && !kSimplifyPermissive && kSimplifyFallbackPermissive)
-		lod.resize(meshopt_simplifyWithAttributes(&lod[0], &indices[0], indices.size(), &vertices[0].px, vertices.size(), sizeof(Vertex), &vertices[0].nx, sizeof(Vertex), normal_weights, 3, locks ? &(*locks)[0] : NULL, target_count, FLT_MAX, options | meshopt_SimplifyPermissive, error));
-
-	// while it's possible to call simplifySloppy directly, it doesn't support sparsity or absolute error, so we need to do some extra work
-	if (lod.size() > target_count && kSimplifyFallbackSloppy)
-		simplifyFallback(lod, vertices, indices, locks, target_count, error);
-
-	return lod;
-}
-
-static float sahOverhead(const std::vector<Cluster>& queue, const std::vector<std::vector<int> >& groups, const std::vector<Vertex>& vertices);
-static void dumpMetrics(int level, const std::vector<Cluster>& queue, const std::vector<std::vector<int> >& groups, const std::vector<unsigned int>& remap, const std::vector<unsigned char>& locks, const std::vector<int>& retry, float saho);
+static int measureComponents(std::vector<int>& parents, const std::vector<unsigned int>& indices, const std::vector<unsigned int>& remap);
+static size_t measureBoundary(std::vector<int>& used, const std::vector<std::vector<unsigned int> >& clusters, const std::vector<unsigned int>& remap);
+static float sahOverhead(const std::vector<std::vector<unsigned int> >& clusters, const std::vector<Vertex>& vertices);
 
 void dumpObj(const std::vector<Vertex>& vertices, const std::vector<unsigned int>& indices, bool recomputeNormals = false);
 void dumpObj(const char* section, const std::vector<unsigned int>& indices);
@@ -276,133 +42,56 @@ void nanite(const std::vector<Vertex>& vertices, const std::vector<unsigned int>
 {
 #ifdef _MSC_VER
 	static const char* dump = NULL; // tired of C4996
+	static const char* clrt = NULL;
 #else
 	static const char* dump = getenv("DUMP");
+	static const char* clrt = getenv("CLRT");
 #endif
 
-	int depth = 0;
-	std::vector<unsigned char> locks(vertices.size());
+	clodConfig config = clodDefaultConfig(/*max_triangles=*/128);
 
-	// for cluster connectivity, we need a position-only remap that maps vertices with the same position to the same index
-	std::vector<unsigned int> remap(vertices.size());
-	meshopt_generatePositionRemap(&remap[0], &vertices[0].px, vertices.size(), sizeof(Vertex));
-
-	// set up protect bits on UV seams for permissive mode
-	if (kUseLocks)
-		for (size_t i = 0; i < vertices.size(); ++i)
-		{
-			unsigned int r = remap[i]; // canonical vertex with the same position
-
-			if (r != i && (vertices[r].tx != vertices[i].tx || vertices[r].ty != vertices[i].ty))
-				locks[i] |= meshopt_SimplifyVertex_Protect;
-		}
-
-	// initial clusterization splits the original mesh
-	std::vector<Cluster> clusters = clusterize(vertices, indices);
-	for (size_t i = 0; i < clusters.size(); ++i)
-		clusters[i].self = bounds(vertices, clusters[i].indices, 0.f);
-
-	std::vector<int> pending(clusters.size());
-	for (size_t i = 0; i < clusters.size(); ++i)
-		pending[i] = int(i);
-
-	// merge and simplify clusters until we can't merge anymore
-	while (pending.size() > 1)
+	if (clrt)
 	{
-		std::vector<std::vector<int> > groups = partition(clusters, pending, remap, vertices);
-
-		if (kUseLocks)
-			lockBoundary(locks, groups, clusters, remap);
-
-		pending.clear();
-
-		std::vector<int> retry;
-
-		size_t triangles = 0;
-		size_t stuck_triangles = 0;
-
-		if (dump && depth == atoi(dump))
-			dumpObj(vertices, std::vector<unsigned int>());
-
-		// every group needs to be simplified now
-		for (size_t i = 0; i < groups.size(); ++i)
-		{
-			std::vector<unsigned int> merged;
-			merged.reserve(kClusterSize * groups[i].size());
-			for (size_t j = 0; j < groups[i].size(); ++j)
-				merged.insert(merged.end(), clusters[groups[i][j]].indices.begin(), clusters[groups[i][j]].indices.end());
-
-			if (dump && depth == atoi(dump))
-			{
-				for (size_t j = 0; j < groups[i].size(); ++j)
-					dumpObj("cluster", clusters[groups[i][j]].indices);
-
-				dumpObj("group", merged);
-			}
-
-			// aim to reduce group size in half
-			size_t target_size = size_t(float(merged.size() / 3) * kSimplifyRatio) * 3;
-
-			float error = 0.f;
-			std::vector<unsigned int> simplified = simplify(vertices, merged, kUseLocks ? &locks : NULL, target_size, &error);
-			if (simplified.size() > merged.size() * kSimplifyThreshold)
-			{
-				stuck_triangles += merged.size() / 3;
-				for (size_t j = 0; j < groups[i].size(); ++j)
-					retry.push_back(groups[i][j]);
-				continue; // simplification is stuck; abandon the merge
-			}
-
-			// enforce bounds and error monotonicity
-			// note: it is incorrect to use the precise bounds of the merged or simplified mesh, because this may violate monotonicity
-			LODBounds groupb = boundsMerge(clusters, groups[i]);
-			groupb.error += error; // this may overestimate the error, but we are starting from the simplified mesh so this is a little more correct
-
-			std::vector<Cluster> split = clusterize(vertices, simplified);
-
-			// update parent bounds and error for all clusters in the group
-			// note that all clusters in the group need to switch simultaneously so they have the same bounds
-			for (size_t j = 0; j < groups[i].size(); ++j)
-			{
-				assert(clusters[groups[i][j]].parent.error == FLT_MAX);
-				clusters[groups[i][j]].parent = groupb;
-			}
-
-			for (size_t j = 0; j < split.size(); ++j)
-			{
-				// update self bounds for all new clusters to be equal to the group bounds as well
-				// this is required for DAG error monotonicity; each cluster should be able to independently arrive at the same binary decision "is my error good enough"
-				split[j].self = groupb;
-
-				triangles += split[j].indices.size() / 3;
-
-				clusters.push_back(std::move(split[j]));
-				pending.push_back(int(clusters.size()) - 1);
-			}
-		}
-
-		dumpMetrics(depth, clusters, groups, remap, locks, retry, kClusterSpatial ? sahOverhead(clusters, groups, vertices) : 0.f);
-		depth++;
-
-		if (kUseRetry)
-		{
-			if (triangles < stuck_triangles / 3)
-				break;
-
-			pending.insert(pending.end(), retry.begin(), retry.end());
-		}
+		config = clodDefaultConfigRT(config.max_triangles);
+		config.cluster_fill_weight = float(atof(clrt));
 	}
 
-	size_t lowest_triangles = 0;
-	size_t lowest_clusters = 0;
-	for (size_t i = 0; i < clusters.size(); ++i)
-		if (clusters[i].parent.error == FLT_MAX)
-		{
-			lowest_triangles += clusters[i].indices.size() / 3;
-			lowest_clusters++;
-		}
+	const float attribute_weights[3] = {0.5f, 0.5f, 0.5f};
 
-	printf("lod %d: (lowest) %d clusters, %d triangles\n", depth, int(lowest_clusters), int(lowest_triangles));
+	clodMesh mesh = {};
+	mesh.indices = indices.data();
+	mesh.index_count = indices.size();
+	mesh.vertex_count = vertices.size();
+	mesh.vertex_positions = &vertices[0].px;
+	mesh.vertex_positions_stride = sizeof(Vertex);
+	mesh.vertex_attributes = &vertices[0].nx;
+	mesh.vertex_attributes_stride = sizeof(Vertex);
+	mesh.attribute_weights = attribute_weights;
+	mesh.attribute_count = sizeof(attribute_weights) / sizeof(attribute_weights[0]);
+	mesh.attribute_protect_mask = (1 << 3) | (1 << 4); // protect UV seams, maps to Vertex::tx/ty
+
+	struct Stats
+	{
+		size_t groups;
+		size_t clusters;
+		size_t triangles;
+		size_t vertices;
+
+		size_t full_clusters;
+
+		size_t stuck_clusters;
+		size_t stuck_triangles;
+
+		double radius;
+
+		std::vector<std::vector<unsigned int> > indices; // for detailed connectivity analysis
+	};
+
+	std::vector<Stats> stats;
+	std::vector<clodBounds> groups;
+
+	std::vector<std::vector<unsigned int> > cut;
+	int cut_level = dump ? atoi(dump) : -2;
 
 	// for testing purposes, we can compute a DAG cut from a given viewpoint and dump it as an OBJ
 	float maxx = 0.f, maxy = 0.f, maxz = 0.f;
@@ -418,20 +107,94 @@ void nanite(const std::vector<Vertex>& vertices, const std::vector<unsigned int>
 	float znear = 1e-2f;
 	float proj = 1.f / tanf(fovy * 3.1415926f / 180.f * 0.5f);
 
-	std::vector<unsigned int> cut;
-	for (size_t i = 0; i < clusters.size(); ++i)
-		if (boundsError(clusters[i].self, maxx, maxy, maxz, proj, znear) <= threshold && boundsError(clusters[i].parent, maxx, maxy, maxz, proj, znear) > threshold)
-			cut.insert(cut.end(), clusters[i].indices.begin(), clusters[i].indices.end());
+	size_t lowest = clodBuild(config, mesh, [&](clodGroup group, const clodCluster* clusters, size_t cluster_count) -> int { // clang-format!
+		if (stats.size() <= size_t(group.depth))
+			stats.push_back({});
 
-	printf("cut (%.3f): %d triangles\n", threshold, int(cut.size() / 3));
+		Stats& level = stats[group.depth];
 
-	if (dump && -1 == atoi(dump))
+		level.groups++;
+		level.clusters += cluster_count;
+		if (group.simplified.error == FLT_MAX)
+			level.stuck_clusters += cluster_count;
+
+		for (size_t i = 0; i < cluster_count; ++i)
+		{
+			const clodCluster& cluster = clusters[i];
+
+			level.triangles += cluster.index_count / 3;
+			if (group.simplified.error == FLT_MAX)
+				level.stuck_triangles += cluster.index_count / 3;
+			level.vertices += cluster.vertex_count;
+
+			level.full_clusters += (cluster.index_count == config.max_triangles * 3);
+			level.radius += cluster.bounds.radius;
+
+			level.indices.push_back(std::vector<unsigned int>(cluster.indices, cluster.indices + cluster.index_count));
+
+			// when requesting DAG cut at a given level, we need to render all terminal clusters at lower depth as well
+			if (cut_level >= 0 && (group.depth == cut_level || (group.depth < cut_level && group.simplified.error == FLT_MAX)))
+				cut.push_back(std::vector<unsigned int>(cluster.indices, cluster.indices + cluster.index_count));
+
+			// when requesting DAG cut from a viewpoint, we need to check if each cluster is the least detailed cluster that passes the error threshold
+			if (cut_level == -1 && (cluster.refined < 0 || boundsError(groups[cluster.refined], maxx, maxy, maxz, proj, znear) <= threshold) && boundsError(group.simplified, maxx, maxy, maxz, proj, znear) > threshold)
+				cut.push_back(std::vector<unsigned int>(cluster.indices, cluster.indices + cluster.index_count));
+		}
+
+		level.indices.push_back(std::vector<unsigned int>()); // mark end of group for measureBoundary
+
+		groups.push_back(group.simplified);
+		return int(groups.size() - 1);
+	});
+
+	// for cluster connectivity analysis and boundary statistics, we need a position-only remap that maps vertices with the same position to the same index
+	std::vector<unsigned int> remap(vertices.size());
+	meshopt_generatePositionRemap(&remap[0], &vertices[0].px, vertices.size(), sizeof(Vertex));
+
+	std::vector<int> used(vertices.size());
+
+	for (size_t i = 0; i < stats.size(); ++i)
 	{
-		dumpObj(vertices, cut);
+		Stats& level = stats[i];
 
-		for (size_t i = 0; i < clusters.size(); ++i)
-			if (boundsError(clusters[i].self, maxx, maxy, maxz, proj, znear) <= threshold && boundsError(clusters[i].parent, maxx, maxy, maxz, proj, znear) > threshold)
-				dumpObj("cluster", clusters[i].indices);
+		size_t connected = 0;
+		for (const auto& cluster : level.indices)
+			connected += measureComponents(used, cluster, remap);
+
+		size_t boundary = measureBoundary(used, level.indices, remap);
+		float saho = clrt ? sahOverhead(level.indices, vertices) : 0.f;
+
+		double inv_clusters = 1.0 / double(level.clusters);
+
+		printf("lod %d: %d clusters (%.1f%% full, %.1f tri/cl, %.1f vtx/cl, %.2f connected, %.1f boundary, %.1f partition, %.3f sah overhead, %f radius), %d triangles",
+		    int(i), int(level.clusters),
+		    double(level.full_clusters) * inv_clusters * 100, double(level.triangles) * inv_clusters, double(level.vertices) * inv_clusters,
+		    double(connected) * inv_clusters, double(boundary) * inv_clusters,
+		    double(level.clusters) / double(level.groups),
+		    saho, level.radius * inv_clusters,
+		    int(level.triangles));
+		if (level.stuck_clusters)
+			printf("; stuck %d clusters (%d triangles)", int(level.stuck_clusters), int(level.stuck_triangles));
+		printf("\n");
+	}
+
+	printf("lod %d: (lowest) %d clusters, %d triangles\n", int(stats.size() - 1), int(stats.back().clusters), int(lowest));
+
+	if (cut_level >= -1)
+	{
+		size_t cut_tris = 0;
+		for (auto& cluster : cut)
+			cut_tris += cluster.size() / 3;
+
+		if (cut_level >= 0)
+			printf("cut (level %d): %d triangles\n", cut_level, int(cut_tris));
+		else
+			printf("cut (error %.3f): %d triangles\n", threshold, int(cut_tris));
+
+		dumpObj(vertices, std::vector<unsigned int>());
+
+		for (auto& cluster : cut)
+			dumpObj("cluster", cluster);
 	}
 }
 
@@ -487,75 +250,49 @@ static int measureComponents(std::vector<int>& parents, const std::vector<unsign
 	return roots;
 }
 
-static int measureUnique(std::vector<int>& used, const std::vector<unsigned int>& indices, const std::vector<unsigned char>* locks = NULL)
+static size_t measureBoundary(std::vector<int>& used, const std::vector<std::vector<unsigned int> >& clusters, const std::vector<unsigned int>& remap)
 {
-	for (size_t i = 0; i < indices.size(); ++i)
+	for (size_t i = 0; i < used.size(); ++i)
+		used[i] = -1;
+
+	// mark vertices that are used by multiple groups with -2
+	int group = 0;
+
+	for (size_t i = 0; i < clusters.size(); ++i)
 	{
-		unsigned int v = indices[i];
-		used[v] = 1;
-	}
+		group += clusters[i].empty();
 
-	size_t vertices = 0;
-
-	for (size_t i = 0; i < indices.size(); ++i)
-	{
-		unsigned int v = indices[i];
-		vertices += used[v] && (!locks || (*locks)[v]);
-		used[v] = 0;
-	}
-
-	return int(vertices);
-}
-
-static void dumpMetrics(int level, const std::vector<Cluster>& queue, const std::vector<std::vector<int> >& groups, const std::vector<unsigned int>& remap, const std::vector<unsigned char>& locks, const std::vector<int>& retry, float saho)
-{
-	std::vector<int> parents(remap.size());
-
-	int clusters = 0;
-	int triangles = 0;
-	int full_clusters = 0;
-	int components = 0;
-	int xformed = 0;
-	int boundary = 0;
-	float radius = 0;
-
-	for (size_t i = 0; i < groups.size(); ++i)
-	{
-		for (size_t j = 0; j < groups[i].size(); ++j)
+		for (size_t j = 0; j < clusters[i].size(); ++j)
 		{
-			const Cluster& cluster = queue[groups[i][j]];
+			unsigned int v = remap[clusters[i][j]];
 
-			clusters++;
-			triangles += int(cluster.indices.size() / 3);
-			full_clusters += cluster.indices.size() == kClusterSize * 3;
-			components += measureComponents(parents, cluster.indices, remap);
-			xformed += measureUnique(parents, cluster.indices);
-			boundary += kUseLocks ? measureUnique(parents, cluster.indices, &locks) : 0;
-			radius += cluster.self.radius;
+			used[v] = (used[v] == -1 || used[v] == group) ? group : -2;
 		}
 	}
 
-	int stuck_clusters = 0;
-	int stuck_triangles = 0;
+	size_t result = 0;
 
-	for (size_t i = 0; i < retry.size(); ++i)
+	for (size_t i = 0; i < clusters.size(); ++i)
 	{
-		const Cluster& cluster = queue[retry[i]];
+		// count vertices that are used by multiple groups and change marks to -1
+		for (size_t j = 0; j < clusters[i].size(); ++j)
+		{
+			unsigned int v = remap[clusters[i][j]];
 
-		stuck_clusters++;
-		stuck_triangles += int(cluster.indices.size() / 3);
+			result += (used[v] == -2);
+			used[v] = (used[v] == -2) ? -1 : used[v];
+		}
+
+		// change marks back from -1 to -2 for the next pass
+		for (size_t j = 0; j < clusters[i].size(); ++j)
+		{
+			unsigned int v = remap[clusters[i][j]];
+
+			used[v] = (used[v] == -1) ? -2 : used[v];
+		}
 	}
 
-	double avg_group = double(clusters) / double(groups.size());
-	double inv_clusters = 1.0 / double(clusters);
-
-	printf("lod %d: %d clusters (%.1f%% full, %.1f tri/cl, %.1f vtx/cl, %.2f connected, %.1f boundary, %.1f partition, %.3f sah overhead, %f radius), %d triangles",
-	    level, clusters,
-	    double(full_clusters) * inv_clusters * 100, double(triangles) * inv_clusters, double(xformed) * inv_clusters, double(components) * inv_clusters, double(boundary) * inv_clusters, avg_group, saho, radius * inv_clusters,
-	    int(triangles));
-	if (stuck_clusters)
-		printf("; stuck %d clusters (%d triangles)", stuck_clusters, stuck_triangles);
-	printf("\n");
+	return int(result);
 }
 
 struct Box
@@ -681,44 +418,44 @@ static float sahCost(const Box* boxes, size_t count)
 	return sahCost(boxes, &order[0], &temp[0], count);
 }
 
-static float sahOverhead(const std::vector<Cluster>& queue, const std::vector<std::vector<int> >& groups, const std::vector<Vertex>& vertices)
+static float sahOverhead(const std::vector<std::vector<unsigned int> >& clusters, const std::vector<Vertex>& vertices)
 {
 	std::vector<Box> all_tris, cluster_tris, cluster_boxes;
 
 	float sahc = 0.f;
 
-	for (size_t i = 0; i < groups.size(); ++i)
-		for (size_t j = 0; j < groups[i].size(); ++j)
+	for (size_t i = 0; i < clusters.size(); ++i)
+	{
+		if (clusters[i].empty())
+			continue;
+
+		cluster_tris.clear();
+
+		Box cluster_box = kDummyBox;
+
+		for (size_t k = 0; k < clusters[i].size(); k += 3)
 		{
-			const Cluster& cluster = queue[groups[i][j]];
+			Box box = kDummyBox;
 
-			cluster_tris.clear();
-
-			Box cluster_box = kDummyBox;
-
-			for (size_t k = 0; k < cluster.indices.size(); k += 3)
+			for (int v = 0; v < 3; ++v)
 			{
-				Box box = kDummyBox;
+				const Vertex& vertex = vertices[clusters[i][k + v]];
 
-				for (int v = 0; v < 3; ++v)
-				{
-					const Vertex& vertex = vertices[cluster.indices[k + v]];
-
-					Box p = {{vertex.px, vertex.py, vertex.pz}, {vertex.px, vertex.py, vertex.pz}};
-					mergeBox(box, p);
-				}
-
-				mergeBox(cluster_box, box);
-
-				all_tris.push_back(box);
-				cluster_tris.push_back(box);
+				Box p = {{vertex.px, vertex.py, vertex.pz}, {vertex.px, vertex.py, vertex.pz}};
+				mergeBox(box, p);
 			}
 
-			cluster_boxes.push_back(cluster_box);
+			mergeBox(cluster_box, box);
 
-			sahc += sahCost(&cluster_tris[0], cluster_tris.size());
-			sahc -= surface(cluster_box); // box will be accounted for in tlas
+			all_tris.push_back(box);
+			cluster_tris.push_back(box);
 		}
+
+		cluster_boxes.push_back(cluster_box);
+
+		sahc += sahCost(&cluster_tris[0], cluster_tris.size());
+		sahc -= surface(cluster_box); // box will be accounted for in tlas
+	}
 
 	sahc += sahCost(&cluster_boxes[0], cluster_boxes.size());
 

--- a/src/partition.cpp
+++ b/src/partition.cpp
@@ -371,7 +371,7 @@ size_t meshopt_partitionClusters(unsigned int* destination, const unsigned int* 
 	assert(vertex_positions_stride % sizeof(float) == 0);
 	assert(target_partition_size > 0);
 
-	size_t max_partition_size = target_partition_size + target_partition_size * 3 / 8;
+	size_t max_partition_size = target_partition_size + target_partition_size / 3;
 
 	meshopt_Allocator allocator;
 

--- a/src/simplifier.cpp
+++ b/src/simplifier.cpp
@@ -2267,7 +2267,7 @@ static float interpolate(float y, float x0, float y0, float x1, float y1, float 
 	// three point interpolation from "revenge of interpolation search" paper
 	float num = (y1 - y) * (x1 - x2) * (x1 - x0) * (y2 - y0);
 	float den = (y2 - y) * (x1 - x2) * (y0 - y1) + (y0 - y) * (x1 - x0) * (y1 - y2);
-	return x1 + num / den;
+	return x1 + (den == 0.f ? 0.f : num / den);
 }
 
 } // namespace meshopt


### PR DESCRIPTION
> This is a followup to #956 and a replacement of #954.

This change significantly reworks the clustered LOD builder example. The actual implementation is mostly identical in the flow, however it's structured to be easier to start with or reuse when implementing a system like Nanite - it exposes a proper C interface with a generalized input mesh, returns the output cluster group data via callbacks, and exposes a lot of configuration knobs to control the process.

For simplicity, this does *not* include a glTF sample but [clodgltf.cpp](https://github.com/zeux/meshoptimizer/blob/7dfe4cc7553f1ee2d4789fd931130c5aec2afda2/tools/clodgltf.cpp) from the linked PR can be used more or less as is; when ran on NVidia Zorah sample scene (~1.7B triangles) it generates a full DAG for every mesh, and the process takes ~2 minutes 35 seconds on Ryzen 7950X using 16 threads and ~60 GB of memory. There's no processing or serialization of output data, so more realistically extra time and memory would be taken if all results were serialized.

The actual code is still using a fair amount of STL and is not too careful with allocations. This might be good to fix in the future if that retains the ease of understanding the code; also, the code is single-threaded which may be a bottleneck for very large individual meshes. Finally, it may be helpful to setup temporary per-thread arenas for internal `meshopt_` allocations - the aforementioned `clodgltf.cpp` code does do that but it's not part of `clusterlod.h` at the moment. Also, calling `meshopt_spatialSortTriangles` when using RT builds makes the process slightly faster (without this, Zorah takes ~2 minutes 45 seconds) - this is currently *not* part of `clusterlod.h` as well but maybe it should be.

In addition to the demo code, this PR has two small tweaks to `meshopt_` algorithms:

- `meshopt_partitionClusters` now produces partitions with a slightly smaller maximum (`target + target / 3`); this results in an average partition size that's slightly closer to target, and allows to pass in `target=3*2^k` to get `max=2^(k+2)`. This control is a little ad-hoc and might improve in the future along side other enhancements to partitioning.
- `meshopt_simplifySloppy` could occasionally internally produce `+Inf` during three-point interpolation search and cast it to an integer, which would break UBSAN builds. This did not affect the behavior of the algorithm otherwise, but has been now fixed. 

*Thanks to NVIDIA engineers for discussions and feedback!*

*This contribution is sponsored by Valve.*