### PR TITLE
tangentspace: Improved tangent space generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -796,6 +796,22 @@ Additionally, note that while the code above works with 32-bit OMM indices, afte
 
 When using 4-state OMMs, rasterization code produces both unknown-transparent and unknown-opaque states based on microtriangle coverage; this enables the use of forced 2-state flag during traversal for specific effects where micromap data is sufficient for reasonable quality; this is recommended for performance as this results in no any-hit invocations.
 
+### Tangent spaces
+
+Meshes that use tangent space normal maps often require per-vertex tangent vectors in addition to normals. These could be exported alongside mesh data, but this library also provides an algorithm similar to MikkTSpace that can generate them from positions, normals and texture coordinates:
+
+```c++
+std::vector<float> tangents(indices.size() * 4);
+meshopt_generateTangents(&tangents[0], &indices[0], indices.size(),
+    &vertices[0].px, vertices.size(), sizeof(Vertex), &vertices[0].nx, sizeof(Vertex), &vertices[0].tx, sizeof(Vertex));
+```
+
+For each triangle *corner* this writes a normalized tangent vector (xyz) and an orientation sign (+-1); the bitangent can be reconstructed in the shader as `cross(normal, tangent.xyz) * tangent.w`. Note that some coordinate space conventions that flip V direction in the texture space require negating orientation sign. The input can be indexed, as in the example above, or not (`indices=NULL`); this does not affect the output tangents.
+
+Because tangents are computed per corner, applying them to mesh vertices requires de-indexing the mesh and generating a new index/vertex buffer afterwards (see `Indexing` section earlier), or using indexed data and copying tangents to existing vertex data while duplicating vertices with different tangents (see `tangents` example in `demo/main.cpp`). With the indexed input, if it contains UV mirroring, vertices along the mirror edge may have different tangent spaces on different sides of the edge and need to be split - copying tangents to existing vertex data without splitting will not produce correct results.
+
+The algorithm uses a MikkTSpace-like construction but by default, uses a modified weighting scheme that significantly improves tangent quality around beveled regions in the mesh. If the normal maps are baked from higher resolution geometry using MikkTSpace weighting, it's possible to produce MikkTSpace-compatible tangents by passing `meshopt_TangentCompatible` option as an extra argument to the function.
+
 ## Memory management
 
 Many algorithms allocate temporary memory to store intermediate results or accelerate processing. The amount of memory allocated is a function of various input parameters such as vertex count and index count. By default memory is allocated using `operator new` and `operator delete`; if these operators are overloaded by the application, the overloads will be used instead. Alternatively it's possible to specify custom allocation/deallocation functions using `meshopt_setAllocator`, e.g.
@@ -828,6 +844,7 @@ Currently, the following APIs are experimental:
 - `meshopt_encode/decodeMeshlet*` functions (`meshopt_encodeMeshlet`, `meshopt_encodeMeshletBound`, `meshopt_decodeMeshlet`, `meshopt_decodeMeshletRaw`)
 - `meshopt_extractMeshletIndices` and `meshopt_optimizeMeshletLevel` functions
 - `meshopt_opacityMap*` functions (`meshopt_opacityMapMeasure`, `meshopt_opacityMapRasterize`, `meshopt_opacityMapCompact`, `meshopt_opacityMapEntrySize`)
+- `meshopt_generateTangents` function and `meshopt_Tangent*` flags
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -801,14 +801,44 @@ When using 4-state OMMs, rasterization code produces both unknown-transparent an
 Meshes that use tangent space normal maps often require per-vertex tangent vectors in addition to normals. These could be exported alongside mesh data, but this library also provides an algorithm similar to MikkTSpace that can generate them from positions, normals and texture coordinates:
 
 ```c++
-std::vector<float> tangents(indices.size() * 4);
-meshopt_generateTangents(&tangents[0], &indices[0], indices.size(),
+std::vector<vec4> tangents(indices.size());
+meshopt_generateTangents(&tangents[0].x, &indices[0], indices.size(),
     &vertices[0].px, vertices.size(), sizeof(Vertex), &vertices[0].nx, sizeof(Vertex), &vertices[0].tx, sizeof(Vertex));
 ```
 
 For each triangle *corner* this writes a normalized tangent vector (xyz) and an orientation sign (+-1); the bitangent can be reconstructed in the shader as `cross(normal, tangent.xyz) * tangent.w`. Note that some coordinate space conventions that flip V direction in the texture space require negating orientation sign. The input can be indexed, as in the example above, or not (`indices=NULL`); this does not affect the output tangents.
 
 Because tangents are computed per corner, applying them to mesh vertices requires de-indexing the mesh and generating a new index/vertex buffer afterwards (see `Indexing` section earlier), or using indexed data and copying tangents to existing vertex data while duplicating vertices with different tangents (see `tangents` example in `demo/main.cpp`). With the indexed input, if it contains UV mirroring, vertices along the mirror edge may have different tangent spaces on different sides of the edge and need to be split - copying tangents to existing vertex data without splitting will not produce correct results.
