### PR TITLE
gltfpack: Introduce support for KHR_meshopt_compression

### DIFF
--- a/gltf/gltfpack.h
+++ b/gltf/gltfpack.h
@@ -173,7 +173,7 @@ struct Settings
 
 	bool compress;
 	bool compressmore;
-	bool compressexp;
+	bool compresskhr;
 	bool fallback;
 
 	int verbose;
@@ -379,7 +379,7 @@ StreamFormat writeIndexStream(std::string& bin, const std::vector<unsigned int>&
 StreamFormat writeTimeStream(std::string& bin, const std::vector<float>& data);
 StreamFormat writeKeyframeStream(std::string& bin, cgltf_animation_path_type type, const std::vector<Attr>& data, const Settings& settings, bool has_tangents = false);
 
-void compressVertexStream(std::string& bin, const std::string& data, size_t count, size_t stride);
+void compressVertexStream(std::string& bin, const std::string& data, size_t count, size_t stride, int level);
 void compressIndexStream(std::string& bin, const std::string& data, size_t count, size_t stride);
 void compressIndexSequence(std::string& bin, const std::string& data, size_t count, size_t stride);
 

--- a/gltf/stream.cpp
+++ b/gltf/stream.cpp
@@ -563,7 +563,7 @@ StreamFormat writeVertexStream(std::string& bin, const Stream& stream, const Qua
 	}
 	else if (stream.type == cgltf_attribute_type_color)
 	{
-		bool col = filters && settings.compressexp && settings.compressmore;
+		bool col = filters && settings.compresskhr && settings.compressmore;
 		int bits = settings.col_bits;
 
 		StreamFormat::Filter filter = col ? StreamFormat::Filter_Color : StreamFormat::Filter_None;
@@ -800,12 +800,12 @@ StreamFormat writeKeyframeStream(std::string& bin, cgltf_animation_path_type typ
 	}
 }
 
-void compressVertexStream(std::string& bin, const std::string& data, size_t count, size_t stride)
+void compressVertexStream(std::string& bin, const std::string& data, size_t count, size_t stride, int level)
 {
 	assert(data.size() == count * stride);
 
 	std::vector<unsigned char> compressed(meshopt_encodeVertexBufferBound(count, stride));
-	size_t size = meshopt_encodeVertexBuffer(&compressed[0], compressed.size(), data.c_str(), count, stride);
+	size_t size = meshopt_encodeVertexBufferLevel(&compressed[0], compressed.size(), data.c_str(), count, stride, level, level > 0);
 
 	bin.append(reinterpret_cast<const char*>(&compressed[0]), size);
 }


### PR DESCRIPTION
It's now possible to select the extension used for meshopt compression via a new `-ce` argument; `-ce ext` uses EXT_meshopt_compression (default), whereas `-ce khr` switches to KHR_meshopt_compression. This option can be used to gradually switch the default to KHR in the future.

This option is orthogonal to the compression level, so just using `-ce khr` will not compress as much as `-cc -ce khr`. For the latter there's a shorthand option `-cz`.

Note that parsing files with KHR_meshopt_compression is not supported yet, as that requires a cgltf change.

Depends on https://github.com/KhronosGroup/glTF/pull/2517