### PR TITLE
meshletcodec: Tune decoding performance

### DIFF
--- a/src/meshletcodec.cpp
+++ b/src/meshletcodec.cpp
@@ -654,7 +654,7 @@ static const unsigned char* decodeTrianglesSimd(unsigned int* triangles, const u
 
 		state = decodeTriangleGroup(state, code, extra);
 
-		unsigned int* tail = &triangles[triangle_count & ~1];
+		unsigned int* tail = &triangles[triangle_count & ~1u];
 
 #if defined(SIMD_SSE)
 		__m128i r = _mm_shuffle_epi8(state, repack);
@@ -726,7 +726,7 @@ static const unsigned char* decodeTrianglesSimd(unsigned char* triangles, const 
 
 		state = decodeTriangleGroup(state, code, extra);
 
-		unsigned char* tail = &triangles[(triangle_count & ~3) * 3];
+		unsigned char* tail = &triangles[(triangle_count & ~3u) * 3];
 
 #if defined(SIMD_SSE)
 		__m128i r = _mm_srli_si128(state, 9);
@@ -783,7 +783,7 @@ static const unsigned char* decodeVerticesSimd(unsigned int* vertices, const uns
 
 		last = decodeVertexGroup(last, code, data);
 
-		unsigned int* tail = &vertices[vertex_count & ~3];
+		unsigned int* tail = &vertices[vertex_count & ~3u];
 
 #if defined(SIMD_SSE)
 		tail[0] = _mm_cvtsi128_si32(last);
@@ -846,7 +846,7 @@ static const unsigned char* decodeVerticesSimd(unsigned short* vertices, const u
 
 		last = decodeVertexGroup(last, code, data);
 
-		unsigned short* tail = &vertices[vertex_count & ~3];
+		unsigned short* tail = &vertices[vertex_count & ~3u];
 
 #if defined(SIMD_SSE)
 		__m128i r = _mm_shufflelo_epi16(last, 8);


### PR DESCRIPTION
This change reworks raw decoding to reuse the same decoding loops, using templates and rounding up the element counts to remove tail processing code (as the compiler recognizes the counts are already aligned to 4/2 boundary and no extra processing is necessary).

This by itself causes additional inlining regressions on MSVC; even before this change, MSVC refused to inline decodeTrianglesSimd/decodeVerticesSimd. So we now use the "flatten" attribute to force this. MSVC has additional codegen quality issues with inlining etc. - using clang results in ~10% faster decoding.

The tail processing has been cleaned up and adjusted to improve branch flow, and work around clang known bits issue that resulted in extraneous `movabs` instructions emitted. The tail is still imperfect but there's some complexity in ensuring codegen is optimal between x64 and aarch64 so this is probably a good middleground.

*This contribution is sponsored by Valve.*