### PR TITLE
meshletutils: Improve computeMeshlet/ClusterBounds performance

### DIFF
--- a/src/meshletutils.cpp
+++ b/src/meshletutils.cpp
@@ -328,6 +328,8 @@ meshopt_Bounds meshopt_computeMeshletBounds(const unsigned int* meshlet_vertices
 		assert(index < vertex_count);
 
 		indices[i] = index;
+
+		// meshlet_vertices[] slice should only contain vertices used by triangle indices, which is the case for any well formed meshlet
 		corner_count = t >= corner_count ? t + 1 : corner_count;
 	}
 

--- a/src/meshoptimizer.h
+++ b/src/meshoptimizer.h
@@ -775,6 +775,7 @@ struct meshopt_Bounds
  *
  * vertex_positions should have float3 position in the first 12 bytes of each vertex
  * vertex_count should specify the number of vertices in the entire mesh, not cluster or meshlet
+ * indices should have at most 256 unique vertex indices
  * index_count/3 and triangle_count must not exceed implementation limits (<= 512)
  */
 MESHOPTIMIZER_API struct meshopt_Bounds meshopt_computeClusterBounds(const unsigned int* indices, size_t index_count, const float* vertex_positions, size_t vertex_count, size_t vertex_positions_stride);


### PR DESCRIPTION
This change adjusts the implementation of `meshopt_computeMeshletBounds` and `meshopt_computeClusterBounds` to be more efficient.

Instead of copying the corner positions to stack arrays, we use the vertex indices to index the original array directly. This significantly reduces stack usage, but slightly regresses performance - however, it's important to be able to do the next optimization with reasonable stack space.

When computing meshlet bounds, we used to replicate corner positions for each triangle corner; a typical meshlet that has, say, 64V/96T, would compute the bounding sphere for an array of 288 positions, despite only 64 of them being unique. With the index inputs, we can directly pass `meshlet_vertices` slice to `computeBoundingSphere` instead. This makes `meshopt_computeMeshletBounds` 1.5-1.7x faster end-to-end.

When computing cluster bounds, we don't have a readily available deduplicated index array. While we could use `meshopt_extractMeshletIndices`, we don't need the precisely deduplicated array, and a best-effort conservative deduplication is sufficient. We can use the same direct mapped cache as a filter, but append a corner index on all misses in the cache; in practice this ends up filtering most duplicates at a smaller cost. As a result, `meshopt_computeClusterBounds` is also 1.5x+ faster.

Finally, the aggregate stack consumption got significantly smaller; previously, `meshopt_computeClusterBounds` would need ~25 KB stack space, and `meshopt_computeMeshletBounds` would need ~31 KB. After this change, `meshopt_computeMeshletBounds` needs ~15 KB stack and `meshopt_computeClusterBounds` needs ~17 KB. These numbers are inclusive of internal functions and measured on a 64-bit debug build.

*This contribution is sponsored by Valve.*