+
+If splitting is required, it can be efficiently done with an extra pass and an index list per vertex:
+
+```c++
+// seed each vertex with one of its corner tangents; the loop below fixes any mismatches
+for (size_t i = 0; i < indices.size(); ++i)
+    vertices[indices[i]].tangent = tangents[i];
+
+std::vector<unsigned int> splits(vertices.size(), ~0u);
+
+for (size_t i = 0; i < indices.size(); ++i)
+{
+    // walk the chain of split copies looking for a vertex whose tangent matches
+    unsigned int v = indices[i];
+    while (v != ~0u && vertices[v].tangent != tangents[i])
+        v = splits[v];
+
+    // no match in chain: append a new split copy with the target tangent and chain it
+    if (v == ~0u)
+    {
+        v = unsigned(vertices.size());
+        vertices.push_back(vertices[indices[i]]);
+        vertices[v].tangent = tangents[i];
+        splits.push_back(splits[indices[i]]);
+        splits[indices[i]] = v;
+    }
+
+    indices[i] = v;
+}
+```
 
 The algorithm uses a MikkTSpace-like construction but by default, uses a modified weighting scheme that significantly improves tangent quality around beveled regions in the mesh. If the normal maps are baked from higher resolution geometry using MikkTSpace weighting, it's possible to produce MikkTSpace-compatible tangents by passing `meshopt_TangentCompatible` option as an extra argument to the function.
 

--- a/demo/main.cpp
+++ b/demo/main.cpp
@@ -1410,8 +1410,8 @@ void tangents(const Mesh& mesh)
 
 	std::vector<VertexTangent> newvertices(mesh.vertices.size());
 	std::vector<unsigned int> newindices = mesh.indices;
-	std::vector<unsigned int> splits(mesh.vertices.size(), ~0u);
 
+	// copy positions/normals/UVs (Vertex has no tangent field, so we use VertexTangent)
 	for (size_t i = 0; i < mesh.vertices.size(); ++i)
 	{
 		VertexTangent& vt = newvertices[i];
@@ -1420,37 +1420,38 @@ void tangents(const Mesh& mesh)
 		vt.px = v.px, vt.py = v.py, vt.pz = v.pz;
 		vt.nx = v.nx, vt.ny = v.ny, vt.nz = v.nz;
 		vt.tu = v.tx, vt.tv = v.ty;
-		// leave vt.txyzw as 0 as we'll fill them below
 	}
