### PR TITLE
vertexfilter: Optimize various decoders for AArch64

### DIFF
--- a/src/vertexfilter.cpp
+++ b/src/vertexfilter.cpp
@@ -728,9 +728,10 @@ static void decodeFilterQuatSimd(short* data, size_t count)
 		uint64x2_t res_1 = vreinterpretq_u64_s16(vzipq_s16(vreinterpretq_s16_s32(wyr), vreinterpretq_s16_s32(xzr)).val[1]);
 
 		// store results to stack so that we can rotate using scalar instructions
-		uint64_t res[4];
-		vst1q_u64(&res[0], res_0);
-		vst1q_u64(&res[2], res_1);
+		// TODO: volatile works around LLVM mis-optimizing code; https://github.com/llvm/llvm-project/issues/166808
+		volatile uint64_t res[4];
+		vst1q_u64(const_cast<uint64_t*>(&res[0]), res_0);
+		vst1q_u64(const_cast<uint64_t*>(&res[2]), res_1);
 
 		// rotate and store
 		uint64_t* out = reinterpret_cast<uint64_t*>(&data[i * 4]);


### PR DESCRIPTION
The original decoders have been written in SSE2 and then converted 1-1 to NEON (minus a custom float->int conversion step). Today most of the ARM CPUs that matter use AArch64 which has a slightly wider instruction set, and in general the code was missing some NEON specific tuning. This change aggregates several optimizations designed to take advantage of this better:

- Use SLI (shift-with-insert) instead of shift/and/or sequences to pack values
- On AArch64, use FMA instead of separate mul/adds; gcc already fuses muls/adds automatically but clang doesn't
- On AArch64, use divide by sqrt in 16-bit octahedral decode; similarly to SSE, this is faster than doing estimates with 1 NR iteration
- In quaternion decoder, use stack store instead of lane access for scalarization (plus volatile to force clang to stop vectorizing rotates). This prevents the compilers from attempting an unprofitable vectorization of the rotate sequence.

Together these changes result in the following speedup:

Algorithm | oct8 | oct16 | quat16 | col8 | col16
----------|------|-------|--------|-----|------
Apple M4 (clang) | 43% | 21% | 47% | 29% | 16%
Graviton 3 (clang) | 32% | 21% | 25% | 23% | 4%
Graviton 3 (gcc) | 10% | 14% | 7% | 10% | 15%
