### PR TITLE
demo: Add optional error clamping based on edge lengths to clusterlod.h

### DIFF
--- a/demo/clusterlod.h
+++ b/demo/clusterlod.h
@@ -52,6 +52,9 @@ struct clodConfig
 	bool simplify_fallback_permissive;
 	bool simplify_fallback_sloppy;
 
+	// use regularization during simplification to make triangle density more uniform, at some cost to overall triangle count; recommended for deformable objects
+	bool simplify_regularize;
+
 	// should clodCluster::bounds be computed based on the geometry of each cluster
 	bool optimize_bounds;
 
@@ -425,7 +428,7 @@ static std::vector<unsigned int> simplify(const clodConfig& config, const clodMe
 
 	std::vector<unsigned int> lod(indices.size());
 
-	unsigned int options = meshopt_SimplifySparse | meshopt_SimplifyErrorAbsolute | (config.simplify_permissive ? meshopt_SimplifyPermissive : 0);
+	unsigned int options = meshopt_SimplifySparse | meshopt_SimplifyErrorAbsolute | (config.simplify_permissive ? meshopt_SimplifyPermissive : 0) | (config.simplify_regularize ? meshopt_SimplifyRegularize : 0);
 
 	lod.resize(meshopt_simplifyWithAttributes(&lod[0], &indices[0], indices.size(),
 	    mesh.vertex_positions, mesh.vertex_count, mesh.vertex_positions_stride,


### PR DESCRIPTION
In some clusters with high attribute divergence, we may simplify the
cluster with an error that leaves triangles small geometrically. Since
the LOD selection is targeting <1px sized triangles, this could result
in the actual triangle density being higher than expected. This should
not be a common problem but might affect some types of content or
setups.

Setting `simplify_error_edge_limit` to a value around 1 will try to limit
the error so that clusters with overly dense geometry can be switched
more quickly; for example, setting the value to 0.5f will try to adjust
the limit such that triangles are 1-2px on screen even if the attribute
error is higher.

To handle thin triangles we use `max(min_edge, max_edge / 2)` as a
balance, so that triangles that aren't perfectly equilateral are still
switched earlier but long and thin triangles like wires are preserved.

Somewhat related, but in some cases like deformable objects, a more
uniform triangle density should be preferred during simplification; a new
option `clodConfig::simplify_regularize` exposes the corresponding
simplification flag too.

Note that `simplify_error_edge_limit` was tested on a limited number of
complex scenes; the logic may be revised in the future and it's not clear
if it should be enabled by default, as in most cases a reasonable attribute
weight setup appears to be sufficient.

*This contribution is sponsored by Valve.*