+
+	// seed each vertex with one of its corner tangents; the loop below fixes any mismatches
+	for (size_t i = 0; i < mesh.indices.size(); ++i)
+	{
+		VertexTangent& vt = newvertices[mesh.indices[i]];
+		const float* t = &tangents[i * 4];
+		vt.tx = t[0], vt.ty = t[1], vt.tz = t[2], vt.tw = t[3];
+	}
+
+	std::vector<unsigned int> splits(mesh.vertices.size(), ~0u);
 
 	for (size_t i = 0; i < mesh.indices.size(); ++i)
 	{
 		const float* t = &tangents[i * 4];
 		unsigned int v = mesh.indices[i];
 
-		// initial tangent value
-		if (newvertices[v].tw == 0.f)
-			newvertices[v].tx = t[0], newvertices[v].ty = t[1], newvertices[v].tz = t[2], newvertices[v].tw = t[3];
-		else if (newvertices[v].tx != t[0] || newvertices[v].ty != t[1] || newvertices[v].tz != t[2] || newvertices[v].tw != t[3])
+		// walk the chain of split copies looking for a vertex whose tangent matches
+		while (v != ~0u && (newvertices[v].tx != t[0] || newvertices[v].ty != t[1] || newvertices[v].tz != t[2] || newvertices[v].tw != t[3]))
+			v = splits[v];
+
+		// no match in chain: append a new split copy with the target tangent and chain it
+		if (v == ~0u)
 		{
-			// tangent split; we might be able to reuse previously split vertices, or might need to add a new one
-			unsigned int sv = splits[v];
-			while (sv != ~0u && (newvertices[sv].tx != t[0] || newvertices[sv].ty != t[1] || newvertices[sv].tz != t[2] || newvertices[sv].tw != t[3]))
-				sv = splits[sv];
-
-			// need to add a new split and chain it to the existing list
-			if (sv == ~0u)
-			{
-				sv = unsigned(newvertices.size());
-				newvertices.push_back(newvertices[v]);
-				newvertices[sv].tx = t[0], newvertices[sv].ty = t[1], newvertices[sv].tz = t[2], newvertices[sv].tw = t[3];
-
-				splits.push_back(splits[v]);
-				splits[v] = sv;
-			}
-
-			newindices[i] = sv;
+			v = unsigned(newvertices.size());
+			newvertices.push_back(newvertices[mesh.indices[i]]);
+			newvertices[v].tx = t[0], newvertices[v].ty = t[1], newvertices[v].tz = t[2], newvertices[v].tw = t[3];
+			splits.push_back(splits[mesh.indices[i]]);
+			splits[mesh.indices[i]] = v;
 		}
+
+		newindices[i] = v;
 	}
 
 	double end = timestamp();

--- a/demo/tests.cpp
+++ b/demo/tests.cpp
@@ -3123,6 +3123,60 @@ static void opacityMapSpecial()
 	}
 }
 
+static void tangentDegenerate()
+{
+	struct Vertex
+	{
+		float px, py, pz;
+		float nx, ny, nz;
+		float tx, ty;
+	};
+
+	const Vertex vertices[] = {
+	    {0, 0, 0, 0, 0, 1, 0, 0},
+	    {1, 1, 0, 0, 0, 1, 1, 1},
+	    {2, 2, 0, 0, 0, 1, 2, 2},
+	    {-1, -2, 1, 0, 0, 1, 0, -2},
+	    {0, 1, 1, 0, 0, 1, 1, 0},
+	    {-1, 0, 0, 0, 0, 1, 1, 0},
+	};
+
+	const unsigned int indices[] = {
+	    0, 3, 1, // outer, positive
+	    0, 1, 2, // inner, degenerate UVs
+	    1, 4, 2, // outer, positive
+	    2, 5, 0, // outer, negative
+	};
+
+	float tangents[12 * 4];
+	meshopt_generateTangents(tangents, indices, 12, &vertices[0].px, 6, sizeof(Vertex), &vertices[0].nx, sizeof(Vertex), &vertices[0].tx, sizeof(Vertex), meshopt_TangentCompatible);
+
+	const float vx = 0.0836f;
+	const float vy = 0.9965f;
+	const float expected[12][4] = {
+	    // outer, positive
+	    {1.f, 0.f, 0.f, 1.f}, // 0
+	    {1.f, 0.f, 0.f, 1.f}, // 3
+	    {vx, vy, 0.f, 1.f},   // 1
+	    // inner, degenerate UVs
+	    {1.f, 0.f, 0.f, 1.f}, // 0
+	    {vx, vy, 0.f, 1.f},   // 1
+	    {0.f, 1.f, 0.f, 1.f}, // 2
+	    // outer, positive
+	    {vx, vy, 0.f, 1.f},   // 1
+	    {0.f, 1.f, 0.f, 1.f}, // 4
+	    {0.f, 1.f, 0.f, 1.f}, // 2
+	    // outer, negative
+	    {-1.f, 0.f, 0.f, -1.f}, // 2 (split)
+	    {-1.f, 0.f, 0.f, -1.f}, // 5
+	    {-1.f, 0.f, 0.f, -1.f}, // 0 (split)
+	};
+
+	for (size_t i = 0; i < 12; ++i)
+		for (size_t k = 0; k < 4; ++k)
+			assert(fabsf(tangents[i * 4 + k] - expected[i][k]) < 1e-3f);
+}
+
 void runTests()
 {
 	decodeIndexV0();
@@ -3254,4 +3308,6 @@ void runTests()
 	opacityMap();
 	opacityMapRasterize0();
 	opacityMapSpecial();
+
+	tangentDegenerate();
 }

