### PR TITLE
tangentspace: Implement experimental tangent space generator

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,7 @@ set(SOURCES
     src/simplifier.cpp
     src/spatialorder.cpp
     src/stripifier.cpp
+    src/tangentspace.cpp
     src/vcacheoptimizer.cpp
     src/vertexcodec.cpp
     src/vertexfilter.cpp

--- a/demo/main.cpp
+++ b/demo/main.cpp
@@ -1388,22 +1388,74 @@ void coverage(const Mesh& mesh)
 	    cs.coverage[0] * 100, cs.coverage[1] * 100, cs.coverage[2] * 100, (end - start) * 1000);
 }
 
+struct VertexTangent
+{
+	float px, py, pz;
+	float nx, ny, nz;
+	float tu, tv;
+	float tx, ty, tz, tw;
+};
+
 void tangents(const Mesh& mesh)
 {
 	double start = timestamp();
 
 	// note: tangent generation produces a tangent vector and orientation (+-1) per *corner* (3 per triangle), even for indexed inputs
 	// you *could* then copy the tangents to the existing vertices, but that will not work correctly in case the input has UV mirroring
-	// the correct way to handle this is to deindex & reindex the mesh if you need correct results, or copy tangents to an existing vertex stream
-	// while duplicating vertices with divergent tangents on the fly.
-	// you also can pass unindexed data (indices==NULL) to meshopt_generateTangents directly, here we don't for simplicity
+	// a simple way to handle this is to work on unindexed data (indices==NULL), generate tangents, and re-index
+	// we show a more involved way that splits vertices with divergent tangents on the fly.
 	std::vector<float> tangents(mesh.indices.size() * 4);
 
 	meshopt_generateTangents(&tangents[0], &mesh.indices[0], mesh.indices.size(), &mesh.vertices[0].px, mesh.vertices.size(), sizeof(Vertex), &mesh.vertices[0].nx, sizeof(Vertex), &mesh.vertices[0].tx, sizeof(Vertex));
 
+	std::vector<VertexTangent> newvertices(mesh.vertices.size());
+	std::vector<unsigned int> newindices = mesh.indices;
+	std::vector<unsigned int> splits(mesh.vertices.size(), ~0u);
+
+	for (size_t i = 0; i < mesh.vertices.size(); ++i)
+	{
+		VertexTangent& vt = newvertices[i];
+		const Vertex& v = mesh.vertices[i];
+
+		vt.px = v.px, vt.py = v.py, vt.pz = v.pz;
+		vt.nx = v.nx, vt.ny = v.ny, vt.nz = v.nz;
+		vt.tu = v.tx, vt.tv = v.ty;
+		// leave vt.txyzw as 0 as we'll fill them below
+	}
+
+	for (size_t i = 0; i < mesh.indices.size(); ++i)
+	{
+		const float* t = &tangents[i * 4];
+		unsigned int v = mesh.indices[i];
+
+		// initial tangent value
+		if (newvertices[v].tw == 0.f)
+			newvertices[v].tx = t[0], newvertices[v].ty = t[1], newvertices[v].tz = t[2], newvertices[v].tw = t[3];
+		else if (newvertices[v].tx != t[0] || newvertices[v].ty != t[1] || newvertices[v].tz != t[2] || newvertices[v].tw != t[3])
+		{
+			// tangent split; we might be able to reuse previously split vertices, or might need to add a new one
+			unsigned int sv = splits[v];
+			while (sv != ~0u && (newvertices[sv].tx != t[0] || newvertices[sv].ty != t[1] || newvertices[sv].tz != t[2] || newvertices[sv].tw != t[3]))
+				sv = splits[sv];
+
+			// need to add a new split and chain it to the existing list
+			if (sv == ~0u)
+			{
+				sv = unsigned(newvertices.size());
+				newvertices.push_back(newvertices[v]);
+				newvertices[sv].tx = t[0], newvertices[sv].ty = t[1], newvertices[sv].tz = t[2], newvertices[sv].tw = t[3];
+
+				splits.push_back(splits[v]);
+				splits[v] = sv;
+			}
+
+			newindices[i] = sv;
+		}
+	}
+
 	double end = timestamp();
 
-	printf("Tangents : %d corners in %.2f msec\n", int(mesh.indices.size()), (end - start) * 1000);
+	printf("Tangents : %d corners, %d splits in %.2f msec\n", int(mesh.indices.size()), int(newvertices.size() - mesh.vertices.size()), (end - start) * 1000);
 }
 
 void nanite(const std::vector<Vertex>& vertices, const std::vector<unsigned int>& indices); // nanite.cpp
@@ -1602,9 +1654,7 @@ void processDev(const char* path)
 	if (!loadMesh(mesh, path))
 		return;
 
-	encodeMeshlets(mesh, 32, 48);
-	encodeMeshlets(mesh, 64, 64);
-	encodeMeshlets(mesh, 64, 96);
+	tangents(mesh);
 }
 
 void processNanite(const char* path)

--- a/demo/main.cpp
+++ b/demo/main.cpp
@@ -1388,6 +1388,24 @@ void coverage(const Mesh& mesh)
 	    cs.coverage[0] * 100, cs.coverage[1] * 100, cs.coverage[2] * 100, (end - start) * 1000);
 }
 
+void tangents(const Mesh& mesh)
+{
+	double start = timestamp();
+
+	// note: tangent generation produces a tangent vector and orientation (+-1) per *corner* (3 per triangle), even for indexed inputs
+	// you *could* then copy the tangents to the existing vertices, but that will not work correctly in case the input has UV mirroring
+	// the correct way to handle this is to deindex & reindex the mesh if you need correct results, or copy tangents to an existing vertex stream
+	// while duplicating vertices with divergent tangents on the fly.
+	// you also can pass unindexed data (indices==NULL) to meshopt_generateTangents directly, here we don't for simplicity
+	std::vector<float> tangents(mesh.indices.size() * 4);
+
+	meshopt_generateTangents(&tangents[0], &mesh.indices[0], mesh.indices.size(), &mesh.vertices[0].px, mesh.vertices.size(), sizeof(Vertex), &mesh.vertices[0].nx, sizeof(Vertex), &mesh.vertices[0].tx, sizeof(Vertex));
+
+	double end = timestamp();
+
+	printf("Tangents : %d corners in %.2f msec\n", int(mesh.indices.size()), (end - start) * 1000);
+}
+
 void nanite(const std::vector<Vertex>& vertices, const std::vector<unsigned int>& indices); // nanite.cpp
 
 bool loadMesh(Mesh& mesh, const char* path)
@@ -1571,6 +1589,8 @@ void process(const char* path)
 
 	reindexFuzzy(mesh);
 	coverage(mesh);
+
+	tangents(mesh);
 
 	if (path)
 		processDeinterleaved(path);

--- a/src/meshoptimizer.h
+++ b/src/meshoptimizer.h
@@ -1054,6 +1054,8 @@ template <typename T>
 inline size_t meshopt_partitionClusters(unsigned int* destination, const T* cluster_indices, size_t total_index_count, const unsigned int* cluster_index_counts, size_t cluster_count, const float* vertex_positions, size_t vertex_count, size_t vertex_positions_stride, size_t target_partition_size);
 template <typename T>
 inline void meshopt_spatialSortTriangles(T* destination, const T* indices, size_t index_count, const float* vertex_positions, size_t vertex_count, size_t vertex_positions_stride);
+template <typename T>
+inline void meshopt_generateTangents(float* result, const T* indices, size_t index_count, const float* vertex_positions, size_t vertex_count, size_t vertex_positions_stride, const float* vertex_normals, size_t vertex_normals_stride, const float* vertex_uvs, size_t vertex_uvs_stride);
 #endif
 
 /* Inline implementation */
