### PR TITLE
 gltfpack: Support optional tangent space generation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -205,6 +205,7 @@ jobs:
           ./gltfpack -test glTF-Sample-Assets/Models/BoxTextured/glTF/BoxTextured.gltf -tc -ts 0.5 -tl 64
           ./gltfpack -test glTF-Sample-Assets/Models/BoxTextured/glTF/BoxTextured.gltf -tc color -tfy -tq 4 -tj 1
           ./gltfpack -test glTF-Sample-Assets/Models/CesiumMan/glTF/CesiumMan.gltf -tu -ts 0.6 -tp -ar 0
+          ./gltfpack -test glTF-Sample-Assets/Models/CesiumMan/glTF/CesiumMan.gltf -gt -kv
           ./gltfpack -test glTF-Sample-Assets/Models/PrimitiveModeNormalsTest/glTF/PrimitiveModeNormalsTest.gltf -si 0.5
           ./gltfpack -test glTF-Sample-Assets/Models/VertexColorTest/glTF/VertexColorTest.gltf -si 0.5 -vc 12
           ./gltfpack -test glTF-Sample-Assets/Models/SimpleMeshes/glTF/SimpleMeshes.gltf -mm

--- a/gltf/gltfpack.cpp
+++ b/gltf/gltfpack.cpp
@@ -419,6 +419,9 @@ static size_t process(cgltf_data* data, const char* input_path, const char* outp
 
 		if (!settings.keep_attributes)
 			filterStreams(mesh, mi);
+
+		if (settings.mesh_tangents && (mi.needs_tangents || settings.keep_attributes))
+			generateTangents(mesh);
 	}
 
 	mergeMeshes(meshes, settings);
@@ -1359,6 +1362,10 @@ int main(int argc, char** argv)
 		{
 			settings.mesh_interleaved = true;
 		}
+		else if (strcmp(arg, "-gt") == 0)
+		{
+			settings.mesh_tangents = true;
+		}
 		else if (strcmp(arg, "-at") == 0 && i + 1 < argc && isdigit(argv[i + 1][0]))
 		{
 			settings.trn_bits = clamp(atoi(argv[++i]), 1, 24);
@@ -1680,6 +1687,7 @@ int main(int argc, char** argv)
 			fprintf(stderr, "\t-vtf: use floating point attributes for texture coordinates\n");
 			fprintf(stderr, "\t-vnf: use floating point attributes for normals\n");
 			fprintf(stderr, "\t-vi: use interleaved vertex attributes (reduces compression efficiency)\n");
+			fprintf(stderr, "\t-gt: generate tangent frames when needed, replacing existing tangents\n");
 			fprintf(stderr, "\t-kv: keep source vertex attributes even if they aren't used\n");
 			fprintf(stderr, "\nAnimations:\n");
 			fprintf(stderr, "\t-at N: use N-bit quantization for translations (default: 16; N should be between 1 and 24)\n");

--- a/gltf/gltfpack.h
+++ b/gltf/gltfpack.h
@@ -145,6 +145,7 @@ struct Settings
 	bool mesh_merge;
 	bool mesh_instancing;
 	bool mesh_interleaved;
+	bool mesh_tangents;
 
 	float simplify_ratio;
 	float simplify_error;
@@ -334,6 +335,7 @@ void mergeMeshInstances(Mesh& mesh);
 void mergeMeshes(std::vector<Mesh>& meshes, const Settings& settings);
 void filterEmptyMeshes(std::vector<Mesh>& meshes);
 void filterStreams(Mesh& mesh, const MaterialInfo& mi);
+void generateTangents(Mesh& mesh);
 
 void mergeMeshMaterials(cgltf_data* data, std::vector<Mesh>& meshes, const Settings& settings);
 void markNeededMaterials(cgltf_data* data, std::vector<MaterialInfo>& materials, const std::vector<Mesh>& meshes, const Settings& settings);

--- a/gltf/mesh.cpp
+++ b/gltf/mesh.cpp
@@ -640,6 +640,92 @@ void filterStreams(Mesh& mesh, const MaterialInfo& mi)
 	mesh.streams.resize(write);
 }
 