--- a/src/meshoptimizer.h
+++ b/src/meshoptimizer.h
@@ -899,6 +899,15 @@ MESHOPTIMIZER_EXPERIMENTAL size_t meshopt_opacityMapEntrySize(int level, int sta
 MESHOPTIMIZER_EXPERIMENTAL size_t meshopt_opacityMapCompact(unsigned char* data, size_t data_size, unsigned char* levels, unsigned int* offsets, size_t omm_count, int* omm_indices, size_t triangle_count, int states);
 
 /**
+ * Experimental: tangent generation options
+ */
+enum
+{
+	/* Produce tangents compatible with MikkTSpace (same weighting and fallbacks) at the cost of reduced quality. Not recommended unless normal maps are baked. */
+	meshopt_TangentCompatible = 1 << 0,
+};
+
+/**
  * Experimental: Tangent space generator
  * Computes per-corner tangent vectors following the MikkTSpace algorithm; for each corner, computes normalized tangent vector (xyz) and orientation (w, +/-1).
  * Bitangent can be reconstructed via cross(normal, tangent.xyz) * tangent.w.
@@ -912,7 +921,7 @@ MESHOPTIMIZER_EXPERIMENTAL size_t meshopt_opacityMapCompact(unsigned char* data,
  * vertex_normals should have unit float3 normal in the first 12 bytes of each vertex
  * vertex_uvs should have float2 texture coordinate in the first 8 bytes of each vertex
  */
-MESHOPTIMIZER_EXPERIMENTAL void meshopt_generateTangents(float* result, const unsigned int* indices, size_t index_count, const float* vertex_positions, size_t vertex_count, size_t vertex_positions_stride, const float* vertex_normals, size_t vertex_normals_stride, const float* vertex_uvs, size_t vertex_uvs_stride);
+MESHOPTIMIZER_EXPERIMENTAL void meshopt_generateTangents(float* result, const unsigned int* indices, size_t index_count, const float* vertex_positions, size_t vertex_count, size_t vertex_positions_stride, const float* vertex_normals, size_t vertex_normals_stride, const float* vertex_uvs, size_t vertex_uvs_stride, unsigned int options);
 
 /**
  * Quantize a float into half-precision (as defined by IEEE-754 fp16) floating point value
@@ -1055,7 +1064,7 @@ inline size_t meshopt_partitionClusters(unsigned int* destination, const T* clus
 template <typename T>
 inline void meshopt_spatialSortTriangles(T* destination, const T* indices, size_t index_count, const float* vertex_positions, size_t vertex_count, size_t vertex_positions_stride);
 template <typename T>
-inline void meshopt_generateTangents(float* result, const T* indices, size_t index_count, const float* vertex_positions, size_t vertex_count, size_t vertex_positions_stride, const float* vertex_normals, size_t vertex_normals_stride, const float* vertex_uvs, size_t vertex_uvs_stride);
+inline void meshopt_generateTangents(float* result, const T* indices, size_t index_count, const float* vertex_positions, size_t vertex_count, size_t vertex_positions_stride, const float* vertex_normals, size_t vertex_normals_stride, const float* vertex_uvs, size_t vertex_uvs_stride, unsigned int options = 0);
 #endif
 
 /* Inline implementation */
@@ -1548,11 +1557,11 @@ inline void meshopt_spatialSortTriangles(T* destination, const T* indices, size_
 }
 
 template <typename T>
-inline void meshopt_generateTangents(float* result, const T* indices, size_t index_count, const float* vertex_positions, size_t vertex_count, size_t vertex_positions_stride, const float* vertex_normals, size_t vertex_normals_stride, const float* vertex_uvs, size_t vertex_uvs_stride)
+inline void meshopt_generateTangents(float* result, const T* indices, size_t index_count, const float* vertex_positions, size_t vertex_count, size_t vertex_positions_stride, const float* vertex_normals, size_t vertex_normals_stride, const float* vertex_uvs, size_t vertex_uvs_stride, unsigned int options)
 {
 	meshopt_IndexAdapter<T> in(NULL, indices, indices ? index_count : 0);
 
-	meshopt_generateTangents(result, indices ? in.data : NULL, index_count, vertex_positions, vertex_count, vertex_positions_stride, vertex_normals, vertex_normals_stride, vertex_uvs, vertex_uvs_stride);
+	meshopt_generateTangents(result, indices ? in.data : NULL, index_count, vertex_positions, vertex_count, vertex_positions_stride, vertex_normals, vertex_normals_stride, vertex_uvs, vertex_uvs_stride, options);
 }
 #endif
 

--- a/src/meshoptimizer.h
+++ b/src/meshoptimizer.h
@@ -899,12 +899,14 @@ MESHOPTIMIZER_EXPERIMENTAL size_t meshopt_opacityMapEntrySize(int level, int sta
 MESHOPTIMIZER_EXPERIMENTAL size_t meshopt_opacityMapCompact(unsigned char* data, size_t data_size, unsigned char* levels, unsigned int* offsets, size_t omm_count, int* omm_indices, size_t triangle_count, int states);
 
 /**
- * Experimental: tangent generation options
+ * Tangent generation options
  */
 enum
 {
 	/* Produce tangents compatible with MikkTSpace (same weighting and fallbacks) at the cost of reduced quality. Not recommended unless normal maps are baked. */
 	meshopt_TangentCompatible = 1 << 0,
+	/* Experimental: For vertices only connected to degenerate triangles, output zero tangents instead of an arbitrary fallback.  */
+	meshopt_TangentZeroFallback = 1 << 1,
 };
 
 /**

--- a/src/meshoptimizer.h
+++ b/src/meshoptimizer.h
@@ -911,7 +911,7 @@ enum
 
 /**
  * Experimental: Tangent space generator
- * Computes per-corner tangent vectors following the MikkTSpace algorithm; for each corner, computes normalized tangent vector (xyz) and orientation (w, +/-1).
+ * Computes per-corner tangent vectors; for each corner, computes normalized tangent vector (xyz) and orientation (w, +/-1).
  * Bitangent can be reconstructed via cross(normal, tangent.xyz) * tangent.w.
  * To apply tangents to the mesh, either deindex and reindex it with the tangent stream, or copy tangents to existing vertex data while duplicating
  * vertices with different tangent vectors (e.g. on UV mirror seams).

--- a/src/tangentspace.cpp
+++ b/src/tangentspace.cpp
@@ -301,7 +301,7 @@ inline float optacos(float x)
 	return x < 0.f ? 3.1415926f - r : r;
 }
 
-static void accumulateTangentGroups(float* result, const unsigned int* groups, const unsigned int* indices, size_t index_count, const unsigned int* remap, const Tangent* face_tangents, const float* vertex_positions, size_t vertex_positions_stride, const float* vertex_normals, size_t vertex_normals_stride)
+static void accumulateTangentGroups(float* result, const unsigned int* groups, const unsigned int* indices, size_t index_count, const unsigned int* remap, const Tangent* face_tangents, const float* vertex_positions, size_t vertex_positions_stride, const float* vertex_normals, size_t vertex_normals_stride, unsigned int options)
 {
 	static const int next[4] = {1, 2, 0, 1};
 
@@ -357,6 +357,10 @@ static void accumulateTangentGroups(float* result, const unsigned int* groups, c
 			// accumulate renormalized tangent weighted by angle
 			float w = angle * (sl == 0.f ? 0.f : 1.f / sl);
 
+			// weight larger adjacent triangles more to reduce interpolation artifacts from slivers; this deviates from reference implementation for higher quality
+			if ((options & meshopt_TangentCompatible) == 0)
+				w *= dpl;
+
 			r[0] += sx * w;
 			r[1] += sy * w;
 			r[2] += sz * w;
@@ -366,7 +370,7 @@ static void accumulateTangentGroups(float* result, const unsigned int* groups, c
 
 } // namespace meshopt
 
-void meshopt_generateTangents(float* result, const unsigned int* indices, size_t index_count, const float* vertex_positions, size_t vertex_count, size_t vertex_positions_stride, const float* vertex_normals, size_t vertex_normals_stride, const float* vertex_uvs, size_t vertex_uvs_stride)
+void meshopt_generateTangents(float* result, const unsigned int* indices, size_t index_count, const float* vertex_positions, size_t vertex_count, size_t vertex_positions_stride, const float* vertex_normals, size_t vertex_normals_stride, const float* vertex_uvs, size_t vertex_uvs_stride, unsigned int options)
 {
 	using namespace meshopt;
 
@@ -417,7 +421,7 @@ void meshopt_generateTangents(float* result, const unsigned int* indices, size_t
 
 	// accumulate tangents into their own respective groups
 	memset(result, 0, index_count * sizeof(float) * 4);
-	accumulateTangentGroups(result, groups, indices, index_count, remap, face_tangents, vertex_positions, vertex_positions_stride, vertex_normals, vertex_normals_stride);
+	accumulateTangentGroups(result, groups, indices, index_count, remap, face_tangents, vertex_positions, vertex_positions_stride, vertex_normals, vertex_normals_stride, options);
 
 	// finalize tangent signs for each face using facegroups
 	for (size_t i = 0; i < face_count; ++i)

--- a/src/tangentspace.cpp
+++ b/src/tangentspace.cpp
@@ -238,38 +238,54 @@ static unsigned int follow2(unsigned int* parents, unsigned int index)
 	return index;
 }
 
-static void mergeTangentGroups(unsigned int* groups, unsigned char* groupsign, const unsigned int* data, size_t count, const unsigned int* indices, const unsigned int* remap)
+static void mergeTangentGroups(unsigned int* groups, unsigned int* facegroups, unsigned char* facesign, const unsigned int* data, size_t count, const unsigned int* indices, const unsigned int* remap)
 {
 	static const int next[4] = {1, 2, 0, 1};
 
 	for (size_t i = 0; i < count; ++i)
 	{
-		unsigned int cib = (data[i] >> 2) * 3 + next[(data[i] & 3) + 0];
-		unsigned int cic = (data[i] >> 2) * 3 + next[(data[i] & 3) + 1];
+		unsigned int ti = data[i] >> 2;
+		unsigned int cib = ti * 3 + next[(data[i] & 3) + 0];
+		unsigned int cic = ti * 3 + next[(data[i] & 3) + 1];
 
 		unsigned int nib = indices ? remap[indices[cib]] : remap[cib];
 		unsigned int nic = indices ? remap[indices[cic]] : remap[cic];
 
 		for (size_t j = i + 1; j < count; ++j)
 		{
-			unsigned int cjb = (data[j] >> 2) * 3 + next[(data[j] & 3) + 0];
-			unsigned int cjc = (data[j] >> 2) * 3 + next[(data[j] & 3) + 1];
+			unsigned int tj = data[j] >> 2;
+			unsigned int cjb = tj * 3 + next[(data[j] & 3) + 0];
+			unsigned int cjc = tj * 3 + next[(data[j] & 3) + 1];
 
 			unsigned int njb = indices ? remap[indices[cjb]] : remap[cjb];
 			unsigned int njc = indices ? remap[indices[cjc]] : remap[cjc];
 
 			// merge tangent groups if triangles are adjacent and orientations agree or either one is degenerate
-			if (njb == nic || njc == nib)
+			if ((njb == nic || njc == nib) && (facesign[ti] | facesign[tj]) != 3)
 			{
-				unsigned int gi = follow2(groups, (data[i] >> 2) * 3 + (data[i] & 3));
-				unsigned int gj = follow2(groups, (data[j] >> 2) * 3 + (data[j] & 3));
-
-				// note, we track signs per group to ensure that we can't merge groups with opposite orientation through a degen bridge
-				if (gi != gj && (groupsign[gi] | groupsign[gj]) != 3)
+				// if either triangle is degenerate, it could have been assigned to a concrete orientation; we need to confirm that via facegroups
+				if ((facesign[ti] & facesign[tj]) == 0)
 				{
-					groups[gj] = gi;
-					groupsign[gi] |= groupsign[gj];
+					unsigned int gti = follow2(facegroups, ti);
+					unsigned int gtj = follow2(facegroups, tj);
+
+					// skip merge if orientations diverge; otherwise, union the groups with gti as the root
+					if (gti != gtj)
+					{
+						if ((facesign[gti] | facesign[gtj]) == 3)
+							continue;
+
+						facegroups[gtj] = gti;
+						facesign[gti] |= facesign[gtj];
+					}
 				}
+
+				// union tangent groups for individual corners with gi as the root; the orientations must match due to facegroups check above
+				unsigned int gi = follow2(groups, ti * 3 + (data[i] & 3));
+				unsigned int gj = follow2(groups, tj * 3 + (data[j] & 3));
+
+				if (gi != gj)
+					groups[gj] = gi;
 			}
 		}
 	}
@@ -344,7 +360,6 @@ static void accumulateTangentGroups(float* result, const unsigned int* groups, c
 			r[0] += sx * w;
 			r[1] += sy * w;
 			r[2] += sz * w;
-			r[3] = t.w;
 		}
 	}
 }
@@ -383,14 +398,19 @@ void meshopt_generateTangents(float* result, const unsigned int* indices, size_t
 	for (size_t i = 0; i < index_count; ++i)
 		groups[i] = unsigned(i);
 
-	// each group must only contain triangles with the same orientation; to simplify accounting we store signs as a bitmask
-	unsigned char* groupsign = allocator.allocate<unsigned char>(index_count);
+	// compute per-face orientation groups: degenerate triangles are merged with adjacent non-degenerate ones and inherit their orientation, stored as a bitmask
+	unsigned int* facegroups = allocator.allocate<unsigned int>(face_count);
+	unsigned char* facesign = allocator.allocate<unsigned char>(face_count);
+
 	for (size_t i = 0; i < face_count; ++i)
-		groupsign[i * 3 + 0] = groupsign[i * 3 + 1] = groupsign[i * 3 + 2] = (face_tangents[i].w > 0.f ? 1 : 0) | (face_tangents[i].w < 0.f ? 2 : 0);
+	{
+		facegroups[i] = unsigned(i);
+		facesign[i] = (face_tangents[i].w > 0.f ? 1 : 0) | (face_tangents[i].w < 0.f ? 2 : 0);
+	}
 
 	for (size_t i = 0; i < vertex_count; ++i)
 		if (adjacency.offsets[i + 1] != adjacency.offsets[i])
-			mergeTangentGroups(groups, groupsign, adjacency.data + adjacency.offsets[i], adjacency.offsets[i + 1] - adjacency.offsets[i], indices, remap);
+			mergeTangentGroups(groups, facegroups, facesign, adjacency.data + adjacency.offsets[i], adjacency.offsets[i + 1] - adjacency.offsets[i], indices, remap);
 
 	for (size_t i = 0; i < index_count; ++i)
 		groups[i] = follow2(groups, unsigned(i));
@@ -399,7 +419,16 @@ void meshopt_generateTangents(float* result, const unsigned int* indices, size_t
 	memset(result, 0, index_count * sizeof(float) * 4);
 	accumulateTangentGroups(result, groups, indices, index_count, remap, face_tangents, vertex_positions, vertex_positions_stride, vertex_normals, vertex_normals_stride);
 
-	// finalize tangents by normalizing roots and propagating the rest
+	// finalize tangent signs for each face using facegroups
+	for (size_t i = 0; i < face_count; ++i)
+	{
+		unsigned int fg = follow2(facegroups, unsigned(i));
+		float w = (facesign[fg] & 1) ? 1.f : -1.f; // note: if face is degenerate, we canonicalize to -1 for consistency
+
+		result[(i * 3 + 0) * 4 + 3] = result[(i * 3 + 1) * 4 + 3] = result[(i * 3 + 2) * 4 + 3] = w;
+	}
+
+	// finalize tangent vectors by normalizing roots and propagating the rest
 	for (size_t i = 0; i < index_count; ++i)
 		if (groups[i] == i)
 		{
@@ -410,11 +439,10 @@ void meshopt_generateTangents(float* result, const unsigned int* indices, size_t
 			r[0] *= s;
 			r[1] *= s;
 			r[2] *= s;
-			r[0] = s == 0.f ? 1.f : r[0];     // for isolated degenerate triangles, use (1, 0, 0) tangent for consistency
-			r[3] = r[3] == 0.f ? -1.f : r[3]; // for isolated degenerate triangles, use orientation -1 for consistency
+			r[0] = s == 0.f ? 1.f : r[0]; // for isolated degenerate triangles, use (1, 0, 0) tangent for consistency
 		}
 
 	for (size_t i = 0; i < index_count; ++i)
 		if (groups[i] != i)
-			memcpy(&result[i * 4], &result[size_t(groups[i]) * 4], sizeof(float) * 4);
+			memcpy(&result[i * 4], &result[size_t(groups[i]) * 4], sizeof(float) * 3); // .w was set per face earlier
 }

--- a/src/tangentspace.cpp
+++ b/src/tangentspace.cpp
@@ -448,7 +448,9 @@ void meshopt_generateTangents(float* result, const unsigned int* indices, size_t
 			r[0] *= s;
 			r[1] *= s;
 			r[2] *= s;
-			r[0] = s == 0.f ? 1.f : r[0]; // for isolated degenerate triangles, use (1, 0, 0) tangent for consistency
+
+			if ((options & meshopt_TangentZeroFallback) == 0)
+				r[0] = s == 0.f ? 1.f : r[0]; // for isolated degenerate triangles, use (1, 0, 0) tangent for consistency
 		}
 
 	for (size_t i = 0; i < index_count; ++i)

--- a/src/tangentspace.cpp
+++ b/src/tangentspace.cpp
@@ -50,6 +50,11 @@ static void computeFaceTangents(Tangent* result, size_t triangle_count, const un
 		float det = dt1x * dt2y - dt1y * dt2x;
 		float rw = det == 0.f ? 0.f : (det > 0.f ? 1.f : -1.f);
 
+		// treat zero area triangles as degenerate even if their UVs aren't for consistency
+		rw = (pa[0] == pb[0] && pa[1] == pb[1] && pa[2] == pb[2]) ? 0.f : rw;
+		rw = (pa[0] == pc[0] && pa[1] == pc[1] && pa[2] == pc[2]) ? 0.f : rw;
+		rw = (pb[0] == pc[0] && pb[1] == pc[1] && pb[2] == pc[2]) ? 0.f : rw;
+
 		float rl = sqrtf(rx * rx + ry * ry + rz * rz);
 		float rs = rl != 0.f ? rw / rl : 0.f;
 


### PR DESCRIPTION
This change builds on top of #1046 and improves the tangent generation behavior further. A couple fixes improve consistency with MikkTSpace while improving some situations that MikkTSpace mishandles; for example, with this change tangent frame orientation is now consistent across all three triangle corners. Additionally, by default this change switches the tangent weighting to be area-sensitive. This is a departure from MikkTSpace; on real world geometry it's often the case that MikkTSpace generates broken tangents because it over-weighs tangent on thin bevels which displaces tangents away from regular triangles.

While this is almost always an improvement, and is generally benign on other parts of the mesh that don't exhibit this problem, this technically produces different tangents which may distort the lighting if the normal maps were baked from higher resolution geometry using MikkTSpace weighting. Because of this, an option `meshopt_TangentCompatible` can be used to use the original MikkTSpace weighting.

I've also spent some time looking into how to improve tangents on degenerate UV triangles (that are zero-area in UV space), but so far all solutions have tradeoffs and aren't clearly beneficial. An experimental option `meshopt_TangentZeroFallback` can be used to zero these out which can work better as it flattens the normal map but it requires renderers to handle non-orthogonal frames properly which is atypical.

A few examples of improved weighting; the left side matches MikkTSpace perfectly whereas the right side is the new default:

compatible | default
-----------------|-------------
<img width="698" height="707" alt="image" src="https://github.com/user-attachments/assets/38c2856f-9f5c-4d9b-b1b7-b58046625504" /> | <img width="698" height="707" alt="image" src="https://github.com/user-attachments/assets/5b45ad22-7e3c-4790-b89b-d92d306965b3" />
<img width="805" height="948" alt="image" src="https://github.com/user-attachments/assets/c09fdefd-3cb8-4ec9-a729-13aa602ffea3" /> | <img width="805" height="948" alt="image" src="https://github.com/user-attachments/assets/48855c9e-7656-451e-a6e9-48740d974449" />
<img width="1192" height="1200" alt="image" src="https://github.com/user-attachments/assets/e6d7fd9a-3a77-46b3-9003-706c553a7de6" /> | <img width="1192" height="1200" alt="image" src="https://github.com/user-attachments/assets/1b978781-de5d-4a5e-b7a5-f740b8cb13d3" />
<img width="815" height="807" alt="image" src="https://github.com/user-attachments/assets/f55d492a-67e6-4208-8e4a-e82107682af2" /> | <img width="815" height="807" alt="image" src="https://github.com/user-attachments/assets/6d4ec51f-8d80-42af-b051-9d2b5b6ebe69" />
<img width="815" height="807" alt="image" src="https://github.com/user-attachments/assets/0ad40df8-19ec-4187-9733-aaa7152b57bb" /> | <img width="815" height="807" alt="image" src="https://github.com/user-attachments/assets/c66fad25-13f0-42bd-82fa-952fdba92209" />



*This contribution is sponsored by Valve.*