### PR TITLE
gltfpack: Implement initial support for XUASTC

### DIFF
--- a/gltf/gltfpack.h
+++ b/gltf/gltfpack.h
@@ -114,6 +114,7 @@ enum TextureMode
 	TextureMode_Raw,
 	TextureMode_ETC1S,
 	TextureMode_UASTC,
+	TextureMode_XUASTC,
 	TextureMode_WebP,
 };
 


### PR DESCRIPTION
When compiling against latest Basis Universal (2.0+), we can now use XUASTC compression. It supports variable block sizes and a much larger gamut of quality settings from the perspective of the resulting file size, using DCT to compress the block data with arith/Zstd on top.

This format is currently not supported by any glTF extensions; as such, this might need refinements if this happens. For now, the block size is fixed at 4x4; this could be controlled via quality settings or a separate future command line argument.

The quality curve for now is somewhat approximate and based on the target size; the quality impact has not been analyzed yet.

<img width="1800" height="1500" alt="texture_quality_chart" src="https://github.com/user-attachments/assets/f5456901-34fa-48d1-a558-b1b200d6f7f3" />