+static int getTangentTexcoord(const cgltf_material* material)
+{
+	if (material->normal_texture.texture)
+		return material->normal_texture.texcoord;
+	if (material->has_clearcoat && material->clearcoat.clearcoat_normal_texture.texture)
+		return material->clearcoat.clearcoat_normal_texture.texcoord;
+	if (material->has_anisotropy && material->anisotropy.anisotropy_texture.texture)
+		return material->anisotropy.anisotropy_texture.texcoord;
+	return 0;
+}
+
+static Stream& prepareTangentStream(Mesh& mesh, size_t vertex_count)
+{
+	// remove existing tangent streams, if any
+	// in particular removes morph target streams as we don't support morph tangent generation
+	for (size_t i = 0; i < mesh.streams.size();)
+		if (mesh.streams[i].type == cgltf_attribute_type_tangent)
+			mesh.streams.erase(mesh.streams.begin() + i);
+		else
+			++i;
+
+	mesh.streams.push_back(Stream());
+
+	Stream& tangent = mesh.streams.back();
+	tangent.type = cgltf_attribute_type_tangent;
+	tangent.data.resize(vertex_count);
+
+	return tangent;
+}
+
+void generateTangents(Mesh& mesh)
+{
+	if (mesh.type != cgltf_primitive_type_triangles || mesh.indices.empty() || !mesh.material)
+		return;
+
+	int texcoord = getTangentTexcoord(mesh.material);
+	Stream* positions = getStream(mesh, cgltf_attribute_type_position);
+	Stream* normals = getStream(mesh, cgltf_attribute_type_normal);
+	Stream* uvs = getStream(mesh, cgltf_attribute_type_texcoord, texcoord);
+
+	if (!positions || !normals || !uvs)
+		return;
+
+	size_t vertex_count = positions->data.size();
+	assert(normals->data.size() == vertex_count && uvs->data.size() == vertex_count);
+
+	std::vector<Attr> tangents(mesh.indices.size());
+	meshopt_generateTangents(tangents[0].f, mesh.indices.data(), mesh.indices.size(), positions->data[0].f, vertex_count, sizeof(Attr), normals->data[0].f, sizeof(Attr), uvs->data[0].f, sizeof(Attr), 0);
+
+	// note: potentially invalidates positions/normals/uvs but we no longer use these
+	Stream& tangent = prepareTangentStream(mesh, vertex_count);
+
+	// seed each vertex with one of its corner tangents; the loop below fixes any mismatches
+	for (size_t i = 0; i < mesh.indices.size(); ++i)
+		tangent.data[mesh.indices[i]] = tangents[i];
+
+	std::vector<unsigned int> splits(vertex_count, ~0u);
+
+	for (size_t i = 0; i < mesh.indices.size(); ++i)
+	{
+		const Attr& t = tangents[i];
+		unsigned int v = mesh.indices[i];
+		unsigned int sv = v;
+
+		// walk the chain of split copies looking for a vertex whose tangent matches
+		while (sv != ~0u && !(tangent.data[sv].f[0] == t.f[0] && tangent.data[sv].f[1] == t.f[1] && tangent.data[sv].f[2] == t.f[2] && tangent.data[sv].f[3] == t.f[3]))
+			sv = splits[sv];
+
+		// no match in chain: append a new split copy with the target tangent and chain it
+		if (sv == ~0u)
+		{
+			sv = unsigned(tangent.data.size());
+
+			for (Stream& stream : mesh.streams)
+				stream.data.push_back(stream.data[v]);
+
+			tangent.data[sv] = t;
+
+			splits.push_back(splits[v]);
+			splits[v] = sv;
+		}
+
+		mesh.indices[i] = sv;
+	}
+}
+
 struct QuantizedTBN
 {
 	int8_t nx, ny, nz, nw;


### PR DESCRIPTION
When `-gt` flag is specified, we now replace the original mesh tangents
with newly generated ones, using the new meshoptimizer tangent algorithm.

While it would be possible to only generate tangent streams for meshes
that don't already have one, a lot of existing glTF assets have tangents
that are broken or poor quality, so for now we always overwrite tangents,
and also use the higher quality default algorithm.

In the future we could add extra options to customize this.

Morph tangents are rare and require custom code so that we only split
the mesh based on original normal stream; for now we simply drop them.