### PR TITLE
meshletcodec: Revise encoding format for slightly more compression

### DIFF
--- a/src/meshletcodec.cpp
+++ b/src/meshletcodec.cpp
@@ -186,7 +186,7 @@ static size_t encodeVertices(unsigned char* ctrl, unsigned char* data, const uns
 
 	unsigned char* start = data;
 
-	unsigned int last = 0;
+	unsigned int last = ~0u;
 
 	for (size_t i = 0; i < vertex_count; ++i)
 	{
@@ -280,7 +280,7 @@ static const unsigned char* decodeTriangles(unsigned int* triangles, const unsig
 
 static const unsigned char* decodeVertices(unsigned int* vertices, const unsigned char* ctrl, const unsigned char* data, const unsigned char* bound, size_t vertex_count)
 {
-	unsigned int last = 0;
+	unsigned int last = ~0u;
 
 	static const unsigned int kMasks[] = {0, 0xff, 0xffff, 0xffffffff};
 	static const unsigned char kLengths[] = {0, 1, 2, 4};
@@ -507,7 +507,7 @@ static const unsigned char* decodeTrianglesSimd(unsigned int* triangles, const u
 
 SIMD_TARGET static const unsigned char* decodeVerticesSimd(unsigned int* vertices, const unsigned char* ctrl, const unsigned char* data, const unsigned char* bound, size_t vertex_count)
 {
-	__m128i last = _mm_setzero_si128();
+	__m128i last = _mm_set1_epi32(-1);
 
 	for (size_t i = 0; i < vertex_count; i += 4)
 	{


### PR DESCRIPTION
> [!WARNING]
> The data format continues to be highly experimental. Until a library point release, data compatibility is not guaranteed.

- Instead of using 0 as the initial delta state, we now use -1; with the offset-by-1 delta encoding that makes the first vertex reference "free" to encode if it's 0. This does not matter when the vertex references are encoded as absolute values, but it's common for engines to store a per-meshlet offset and rebase the references relative to that offset, in which case the first reference is often 0.
- Place triangle codes at the end of the encoded data, after the vertex control bits. This aligns the data order between fixed-size and variable-sized sections, and can compress 0.5-1% better with zstd.

*This contribution is sponsored by Valve.*