@@ -1543,6 +1545,14 @@ inline void meshopt_spatialSortTriangles(T* destination, const T* indices, size_
 	meshopt_IndexAdapter<T> out(destination, NULL, index_count);
 
 	meshopt_spatialSortTriangles(out.data, in.data, index_count, vertex_positions, vertex_count, vertex_positions_stride);
+}
+
+template <typename T>
+inline void meshopt_generateTangents(float* result, const T* indices, size_t index_count, const float* vertex_positions, size_t vertex_count, size_t vertex_positions_stride, const float* vertex_normals, size_t vertex_normals_stride, const float* vertex_uvs, size_t vertex_uvs_stride)
+{
+	meshopt_IndexAdapter<T> in(NULL, indices, indices ? index_count : 0);
+
+	meshopt_generateTangents(result, indices ? in.data : NULL, index_count, vertex_positions, vertex_count, vertex_positions_stride, vertex_normals, vertex_normals_stride, vertex_uvs, vertex_uvs_stride);
 }
 #endif
 

--- a/src/meshoptimizer.h
+++ b/src/meshoptimizer.h
@@ -899,6 +899,11 @@ MESHOPTIMIZER_EXPERIMENTAL size_t meshopt_opacityMapEntrySize(int level, int sta
 MESHOPTIMIZER_EXPERIMENTAL size_t meshopt_opacityMapCompact(unsigned char* data, size_t data_size, unsigned char* levels, unsigned int* offsets, size_t omm_count, int* omm_indices, size_t triangle_count, int states);
 
 /**
+ * Experimental: MikkTSpace tangent space generator
+ */
+MESHOPTIMIZER_EXPERIMENTAL void meshopt_generateTangentsMikkT(float* result, const unsigned int* indices, size_t index_count, const float* vertex_positions, size_t vertex_count, size_t vertex_positions_stride, const float* vertex_normals, size_t vertex_normals_stride, const float* vertex_uvs, size_t vertex_uvs_stride);
+
+/**
  * Quantize a float into half-precision (as defined by IEEE-754 fp16) floating point value
  * Generates +-inf for overflow, preserves NaN, flushes denormals to zero, rounds to nearest
  * Representable magnitude range: [6e-5; 65504]

--- a/src/meshoptimizer.h
+++ b/src/meshoptimizer.h
@@ -899,7 +899,18 @@ MESHOPTIMIZER_EXPERIMENTAL size_t meshopt_opacityMapEntrySize(int level, int sta
 MESHOPTIMIZER_EXPERIMENTAL size_t meshopt_opacityMapCompact(unsigned char* data, size_t data_size, unsigned char* levels, unsigned int* offsets, size_t omm_count, int* omm_indices, size_t triangle_count, int states);
 
 /**
- * Experimental: MikkTSpace tangent space generator
+ * Experimental: Tangent space generator
+ * Computes per-corner tangent vectors following the MikkTSpace algorithm; for each corner, computes normalized tangent vector (xyz) and orientation (w, +/-1).
+ * Bitangent can be reconstructed via cross(normal, tangent.xyz) * tangent.w.
+ * To apply tangents to the mesh, either deindex and reindex it with the tangent stream, or copy tangents to existing vertex data while duplicating
+ * vertices with different tangent vectors (e.g. on UV mirror seams).
+ * Input can be indexed or unindexed (indices=NULL); this does not affect the resulting tangents, but indexed inputs are ~30% faster to process.
+ *
+ * result must contain enough space for the output tangent data (index_count*4 elements)
+ * indices can be NULL if the input is unindexed
+ * vertex_positions should have float3 position in the first 12 bytes of each vertex
+ * vertex_normals should have unit float3 normal in the first 12 bytes of each vertex
+ * vertex_uvs should have float2 texture coordinate in the first 8 bytes of each vertex
  */
 MESHOPTIMIZER_EXPERIMENTAL void meshopt_generateTangents(float* result, const unsigned int* indices, size_t index_count, const float* vertex_positions, size_t vertex_count, size_t vertex_positions_stride, const float* vertex_normals, size_t vertex_normals_stride, const float* vertex_uvs, size_t vertex_uvs_stride);
 

--- a/src/meshoptimizer.h
+++ b/src/meshoptimizer.h
@@ -901,7 +901,7 @@ MESHOPTIMIZER_EXPERIMENTAL size_t meshopt_opacityMapCompact(unsigned char* data,
 /**
  * Experimental: MikkTSpace tangent space generator
  */
-MESHOPTIMIZER_EXPERIMENTAL void meshopt_generateTangentsMikkT(float* result, const unsigned int* indices, size_t index_count, const float* vertex_positions, size_t vertex_count, size_t vertex_positions_stride, const float* vertex_normals, size_t vertex_normals_stride, const float* vertex_uvs, size_t vertex_uvs_stride);
+MESHOPTIMIZER_EXPERIMENTAL void meshopt_generateTangents(float* result, const unsigned int* indices, size_t index_count, const float* vertex_positions, size_t vertex_count, size_t vertex_positions_stride, const float* vertex_normals, size_t vertex_normals_stride, const float* vertex_uvs, size_t vertex_uvs_stride);
 
 /**
  * Quantize a float into half-precision (as defined by IEEE-754 fp16) floating point value

--- a/src/tangentspace.cpp
+++ b/src/tangentspace.cpp
@@ -358,7 +358,7 @@ static void accumulateTangentGroups(float* result, const unsigned int* groups, c
 
 } // namespace meshopt
 
-MESHOPTIMIZER_EXPERIMENTAL void meshopt_generateTangentsMikkT(float* result, const unsigned int* indices, size_t index_count, const float* vertex_positions, size_t vertex_count, size_t vertex_positions_stride, const float* vertex_normals, size_t vertex_normals_stride, const float* vertex_uvs, size_t vertex_uvs_stride)
+MESHOPTIMIZER_EXPERIMENTAL void meshopt_generateTangents(float* result, const unsigned int* indices, size_t index_count, const float* vertex_positions, size_t vertex_count, size_t vertex_positions_stride, const float* vertex_normals, size_t vertex_normals_stride, const float* vertex_uvs, size_t vertex_uvs_stride)
 {
 	using namespace meshopt;
 

--- a/src/tangentspace.cpp
+++ b/src/tangentspace.cpp
@@ -173,29 +173,27 @@ static void buildVertexRemap(unsigned int* remap, const float* vertex_positions,
 
 struct CornerAdjacency
 {
-	unsigned int* counts;
 	unsigned int* offsets;
 	unsigned int* data;
 };
 
 static void buildCornerAdjacency(CornerAdjacency& adjacency, const unsigned int* indices, size_t index_count, const unsigned int* remap, size_t vertex_count, meshopt_Allocator& allocator)
 {
-	size_t face_count = index_count / 3;
-
-	// allocate arrays
-	adjacency.counts = allocator.allocate<unsigned int>(vertex_count);
-	adjacency.offsets = allocator.allocate<unsigned int>(vertex_count);
+	adjacency.offsets = allocator.allocate<unsigned int>(vertex_count + 1);
 	adjacency.data = allocator.allocate<unsigned int>(index_count);
 
-	// fill triangle counts
-	memset(adjacency.counts, 0, vertex_count * sizeof(unsigned int));
+	size_t face_count = index_count / 3;
+	unsigned int* offsets = adjacency.offsets + 1;
+
+	// fill corner counts
+	memset(offsets, 0, vertex_count * sizeof(unsigned int));
 
 	for (size_t i = 0; i < index_count; ++i)
 	{
 		unsigned int v = indices ? remap[indices[i]] : remap[i];
 		assert(v < vertex_count);
 
-		adjacency.counts[v]++;
+		offsets[v]++;
 	}
 
 	// fill offset table
@@ -203,8 +201,9 @@ static void buildCornerAdjacency(CornerAdjacency& adjacency, const unsigned int*
 
 	for (size_t i = 0; i < vertex_count; ++i)
 	{
-		adjacency.offsets[i] = offset;
-		offset += adjacency.counts[i];
+		unsigned int count = offsets[i];
+		offsets[i] = offset;
+		offset += count;
 	}
 
 	assert(offset == index_count);
@@ -217,18 +216,14 @@ static void buildCornerAdjacency(CornerAdjacency& adjacency, const unsigned int*
 		unsigned int c = indices ? remap[indices[i * 3 + 2]] : remap[i * 3 + 2];
 
 		// encode corner index in the low 2 bits
-		adjacency.data[adjacency.offsets[a]++] = unsigned(i << 2) | 0;
-		adjacency.data[adjacency.offsets[b]++] = unsigned(i << 2) | 1;
-		adjacency.data[adjacency.offsets[c]++] = unsigned(i << 2) | 2;
+		adjacency.data[offsets[a]++] = unsigned(i << 2) | 0;
+		adjacency.data[offsets[b]++] = unsigned(i << 2) | 1;
+		adjacency.data[offsets[c]++] = unsigned(i << 2) | 2;
 	}
 
-	// fix offsets that have been disturbed by the previous pass
-	for (size_t i = 0; i < vertex_count; ++i)
-	{
-		assert(adjacency.offsets[i] >= adjacency.counts[i]);
-
-		adjacency.offsets[i] -= adjacency.counts[i];
-	}
+	// finalize offsets
+	adjacency.offsets[0] = 0;
+	assert(adjacency.offsets[vertex_count] == index_count);
 }
 
 static unsigned int follow2(unsigned int* parents, unsigned int index)
@@ -394,8 +389,8 @@ void meshopt_generateTangents(float* result, const unsigned int* indices, size_t
 		groupsign[i * 3 + 0] = groupsign[i * 3 + 1] = groupsign[i * 3 + 2] = (face_tangents[i].w > 0.f ? 1 : 0) | (face_tangents[i].w < 0.f ? 2 : 0);
 
 	for (size_t i = 0; i < vertex_count; ++i)
-		if (adjacency.counts[i])
-			mergeTangentGroups(groups, groupsign, adjacency.data + adjacency.offsets[i], adjacency.counts[i], indices, remap);
+		if (adjacency.offsets[i + 1] != adjacency.offsets[i])
+			mergeTangentGroups(groups, groupsign, adjacency.data + adjacency.offsets[i], adjacency.offsets[i + 1] - adjacency.offsets[i], indices, remap);
 
 	for (size_t i = 0; i < index_count; ++i)
 		groups[i] = follow2(groups, unsigned(i));

--- a/src/tangentspace.cpp
+++ b/src/tangentspace.cpp
@@ -9,19 +9,86 @@
 // Morten Mikkelsen. Simulation of wrinkled surfaces revisited. 2008
 namespace meshopt
 {
+
+struct Tangent
+{
+	float x, y, z, w;
+};
+
+static void computeFaceTangents(Tangent* result, size_t triangle_count, const unsigned int* indices, const float* vertex_positions, size_t vertex_positions_stride, const float* vertex_uvs, size_t vertex_uvs_stride)
+{
+	size_t vertex_position_stride_float = vertex_positions_stride / sizeof(float);
+	size_t vertex_uv_stride_float = vertex_uvs_stride / sizeof(float);
+
+	for (size_t i = 0; i < triangle_count; ++i)
+	{
+		unsigned int a = indices ? indices[i * 3 + 0] : unsigned(i * 3 + 0);
+		unsigned int b = indices ? indices[i * 3 + 1] : unsigned(i * 3 + 1);
+		unsigned int c = indices ? indices[i * 3 + 2] : unsigned(i * 3 + 2);
+
+		const float* pa = &vertex_positions[a * vertex_position_stride_float];
+		const float* pb = &vertex_positions[b * vertex_position_stride_float];
+		const float* pc = &vertex_positions[c * vertex_position_stride_float];
+
+		const float* ta = &vertex_uvs[a * vertex_uv_stride_float];
+		const float* tb = &vertex_uvs[b * vertex_uv_stride_float];
+		const float* tc = &vertex_uvs[c * vertex_uv_stride_float];
+
+		// compute face tangents using chain rule, see eq. 42
+		float dp1x = pb[0] - pa[0], dp1y = pb[1] - pa[1], dp1z = pb[2] - pa[2];
+		float dp2x = pc[0] - pa[0], dp2y = pc[1] - pa[1], dp2z = pc[2] - pa[2];
+		float dt1x = tb[0] - ta[0], dt1y = tb[1] - ta[1];
+		float dt2x = tc[0] - ta[0], dt2y = tc[1] - ta[1];
+
+		float rx = dt2y * dp1x - dt1y * dp2x;
+		float ry = dt2y * dp1y - dt1y * dp2y;
+		float rz = dt2y * dp1z - dt1y * dp2z;
+
+		// .w stores orientation (+1/-1) or 0 for degenerate triangles, see eq. 48
+		float det = dt1x * dt2y - dt1y * dt2x;
+		float rw = det == 0.f ? 0.f : (det > 0.f ? 1.f : -1.f);
+
+		float rl = sqrtf(rx * rx + ry * ry + rz * rz);
+		float rs = (det != 0.f && rl != 0.f) ? rw / rl : 0.f;
+
+		result[i].x = rx * rs;
+		result[i].y = ry * rs;
+		result[i].z = rz * rs;
+		result[i].w = rw;
+	}
 }
+
+} // namespace meshopt
 
 // TODO: argument order?
 MESHOPTIMIZER_EXPERIMENTAL void meshopt_generateTangentsMikkT(float* result, const unsigned int* indices, size_t index_count, const float* vertex_positions, size_t vertex_count, size_t vertex_positions_stride, const float* vertex_normals, size_t vertex_normals_stride, const float* vertex_uvs, size_t vertex_uvs_stride)
 {
-	(void)result;
-	(void)indices;
-	(void)index_count;
-	(void)vertex_positions;
+	using namespace meshopt;
+
+	assert(indices || index_count == vertex_count);
+	assert(index_count % 3 == 0);
+	assert(vertex_positions_stride >= 12 && vertex_positions_stride <= 256);
+	assert(vertex_normals_stride >= 12 && vertex_normals_stride <= 256);
+	assert(vertex_uvs_stride >= 12 && vertex_uvs_stride <= 256);
+	assert(vertex_positions_stride % sizeof(float) == 0 && vertex_normals_stride % sizeof(float) == 0 && vertex_uvs_stride % sizeof(float) == 0);
+
+	meshopt_Allocator allocator;
+
+	size_t face_count = index_count / 3;
+
 	(void)vertex_count;
-	(void)vertex_positions_stride;
 	(void)vertex_normals;
 	(void)vertex_normals_stride;
-	(void)vertex_uvs;
-	(void)vertex_uvs_stride;
+
+	// compute per-triangle tangents
+	Tangent* face_tangents = allocator.allocate<Tangent>(face_count);
+	computeFaceTangents(face_tangents, face_count, indices, vertex_positions, vertex_positions_stride, vertex_uvs, vertex_uvs_stride);
+
+	// TODO: for now output per face tangents
+	for (size_t i = 0; i < index_count; ++i)
+	{
+		float* r = &result[i * 4];
+		const Tangent& t = face_tangents[i / 3];
+		r[0] = t.x, r[1] = t.y, r[2] = t.z, r[3] = t.w;
+	}
 }

--- a/src/tangentspace.cpp
+++ b/src/tangentspace.cpp
@@ -7,6 +7,7 @@
 
 // This work is based on:
 // Morten Mikkelsen. Simulation of wrinkled surfaces revisited. 2008
+// Cecil Hastings Jr. Approximations for digital computers. 1955
 namespace meshopt
 {
 
@@ -281,6 +282,16 @@ static void mergeTangentGroups(unsigned int* groups, const unsigned int* data, s
 	}
 }
 
+inline float optacos(float x)
+{
+	// approximation for acos(x) = sqrt(1 - abs(x)) * 2-degree polynomial, max error ~5e-4
+	float ax = fabsf(x);
+	ax = ax > 1.f ? 1.f : ax;
+	float r = 1.570337f + ax * (-0.2053972f + ax * 0.05147786f);
+	r *= sqrtf(1.0f - ax);
+	return x < 0.f ? 3.1415926f - r : r;
+}
+
 static void accumulateTangentGroups(float* result, const unsigned int* groups, const unsigned int* indices, size_t index_count, const unsigned int* remap, const Tangent* face_tangents, const float* vertex_positions, size_t vertex_positions_stride, const float* vertex_normals, size_t vertex_normals_stride)
 {
 	static const int next[4] = {1, 2, 0, 1};
@@ -332,7 +343,7 @@ static void accumulateTangentGroups(float* result, const unsigned int* groups, c
 			float dpl = sqrtf(dp1l * dp2l);
 
 			float cosa = (dp1x * dp2x + dp1y * dp2y + dp1z * dp2z) * (dpl == 0.f ? 0.f : 1.f / dpl);
-			float angle = acosf(cosa < -1.f ? -1.f : (cosa > 1.f ? 1.f : cosa));
+			float angle = optacos(cosa); // optacos handles clamping to [-1..1]
 
 			float w = angle * (sl == 0.f ? 0.f : 1.f / sl);
 

--- a/src/tangentspace.cpp
+++ b/src/tangentspace.cpp
@@ -232,6 +232,55 @@ static void buildCornerAdjacency(CornerAdjacency& adjacency, const unsigned int*
 	}
 }
 
+static unsigned int follow2(unsigned int* parents, unsigned int index)
+{
+	while (index != parents[index])
+	{
+		unsigned int parent = parents[index];
+		parents[index] = parents[parent];
+		index = parent;
+	}
+
+	return index;
+}
+
+static void mergeTangentGroups(unsigned int* groups, const unsigned int* data, size_t count, const unsigned int* indices, const unsigned int* remap, const Tangent* face_tangents)
+{
+	static const int next[4] = {1, 2, 0, 1};
+
+	for (size_t i = 0; i < count; ++i)
+	{
+		unsigned int cib = (data[i] >> 2) * 3 + next[(data[i] & 3) + 0];
+		unsigned int cic = (data[i] >> 2) * 3 + next[(data[i] & 3) + 1];
+
+		unsigned int nib = indices ? remap[indices[cib]] : remap[cib];
+		unsigned int nic = indices ? remap[indices[cic]] : remap[cic];
+
+		float oi = face_tangents[data[i] >> 2].w;
+
+		for (size_t j = i + 1; j < count; ++j)
+		{
+			unsigned int cjb = (data[j] >> 2) * 3 + next[(data[j] & 3) + 0];
+			unsigned int cjc = (data[j] >> 2) * 3 + next[(data[j] & 3) + 1];
+
+			unsigned int njb = indices ? remap[indices[cjb]] : remap[cjb];
+			unsigned int njc = indices ? remap[indices[cjc]] : remap[cjc];
+
+			float oj = face_tangents[data[j] >> 2].w;
+
+			// merge tangent groups if triangles are adjacent and orientations agree or either one is degenerate
+			if ((njb == nic || njc == nib) && oi * oj >= 0.f)
+			{
+				unsigned int gi = follow2(groups, (data[i] >> 2) * 3 + (data[i] & 3));
+				unsigned int gj = follow2(groups, (data[j] >> 2) * 3 + (data[j] & 3));
+
+				if (gi != gj) // TODO: unconditional? perf
+					groups[gj] = gi;
+			}
+		}
+	}
+}
+
 } // namespace meshopt
 
 // TODO: argument order?
@@ -266,6 +315,15 @@ MESHOPTIMIZER_EXPERIMENTAL void meshopt_generateTangentsMikkT(float* result, con
 	// compute per-triangle tangents
 	Tangent* face_tangents = allocator.allocate<Tangent>(face_count);
 	computeFaceTangents(face_tangents, face_count, indices, vertex_positions, vertex_positions_stride, vertex_uvs, vertex_uvs_stride);
+
+	// compute per-corner tangent groups: triangles adjacent to the same vertex with the same orientation are merged in strips
+	unsigned int* groups = allocator.allocate<unsigned int>(index_count);
+	for (size_t i = 0; i < index_count; ++i)
+		groups[i] = unsigned(i);
+
+	for (size_t i = 0; i < vertex_count; ++i)
+		if (adjacency.counts[i])
+			mergeTangentGroups(groups, adjacency.data + adjacency.offsets[i], adjacency.counts[i], indices, remap, face_tangents);
 
 	// TODO: for now output per face tangents
 	for (size_t i = 0; i < index_count; ++i)

--- a/src/tangentspace.cpp
+++ b/src/tangentspace.cpp
@@ -366,7 +366,7 @@ MESHOPTIMIZER_EXPERIMENTAL void meshopt_generateTangents(float* result, const un
 	assert(index_count % 3 == 0);
 	assert(vertex_positions_stride >= 12 && vertex_positions_stride <= 256);
 	assert(vertex_normals_stride >= 12 && vertex_normals_stride <= 256);
-	assert(vertex_uvs_stride >= 12 && vertex_uvs_stride <= 256);
+	assert(vertex_uvs_stride >= 8 && vertex_uvs_stride <= 256);
 	assert(vertex_positions_stride % sizeof(float) == 0 && vertex_normals_stride % sizeof(float) == 0 && vertex_uvs_stride % sizeof(float) == 0);
 
 	meshopt_Allocator allocator;
@@ -417,10 +417,11 @@ MESHOPTIMIZER_EXPERIMENTAL void meshopt_generateTangents(float* result, const un
 			r[0] *= s;
 			r[1] *= s;
 			r[2] *= s;
+			r[0] = s == 0.f ? 1.f : r[0];     // for isolated degenerate triangles, use (1, 0, 0) tangent for consistency
 			r[3] = r[3] == 0.f ? -1.f : r[3]; // for isolated degenerate triangles, use orientation -1 for consistency
 		}
 
 	for (size_t i = 0; i < index_count; ++i)
 		if (groups[i] != i)
-			memcpy(&result[i * 4], &result[groups[i] * 4], sizeof(float) * 4);
+			memcpy(&result[i * 4], &result[size_t(groups[i]) * 4], sizeof(float) * 4);
 }

--- a/src/tangentspace.cpp
+++ b/src/tangentspace.cpp
@@ -1,0 +1,27 @@
+// This file is part of meshoptimizer library; see meshoptimizer.h for version/license details
+#include "meshoptimizer.h"
+
+#include <assert.h>
+#include <math.h>
+#include <string.h>
+
+// This work is based on:
+// Morten Mikkelsen. Simulation of wrinkled surfaces revisited. 2008
+namespace meshopt
+{
+}
+
+// TODO: argument order?
+MESHOPTIMIZER_EXPERIMENTAL void meshopt_generateTangentsMikkT(float* result, const unsigned int* indices, size_t index_count, const float* vertex_positions, size_t vertex_count, size_t vertex_positions_stride, const float* vertex_normals, size_t vertex_normals_stride, const float* vertex_uvs, size_t vertex_uvs_stride)
+{
+	(void)result;
+	(void)indices;
+	(void)index_count;
+	(void)vertex_positions;
+	(void)vertex_count;
+	(void)vertex_positions_stride;
+	(void)vertex_normals;
+	(void)vertex_normals_stride;
+	(void)vertex_uvs;
+	(void)vertex_uvs_stride;
+}

--- a/src/tangentspace.cpp
+++ b/src/tangentspace.cpp
@@ -246,7 +246,7 @@ static unsigned int follow2(unsigned int* parents, unsigned int index)
 	return index;
 }
 
-static void mergeTangentGroups(unsigned int* groups, const unsigned int* data, size_t count, const unsigned int* indices, const unsigned int* remap, const Tangent* face_tangents)
+static void mergeTangentGroups(unsigned int* groups, unsigned char* groupsign, const unsigned int* data, size_t count, const unsigned int* indices, const unsigned int* remap)
 {
 	static const int next[4] = {1, 2, 0, 1};
 
@@ -258,8 +258,6 @@ static void mergeTangentGroups(unsigned int* groups, const unsigned int* data, s
 		unsigned int nib = indices ? remap[indices[cib]] : remap[cib];
 		unsigned int nic = indices ? remap[indices[cic]] : remap[cic];
 
-		float oi = face_tangents[data[i] >> 2].w;
-
 		for (size_t j = i + 1; j < count; ++j)
 		{
 			unsigned int cjb = (data[j] >> 2) * 3 + next[(data[j] & 3) + 0];
@@ -268,17 +266,18 @@ static void mergeTangentGroups(unsigned int* groups, const unsigned int* data, s
 			unsigned int njb = indices ? remap[indices[cjb]] : remap[cjb];
 			unsigned int njc = indices ? remap[indices[cjc]] : remap[cjc];
 
-			float oj = face_tangents[data[j] >> 2].w;
-
 			// merge tangent groups if triangles are adjacent and orientations agree or either one is degenerate
-			// TODO: as is this can create degen bridges between +/-
-			if ((njb == nic || njc == nib) && oi * oj >= 0.f)
+			if (njb == nic || njc == nib)
 			{
 				unsigned int gi = follow2(groups, (data[i] >> 2) * 3 + (data[i] & 3));
 				unsigned int gj = follow2(groups, (data[j] >> 2) * 3 + (data[j] & 3));
 
-				if (gi != gj) // TODO: order?
+				// note, we track signs per group to ensure that we can't merge groups with opposite orientation through a degen bridge
+				if (gi != gj && (groupsign[gi] | groupsign[gj]) != 3)
+				{
 					groups[gj] = gi;
+					groupsign[gi] |= groupsign[gj];
+				}
 			}
 		}
 	}
@@ -391,9 +390,14 @@ MESHOPTIMIZER_EXPERIMENTAL void meshopt_generateTangentsMikkT(float* result, con
 	for (size_t i = 0; i < index_count; ++i)
 		groups[i] = unsigned(i);
 
+	// each group must only contain triangles with the same orientation; to simplify accounting we store signs as a bitmask
+	unsigned char* groupsign = allocator.allocate<unsigned char>(index_count);
+	for (size_t i = 0; i < face_count; ++i)
+		groupsign[i * 3 + 0] = groupsign[i * 3 + 1] = groupsign[i * 3 + 2] = (face_tangents[i].w > 0.f ? 1 : 0) | (face_tangents[i].w < 0.f ? 2 : 0);
+
 	for (size_t i = 0; i < vertex_count; ++i)
 		if (adjacency.counts[i])
-			mergeTangentGroups(groups, adjacency.data + adjacency.offsets[i], adjacency.counts[i], indices, remap, face_tangents);
+			mergeTangentGroups(groups, groupsign, adjacency.data + adjacency.offsets[i], adjacency.counts[i], indices, remap);
 
 	for (size_t i = 0; i < index_count; ++i)
 		groups[i] = follow2(groups, unsigned(i));
@@ -413,7 +417,7 @@ MESHOPTIMIZER_EXPERIMENTAL void meshopt_generateTangentsMikkT(float* result, con
 			r[0] *= s;
 			r[1] *= s;
 			r[2] *= s;
-			r[3] = r[3] == 0.f ? 1.f : r[3]; // for isolated degenerate triangles, use orientation 1 for consistency (TODO: -1?)
+			r[3] = r[3] == 0.f ? -1.f : r[3]; // for isolated degenerate triangles, use orientation -1 for consistency
 		}
 
 	for (size_t i = 0; i < index_count; ++i)

--- a/src/tangentspace.cpp
+++ b/src/tangentspace.cpp
@@ -175,6 +175,63 @@ static void buildVertexRemap(unsigned int* remap, const float* vertex_positions,
 	allocator.deallocate(vertex_table);
 }
 
+struct CornerAdjacency
+{
+	unsigned int* counts;
+	unsigned int* offsets;
+	unsigned int* data;
+};
+
+static void buildCornerAdjacency(CornerAdjacency& adjacency, const unsigned int* indices, size_t index_count, const unsigned int* remap, size_t vertex_count, meshopt_Allocator& allocator)
+{
+	size_t face_count = index_count / 3;
+
+	// allocate arrays
+	adjacency.counts = allocator.allocate<unsigned int>(vertex_count);
+	adjacency.offsets = allocator.allocate<unsigned int>(vertex_count);
+	adjacency.data = allocator.allocate<unsigned int>(index_count);
+
+	// fill triangle counts
+	memset(adjacency.counts, 0, vertex_count * sizeof(unsigned int));
+
+	for (size_t i = 0; i < index_count; ++i)
+	{
+		unsigned int v = indices ? remap[indices[i]] : remap[i];
+		adjacency.counts[v]++;
+	}
+
+	// fill offset table
+	unsigned int offset = 0;
+
+	for (size_t i = 0; i < vertex_count; ++i)
+	{
+		adjacency.offsets[i] = offset;
+		offset += adjacency.counts[i];
+	}
+
+	assert(offset == index_count);
+
+	// fill triangle data
+	for (size_t i = 0; i < face_count; ++i)
+	{
+		unsigned int a = indices ? remap[indices[i * 3 + 0]] : remap[i * 3 + 0];
+		unsigned int b = indices ? remap[indices[i * 3 + 1]] : remap[i * 3 + 1];
+		unsigned int c = indices ? remap[indices[i * 3 + 2]] : remap[i * 3 + 2];
+
+		adjacency.data[adjacency.offsets[a]++] = unsigned(i << 2) | 0;
+		adjacency.data[adjacency.offsets[b]++] = unsigned(i << 2) | 1;
+		adjacency.data[adjacency.offsets[c]++] = unsigned(i << 2) | 2;
+	}
+
+	// fix offsets that have been disturbed by the previous pass
+	for (size_t i = 0; i < vertex_count; ++i)
+	{
+		assert(adjacency.offsets[i] >= adjacency.counts[i]);
+
+		adjacency.offsets[i] -= adjacency.counts[i];
+	}
+}
+
 } // namespace meshopt
 
 // TODO: argument order?
@@ -200,6 +257,11 @@ MESHOPTIMIZER_EXPERIMENTAL void meshopt_generateTangentsMikkT(float* result, con
 	// compute vertex remap to unique vertex index
 	unsigned int* remap = allocator.allocate<unsigned int>(vertex_count);
 	buildVertexRemap(remap, vertex_positions, vertex_count, vertex_positions_stride, vertex_normals, vertex_normals_stride, vertex_uvs, vertex_uvs_stride, allocator);
+
+	// build adjacency information
+	// TODO: since remap maps to original vertices, adjacency will have a lot of holes
+	CornerAdjacency adjacency = {};
+	buildCornerAdjacency(adjacency, indices, index_count, remap, vertex_count, allocator);
 
 	// compute per-triangle tangents
 	Tangent* face_tangents = allocator.allocate<Tangent>(face_count);

--- a/src/tangentspace.cpp
+++ b/src/tangentspace.cpp
@@ -58,6 +58,123 @@ static void computeFaceTangents(Tangent* result, size_t triangle_count, const un
 	}
 }
 
+static unsigned int hashUpdate4(unsigned int h, const unsigned char* key, size_t len)
+{
+	// MurmurHash2
+	const unsigned int m = 0x5bd1e995;
+	const int r = 24;
+
+	while (len >= 4)
+	{
+		unsigned int k = *reinterpret_cast<const unsigned int*>(key);
+
+		k *= m;
+		k ^= k >> r;
+		k *= m;
+
+		h *= m;
+		h ^= k;
+
+		key += 4;
+		len -= 4;
+	}
+
+	return h;
+}
+
+struct VertexHasherF
+{
+	const float* vertex_positions;
+	size_t vertex_positions_stride_float;
+	const float* vertex_normals;
+	size_t vertex_normals_stride_float;
+	const float* vertex_uvs;
+	size_t vertex_uvs_stride_float;
+
+	size_t hash(unsigned int index) const
+	{
+		const float* p = vertex_positions + index * vertex_positions_stride_float;
+		const float* n = vertex_normals + index * vertex_normals_stride_float;
+		const float* t = vertex_uvs + index * vertex_uvs_stride_float;
+
+		// TODO: use a simpler / more direct hash function + handle negative zero
+		unsigned int hash = 0;
+		hash = hashUpdate4(hash, reinterpret_cast<const unsigned char*>(p), 3 * sizeof(float));
+		hash = hashUpdate4(hash, reinterpret_cast<const unsigned char*>(n), 3 * sizeof(float));
+		hash = hashUpdate4(hash, reinterpret_cast<const unsigned char*>(t), 2 * sizeof(float));
+		return hash;
+	}
+
+	bool equal(unsigned int lhs, unsigned int rhs) const
+	{
+		const float* lp = vertex_positions + lhs * vertex_positions_stride_float;
+		const float* ln = vertex_normals + lhs * vertex_normals_stride_float;
+		const float* lt = vertex_uvs + lhs * vertex_uvs_stride_float;
+		const float* rp = vertex_positions + rhs * vertex_positions_stride_float;
+		const float* rn = vertex_normals + rhs * vertex_normals_stride_float;
+		const float* rt = vertex_uvs + rhs * vertex_uvs_stride_float;
+		return lp[0] == rp[0] && lp[1] == rp[1] && lp[2] == rp[2] && ln[0] == rn[0] && ln[1] == rn[1] && ln[2] == rn[2] && lt[0] == rt[0] && lt[1] == rt[1];
+	}
+};
+
+static size_t hashBuckets4(size_t count)
+{
+	size_t buckets = 1;
+	while (buckets < count + count / 4)
+		buckets *= 2;
+
+	return buckets;
+}
+
+template <typename T, typename Hash>
+static T* hashLookup4(T* table, size_t buckets, const Hash& hash, const T& key, const T& empty)
+{
+	assert(buckets > 0);
+	assert((buckets & (buckets - 1)) == 0);
+
+	size_t hashmod = buckets - 1;
+	size_t bucket = hash.hash(key) & hashmod;
+
+	for (size_t probe = 0; probe <= hashmod; ++probe)
+	{
+		T& item = table[bucket];
+
+		if (item == empty)
+			return &item;
+
+		if (hash.equal(item, key))
+			return &item;
+
+		// hash collision, quadratic probing
+		bucket = (bucket + probe + 1) & hashmod;
+	}
+
+	assert(false && "Hash table is full"); // unreachable
+	return NULL;
+}
+
+static void buildVertexRemap(unsigned int* remap, const float* vertex_positions, size_t vertex_count, size_t vertex_positions_stride, const float* vertex_normals, size_t vertex_normals_stride, const float* vertex_uvs, size_t vertex_uvs_stride, meshopt_Allocator& allocator)
+{
+	VertexHasherF vertex_hasher = {vertex_positions, vertex_positions_stride / sizeof(float), vertex_normals, vertex_normals_stride / sizeof(float), vertex_uvs, vertex_uvs_stride / sizeof(float)};
+
+	size_t vertex_table_size = hashBuckets4(vertex_count);
+	unsigned int* vertex_table = allocator.allocate<unsigned int>(vertex_table_size);
+	memset(vertex_table, -1, vertex_table_size * sizeof(unsigned int));
+
+	for (size_t i = 0; i < vertex_count; ++i)
+	{
+		unsigned int index = unsigned(i);
+		unsigned int* entry = hashLookup4(vertex_table, vertex_table_size, vertex_hasher, index, ~0u);
+
+		if (*entry == ~0u)
+			*entry = index;
+
+		remap[index] = *entry;
+	}
+
+	allocator.deallocate(vertex_table);
+}
+
 } // namespace meshopt
 
 // TODO: argument order?
@@ -79,6 +196,10 @@ MESHOPTIMIZER_EXPERIMENTAL void meshopt_generateTangentsMikkT(float* result, con
 	(void)vertex_count;
 	(void)vertex_normals;
 	(void)vertex_normals_stride;
+
+	// compute vertex remap to unique vertex index
+	unsigned int* remap = allocator.allocate<unsigned int>(vertex_count);
+	buildVertexRemap(remap, vertex_positions, vertex_count, vertex_positions_stride, vertex_normals, vertex_normals_stride, vertex_uvs, vertex_uvs_stride, allocator);
 
 	// compute per-triangle tangents
 	Tangent* face_tangents = allocator.allocate<Tangent>(face_count);

--- a/src/tangentspace.cpp
+++ b/src/tangentspace.cpp
@@ -51,7 +51,7 @@ static void computeFaceTangents(Tangent* result, size_t triangle_count, const un
 		float rw = det == 0.f ? 0.f : (det > 0.f ? 1.f : -1.f);
 
 		float rl = sqrtf(rx * rx + ry * ry + rz * rz);
-		float rs = (det != 0.f && rl != 0.f) ? rw / rl : 0.f;
+		float rs = rl != 0.f ? rw / rl : 0.f;
 
 		result[i].x = rx * rs;
 		result[i].y = ry * rs;
@@ -193,6 +193,8 @@ static void buildCornerAdjacency(CornerAdjacency& adjacency, const unsigned int*
 	for (size_t i = 0; i < index_count; ++i)
 	{
 		unsigned int v = indices ? remap[indices[i]] : remap[i];
+		assert(v < vertex_count);
+
 		adjacency.counts[v]++;
 	}
 
@@ -207,13 +209,14 @@ static void buildCornerAdjacency(CornerAdjacency& adjacency, const unsigned int*
 
 	assert(offset == index_count);
 
-	// fill triangle data
+	// fill corner data
 	for (size_t i = 0; i < face_count; ++i)
 	{
 		unsigned int a = indices ? remap[indices[i * 3 + 0]] : remap[i * 3 + 0];
 		unsigned int b = indices ? remap[indices[i * 3 + 1]] : remap[i * 3 + 1];
 		unsigned int c = indices ? remap[indices[i * 3 + 2]] : remap[i * 3 + 2];
 
+		// encode corner index in the low 2 bits
 		adjacency.data[adjacency.offsets[a]++] = unsigned(i << 2) | 0;
 		adjacency.data[adjacency.offsets[b]++] = unsigned(i << 2) | 1;
 		adjacency.data[adjacency.offsets[c]++] = unsigned(i << 2) | 2;
@@ -323,7 +326,7 @@ static void accumulateTangentGroups(float* result, const unsigned int* groups, c
 			float sl = sqrtf(sx * sx + sy * sy + sz * sz);
 
 			// compute incident angle for weighting, in tangent plane
-			// note: this step is absent from the paper, and the implementation computes angle after projecting edges to tangent plane...
+			// note: this step is absent from the paper, reference implementation computes angle after projecting edges to tangent plane...
 			float dp1x = pb[0] - pa[0], dp1y = pb[1] - pa[1], dp1z = pb[2] - pa[2];
 			float dp2x = pc[0] - pa[0], dp2y = pc[1] - pa[1], dp2z = pc[2] - pa[2];
 
@@ -340,6 +343,7 @@ static void accumulateTangentGroups(float* result, const unsigned int* groups, c
 			float cosa = (dp1x * dp2x + dp1y * dp2y + dp1z * dp2z) * (dpl == 0.f ? 0.f : 1.f / dpl);
 			float angle = optacos(cosa); // optacos handles clamping to [-1..1]
 
+			// accumulate renormalized tangent weighted by angle
 			float w = angle * (sl == 0.f ? 0.f : 1.f / sl);
 
 			r[0] += sx * w;

--- a/src/tangentspace.cpp
+++ b/src/tangentspace.cpp
@@ -114,6 +114,7 @@ struct VertexHasherF
 		const float* rp = vertex_positions + rhs * vertex_positions_stride_float;
 		const float* rn = vertex_normals + rhs * vertex_normals_stride_float;
 		const float* rt = vertex_uvs + rhs * vertex_uvs_stride_float;
+
 		return lp[0] == rp[0] && lp[1] == rp[1] && lp[2] == rp[2] && ln[0] == rn[0] && ln[1] == rn[1] && ln[2] == rn[2] && lt[0] == rt[0] && lt[1] == rt[1];
 	}
 };
@@ -270,12 +271,13 @@ static void mergeTangentGroups(unsigned int* groups, const unsigned int* data, s
 			float oj = face_tangents[data[j] >> 2].w;
 
 			// merge tangent groups if triangles are adjacent and orientations agree or either one is degenerate
+			// TODO: as is this can create degen bridges between +/-
 			if ((njb == nic || njc == nib) && oi * oj >= 0.f)
 			{
 				unsigned int gi = follow2(groups, (data[i] >> 2) * 3 + (data[i] & 3));
 				unsigned int gj = follow2(groups, (data[j] >> 2) * 3 + (data[j] & 3));
 
-				if (gi != gj) // TODO: unconditional? perf
+				if (gi != gj) // TODO: order?
 					groups[gj] = gi;
 			}
 		}
@@ -357,7 +359,6 @@ static void accumulateTangentGroups(float* result, const unsigned int* groups, c
 
 } // namespace meshopt
 
-// TODO: argument order?
 MESHOPTIMIZER_EXPERIMENTAL void meshopt_generateTangentsMikkT(float* result, const unsigned int* indices, size_t index_count, const float* vertex_positions, size_t vertex_count, size_t vertex_positions_stride, const float* vertex_normals, size_t vertex_normals_stride, const float* vertex_uvs, size_t vertex_uvs_stride)
 {
 	using namespace meshopt;
@@ -373,16 +374,11 @@ MESHOPTIMIZER_EXPERIMENTAL void meshopt_generateTangentsMikkT(float* result, con
 
 	size_t face_count = index_count / 3;
 
-	(void)vertex_count;
-	(void)vertex_normals;
-	(void)vertex_normals_stride;
-
 	// compute vertex remap to unique vertex index
 	unsigned int* remap = allocator.allocate<unsigned int>(vertex_count);
 	buildVertexRemap(remap, vertex_positions, vertex_count, vertex_positions_stride, vertex_normals, vertex_normals_stride, vertex_uvs, vertex_uvs_stride, allocator);
 
 	// build adjacency information
-	// TODO: since remap maps to original vertices, adjacency will have a lot of holes
 	CornerAdjacency adjacency = {};
 	buildCornerAdjacency(adjacency, indices, index_count, remap, vertex_count, allocator);
 
@@ -417,7 +413,7 @@ MESHOPTIMIZER_EXPERIMENTAL void meshopt_generateTangentsMikkT(float* result, con
 			r[0] *= s;
 			r[1] *= s;
 			r[2] *= s;
-			r[3] = r[3] == 0.f ? 1.f : r[3]; // for isolated degenerate triangles, use orientation 1 for consistency
+			r[3] = r[3] == 0.f ? 1.f : r[3]; // for isolated degenerate triangles, use orientation 1 for consistency (TODO: -1?)
 		}
 
 	for (size_t i = 0; i < index_count; ++i)

--- a/src/tangentspace.cpp
+++ b/src/tangentspace.cpp
@@ -7,6 +7,7 @@
 
 // This work is based on:
 // Morten Mikkelsen. Simulation of wrinkled surfaces revisited. 2008
+// Matthias Teschner, Bruno Heidelberger, Matthias Mueller, Danat Pomeranets, Markus Gross. Optimized Spatial Hashing for Collision Detection of Deformable Objects. 2003
 // Cecil Hastings Jr. Approximations for digital computers. 1955
 namespace meshopt
 {
@@ -59,30 +60,6 @@ static void computeFaceTangents(Tangent* result, size_t triangle_count, const un
 	}
 }
 
-static unsigned int hashUpdate4(unsigned int h, const unsigned char* key, size_t len)
-{
-	// MurmurHash2
-	const unsigned int m = 0x5bd1e995;
-	const int r = 24;
-
-	while (len >= 4)
-	{
-		unsigned int k = *reinterpret_cast<const unsigned int*>(key);
-
-		k *= m;
-		k ^= k >> r;
-		k *= m;
-
-		h *= m;
-		h ^= k;
-
-		key += 4;
-		len -= 4;
-	}
-
-	return h;
-}
-
 struct VertexHasherF
 {
 	const float* vertex_positions;
@@ -94,16 +71,33 @@ struct VertexHasherF
 
 	size_t hash(unsigned int index) const
 	{
-		const float* p = vertex_positions + index * vertex_positions_stride_float;
-		const float* n = vertex_normals + index * vertex_normals_stride_float;
-		const float* t = vertex_uvs + index * vertex_uvs_stride_float;
+		const unsigned int* p = reinterpret_cast<const unsigned int*>(vertex_positions + index * vertex_positions_stride_float);
+		const unsigned int* n = reinterpret_cast<const unsigned int*>(vertex_normals + index * vertex_normals_stride_float);
+		const unsigned int* t = reinterpret_cast<const unsigned int*>(vertex_uvs + index * vertex_uvs_stride_float);
 
-		// TODO: use a simpler / more direct hash function + handle negative zero
-		unsigned int hash = 0;
-		hash = hashUpdate4(hash, reinterpret_cast<const unsigned char*>(p), 3 * sizeof(float));
-		hash = hashUpdate4(hash, reinterpret_cast<const unsigned char*>(n), 3 * sizeof(float));
-		hash = hashUpdate4(hash, reinterpret_cast<const unsigned char*>(t), 2 * sizeof(float));
-		return hash;
+		unsigned int x = p[0], y = p[1], z = p[2];
+
+		// replace negative zero with zero
+		x = (x == 0x80000000) ? 0 : x;
+		y = (y == 0x80000000) ? 0 : y;
+		z = (z == 0x80000000) ? 0 : z;
+
+		// scramble bits to make sure that integer coordinates have entropy in lower bits
+		x ^= x >> 17;
+		y ^= y >> 17;
+		z ^= z >> 17;
+
+		// mix in normal bits
+		x ^= (n[0] == 0x80000000) ? 0 : n[0] >> 15;
+		y ^= (n[1] == 0x80000000) ? 0 : n[1] >> 15;
+		z ^= (n[2] == 0x80000000) ? 0 : n[2] >> 15;
+
+		// collect texture coordinate bits (simplified -0 handling and scrambling)
+		unsigned int w = (t[0] ^ t[1]) & 0x7fffffff;
+		w ^= w >> 13;
+
+		// Optimized Spatial Hashing for Collision Detection of Deformable Objects
+		return (x * 73856093) ^ (y * 19349663) ^ (z * 83492791) ^ (w * 50331653);
 	}
 
 	bool equal(unsigned int lhs, unsigned int rhs) const

--- a/src/tangentspace.cpp
+++ b/src/tangentspace.cpp
@@ -352,7 +352,7 @@ static void accumulateTangentGroups(float* result, const unsigned int* groups, c
 
 } // namespace meshopt
 
-MESHOPTIMIZER_EXPERIMENTAL void meshopt_generateTangents(float* result, const unsigned int* indices, size_t index_count, const float* vertex_positions, size_t vertex_count, size_t vertex_positions_stride, const float* vertex_normals, size_t vertex_normals_stride, const float* vertex_uvs, size_t vertex_uvs_stride)
+void meshopt_generateTangents(float* result, const unsigned int* indices, size_t index_count, const float* vertex_positions, size_t vertex_count, size_t vertex_positions_stride, const float* vertex_normals, size_t vertex_normals_stride, const float* vertex_uvs, size_t vertex_uvs_stride)
 {
 	using namespace meshopt;
 

--- a/src/tangentspace.cpp
+++ b/src/tangentspace.cpp
@@ -281,6 +281,69 @@ static void mergeTangentGroups(unsigned int* groups, const unsigned int* data, s
 	}
 }
 
+static void accumulateTangentGroups(float* result, const unsigned int* groups, const unsigned int* indices, size_t index_count, const unsigned int* remap, const Tangent* face_tangents, const float* vertex_positions, size_t vertex_positions_stride, const float* vertex_normals, size_t vertex_normals_stride)
+{
+	static const int next[4] = {1, 2, 0, 1};
+
+	size_t vertex_position_stride_float = vertex_positions_stride / sizeof(float);
+	size_t vertex_normal_stride_float = vertex_normals_stride / sizeof(float);
+
+	size_t face_count = index_count / 3;
+
+	for (size_t i = 0; i < face_count; ++i)
+	{
+		const Tangent& t = face_tangents[i];
+
+		if (t.w == 0.f)
+			continue;
+
+		for (int k = 0; k < 3; ++k)
+		{
+			float* r = &result[size_t(groups[i * 3 + k]) * 4];
+
+			unsigned int a = indices ? remap[indices[i * 3 + k]] : remap[i * 3 + k];
+			unsigned int b = indices ? remap[indices[i * 3 + next[k]]] : remap[i * 3 + next[k]];
+			unsigned int c = indices ? remap[indices[i * 3 + next[k + 1]]] : remap[i * 3 + next[k + 1]];
+
+			const float* pa = vertex_positions + a * vertex_position_stride_float;
+			const float* pb = vertex_positions + b * vertex_position_stride_float;
+			const float* pc = vertex_positions + c * vertex_position_stride_float;
+
+			const float* n = vertex_normals + a * vertex_normal_stride_float;
+
+			// reproject tangent vector onto vertex normal
+			float sd = t.x * n[0] + t.y * n[1] + t.z * n[2];
+			float sx = t.x - n[0] * sd, sy = t.y - n[1] * sd, sz = t.z - n[2] * sd;
+			float sl = sqrtf(sx * sx + sy * sy + sz * sz);
+
+			// compute incident angle for weighting, in tangent plane
+			// note: this step is absent from the paper, and the implementation computes angle after projecting edges to tangent plane...
+			float dp1x = pb[0] - pa[0], dp1y = pb[1] - pa[1], dp1z = pb[2] - pa[2];
+			float dp2x = pc[0] - pa[0], dp2y = pc[1] - pa[1], dp2z = pc[2] - pa[2];
+
+			float dp1d = dp1x * n[0] + dp1y * n[1] + dp1z * n[2];
+			float dp2d = dp2x * n[0] + dp2y * n[1] + dp2z * n[2];
+
+			dp1x -= n[0] * dp1d, dp1y -= n[1] * dp1d, dp1z -= n[2] * dp1d;
+			dp2x -= n[0] * dp2d, dp2y -= n[1] * dp2d, dp2z -= n[2] * dp2d;
+
+			float dp1l = dp1x * dp1x + dp1y * dp1y + dp1z * dp1z;
+			float dp2l = dp2x * dp2x + dp2y * dp2y + dp2z * dp2z;
+			float dpl = sqrtf(dp1l * dp2l);
+
+			float cosa = (dp1x * dp2x + dp1y * dp2y + dp1z * dp2z) * (dpl == 0.f ? 0.f : 1.f / dpl);
+			float angle = acosf(cosa < -1.f ? -1.f : (cosa > 1.f ? 1.f : cosa));
+
+			float w = angle * (sl == 0.f ? 0.f : 1.f / sl);
+
+			r[0] += sx * w;
+			r[1] += sy * w;
+			r[2] += sz * w;
+			r[3] = t.w;
+		}
+	}
+}
+
 } // namespace meshopt
 
 // TODO: argument order?
@@ -325,11 +388,28 @@ MESHOPTIMIZER_EXPERIMENTAL void meshopt_generateTangentsMikkT(float* result, con
 		if (adjacency.counts[i])
 			mergeTangentGroups(groups, adjacency.data + adjacency.offsets[i], adjacency.counts[i], indices, remap, face_tangents);
 
-	// TODO: for now output per face tangents
 	for (size_t i = 0; i < index_count; ++i)
-	{
-		float* r = &result[i * 4];
-		const Tangent& t = face_tangents[i / 3];
-		r[0] = t.x, r[1] = t.y, r[2] = t.z, r[3] = t.w;
-	}
+		groups[i] = follow2(groups, unsigned(i));
+
+	// accumulate tangents into their own respective groups
+	memset(result, 0, index_count * sizeof(float) * 4);
+	accumulateTangentGroups(result, groups, indices, index_count, remap, face_tangents, vertex_positions, vertex_positions_stride, vertex_normals, vertex_normals_stride);
+
+	// finalize tangents by normalizing roots and propagating the rest
+	for (size_t i = 0; i < index_count; ++i)
+		if (groups[i] == i)
+		{
+			float* r = &result[i * 4];
+			float l = sqrtf(r[0] * r[0] + r[1] * r[1] + r[2] * r[2]);
+			float s = l == 0.f ? 0.f : 1.f / l;
+
+			r[0] *= s;
+			r[1] *= s;
+			r[2] *= s;
+			r[3] = r[3] == 0.f ? 1.f : r[3]; // for isolated degenerate triangles, use orientation 1 for consistency
+		}
+
+	for (size_t i = 0; i < index_count; ++i)
+		if (groups[i] != i)
+			memcpy(&result[i * 4], &result[groups[i] * 4], sizeof(float) * 4);
 }


### PR DESCRIPTION
This change implements `meshopt_generateTangents`, which generates per-corner tangent frames (tangent vector and orientation) following MikkTSpace algorithm.

## Motivation

`mikktspace.c` is an industry standard, but is often a bottleneck during import as it's not written for efficiency. It also has an interface that is too easy to get wrong (more than half of the engine integrations I have reviewed do not use the library correctly), a few implementation defects and some inconsistent promises about the generated data. It's also 1900 lines of code. Because engine processing pipelines typically use `meshoptimizer` for one reason or another, it would be great if they can switch to using meshoptimizer tangent generation code, and get compatible results at lower cost.

## Usage

The generated frames are *per corner*: three frames are generated for each triangle. The function supports both indexed and un-indexed inputs (similar to `generateVertexRemap` et al); the generated results do *not* depend on the indexing, but the indexed inputs are processed faster.

If you start from an unindexed input, the results of this function can be treated as another unindexed stream, and a reindexing pass will produce final vertex/index buffer.
If you start from an indexed input, it's recommended to duplicate vertices on the fly based on tangent information (see `tangents` example in `demo/main.cpp`). While you *can* omit the duplication step and simply copy tangents into existing vertex data, note that MikkTSpace algorithm splits tangents on UV mirror seams (edges where UV mapping changes winding) - such seams may not have duplicated vertices in the original indexed topology.

Compared to the reference implementation, this implementation is ~5-7x faster on unindexed inputs, ~10-11x faster on indexed inputs, and in most cases produces visually identical outputs.

## Internals

The implementation follows the MikkTSpace *paper* faithfully, and only follows the *reference implementation* (`mikktspace.c`) loosely. It is not based on the reference implementation. It is not guaranteed to produce the same results; however, short of floating point numerics and a couple rare edge cases, it should produce the same results on manifold inputs without degenerate triangles in UV space (triangles that map to a line/point).

MikkTSpace reference implementation has inconsistencies in handling of non-manifold data (it arbitrarily groups triangles into pairs, which violates order independence) and in handling of degenerate triangles (here any algorithm will have to make arbitrary choices; the choices this implementation makes may be different). In either case it should be rare that the difference materially affects the rendered result, and in these cases you'd likely see MikkTSpace generated data flip between different mesh representations anyway.

Compared to the paper, this implementation incorporates the corner weighting by projected angle; this choice of weighting is unexplained and arbitrary, but is necessary to have parity with reference implementation on well-formed meshes. This is the only significant gap in the paper on normal meshes.

Compared to the reference implementation, this implementation uses a different strategy of unifying UV-degenerate triangles with neighbors, and a different strategy of identifying adjacent triangles for non-manifold inputs. The latter uses an actual order-independent approach; the former is inherently input dependent.

The reference implementation has a few defects that this implementation fixes; neither is a problem here:

- Output tangents can be degenerate (0/0/0) in rare cases
- The angular threshold is not correctly disabled by default, which results in rare, numerics-dependent, excessive tangent splits. Notably, Blender ships a rewritten implementation that mostly follows the reference implementation but fixes this issue too.

## Future work

The current implementation has a few known defects, also present in the reference implementation:

- Output triangles can have inconsistent orientation between the three corners (+/-1)
- Output tangent vectors are not always orthogonal to the vertex normals (when using 1,0,0 fallback)
- Tangent vector weighting ignores triangle area which can lead to visibly incorrect tangents.
- Input triangles with degenerate positions but non-degenerate UVs might result in extra tangent splits

These can cause visual artifacts depending on the data representation, but they are difficult to fix in a rigorous manner. In first two cases the problems are specific to UV-degenerate triangles; the third case is dictated by reference implementation if the goal is to match it as closely as possible.

While MikkTSpace can generate both tangent & bitangent vectors separately, almost every usage in the industry uses the recommended cross product based reconstruction; hence this PR only supports that for now. It also expects the caller to figure out how to encode the tangent vectors. Additional functions could be provided to cover either use case in the future as part of the same `.cpp` file.

*This contribution is sponsored by Valve.*