### PR TITLE
Implement shared exponent helper for cluster encoding

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,3 +6,6 @@ indent_style = tab
 indent_size = 4
 trim_trailing_whitespace = true
 insert_final_newline = true
+
+[*.md]
+indent_style = space

--- a/README.md
+++ b/README.md
@@ -298,8 +298,8 @@ Both of the meshlet algorithms are designed to work with triangle meshes. In som
 ```c++
 const size_t cluster_size = 256;
 
-std::vector<unsigned int> index(mesh.vertices.size());
-meshopt_spatialClusterPoints(&index[0], &mesh.vertices[0].px, mesh.vertices.size(), sizeof(Vertex), cluster_size);
+std::vector<unsigned int> index(vertices.size());
+meshopt_spatialClusterPoints(&index[0], &vertices[0].px, vertices.size(), sizeof(Vertex), cluster_size);
 ```
 
 The resulting index buffer could be used to process the points directly, or reorganize the point data into flat contiguous arrays. Every consecutive chunk of `cluster_size` points in the index buffer refers to a single cluster, with just the last cluster containing fewer points if the total number of points is not a multiple of `cluster_size`. Note that the index buffer is not a remap table, so `meshopt_remapVertexBuffer` can't be used to flatten the point data.
@@ -323,6 +323,52 @@ Two clusters are considered topologically adjacent if they reference the same in
 If vertex positions are specified (not `NULL`), spatial locality will influence priority of merging clusters; otherwise, the algorithm will rely solely on topological connections and will not merge disconnected clusters into the same partition, which may result in smaller partitions for some inputs.
 
 After partitioning, each element in the destination array contains the partition ID (ranging from 0 to the returned partition count minus 1) for the corresponding cluster. Note that the partitions may be both smaller and larger than the target size; given a target size, the maximum partition size returned currently is `target + target / 3`.
+
+### Cluster position quantization
+
+When working with clustered geometry, it may be possible to use cluster-relative quantization for vertex positions. In particular, a common representation involves quantizing positions to lie on an integer grid with an exponent shared between clusters, to avoid quantizing shared vertices differently between clusters, and storing each position as an offset from the cluster anchor. A variant of this representation called [Compressed1 position encoding](https://microsoft.github.io/DirectX-Specs/d3d/Raytracing2.html#compressed1-position-encoding) is supported by DXR2. This library provides a helper function, `meshopt_computePositionExponent`, that can be used to compute the exponent, as well as an example (see `encodeMeshletsDXR` in `demo/main.cpp`) demonstrating the full pipeline.
+
+First, compute the shared exponent to guarantee that any vertex in every cluster fits in a 24-bit signed integer, and additionally can be encoded as a K-bit unsigned delta from the per-cluster anchor (in the example below, `K=16` which matches DXR2 limits):
+
+```c++
+const int min_exp = -13; // start with an acceptable level of precision; 2^-13 ~= 0.1mm in metric units
+int exponent = min_exp;
+
+for (size_t i = 0; i < meshlets.size(); ++i)
+{
+    int cexp = meshopt_computePositionExponent(meshlet_aabb[i].min, meshlet_aabb[i].max, min_exp, /* max_bits= */ 16);
+    exponent = std::max(exponent, cexp);
+}
+
+float scale = ldexpf(1.f, exponent);
+```
+
+After this, each cluster can be encoded independently; when encoding each position, positions should be converted to the integer grid, and the anchor should be established:
+
+```c++
+int positions[256][3];
+int anchor[3] = {INT_MAX, INT_MAX, INT_MAX};
+
+for (size_t j = 0; j < meshlet.vertex_count; ++j)
+{
+    unsigned int v = meshlet_vertices[meshlet.vertex_offset + j];
+    const float* p = &vertices[v].px;
+
+    for (int k = 0; k < 3; ++k)
+    {
+        positions[j][k] = int(roundf(p[k] / scale));
+        anchor[k] = std::min(anchor[k], positions[j][k]);
+    }
+}
+```
+
+The exponent selection guarantees that as a result, for each cluster, we get 24-bit `anchor` components, and for each vertex `position[k] - anchor[k]` fits into a 16-bit unsigned integer. The positions *could* then be encoded using a fixed-width 16-bit encoding, with 6 bytes per vertex; however, because many clusters will require fewer bits, it's more efficient to determine the bit count per axis per cluster (by computing the number of bits per axis that is sufficient to fit `position[k] - anchor[k]`), and encoding the resulting deltas from the anchor into a bitstream. When using DXR2, the resulting position bits can be given directly to the cluster BVH builder by using `D3D12_VERTEX_FORMAT_COMPRESSED1` format.
+
+The same data could be directly decoded from a mesh shader in hybrid rendering pipelines, since each cluster uses a consistent number of bits per axis; this would require implementing unaligned bitstream read access in the shader, an exercise which shall be left to the reader.
+
+> In the examples above, `max_bits` is set to 16 to match DXR2 limits. If DXR2 compatibility is not required, it may sometimes be necessary to use more bits to accommodate larger clusters. This is particularly relevant when using hierarchical cluster LOD, as all clusters at all levels of detail must share the exponent to eliminate gaps between adjacent clusters at different resolutions; Nanite uses up to 21 bits per axis for this reason.
+
+This scheme works well together with meshlet compression described below, which can be used to encode topology (triangles) efficiently.
 
 ## Mesh compression
 
@@ -873,6 +919,7 @@ Currently, the following APIs are experimental:
 - `meshopt_SimplifyRegularizeLight` flag for `meshopt_simplify*` functions
 - `meshopt_encode/decodeMeshlet*` functions (`meshopt_encodeMeshlet`, `meshopt_encodeMeshletBound`, `meshopt_decodeMeshlet`, `meshopt_decodeMeshletRaw`)
 - `meshopt_extractMeshletIndices` and `meshopt_optimizeMeshletLevel` functions
+- `meshopt_computePositionExponent` function
 - `meshopt_opacityMap*` functions (`meshopt_opacityMapMeasure`, `meshopt_opacityMapRasterize`, `meshopt_opacityMapCompact`, `meshopt_opacityMapEntrySize`)
 - `meshopt_generateTangents` function and `meshopt_Tangent*` flags
 

--- a/README.md
+++ b/README.md
@@ -336,7 +336,8 @@ int exponent = min_exp;
 
 for (size_t i = 0; i < meshlets.size(); ++i)
 {
-    int cexp = meshopt_computePositionExponent(meshlet_aabb[i].min, meshlet_aabb[i].max, min_exp, /* max_bits= */ 16);
+    AABB meshlet_aabb = ...; // compute meshlet AABB based on vertex positions
+    int cexp = meshopt_computePositionExponent(meshlet_aabb.min, meshlet_aabb.max, min_exp, /* max_bits= */ 16);
     exponent = std::max(exponent, cexp);
 }
 
@@ -364,7 +365,7 @@ for (size_t j = 0; j < meshlet.vertex_count; ++j)
 
 The exponent selection guarantees that as a result, for each cluster, we get 24-bit `anchor` components, and for each vertex `position[k] - anchor[k]` fits into a 16-bit unsigned integer. The positions *could* then be encoded using a fixed-width 16-bit encoding, with 6 bytes per vertex; however, because many clusters will require fewer bits, it's more efficient to determine the bit count per axis per cluster (by computing the number of bits per axis that is sufficient to fit `position[k] - anchor[k]`), and encoding the resulting deltas from the anchor into a bitstream. When using DXR2, the resulting position bits can be given directly to the cluster BVH builder by using `D3D12_VERTEX_FORMAT_COMPRESSED1` format.
 
-The same data could be directly decoded from a mesh shader in hybrid rendering pipelines, since each cluster uses a consistent number of bits per axis; this would require implementing unaligned bitstream read access in the shader, an exercise which shall be left to the reader.
+The same data could be directly decoded from a mesh shader in hybrid rendering pipelines, since each cluster uses a consistent number of bits per axis; this would require implementing unaligned bitstream read access in the shader. Alternatively, deltas could be stored as 16-bit integers alongside other vertex data (taking as much space as `snorm16`/`half` positions with significantly increased precision for larger meshes).
 
 > In the examples above, `max_bits` is set to 16 to match DXR2 limits. If DXR2 compatibility is not required, it may sometimes be necessary to use more bits to accommodate larger clusters. This is particularly relevant when using hierarchical cluster LOD, as all clusters at all levels of detail must share the exponent to eliminate gaps between adjacent clusters at different resolutions; Nanite uses up to 21 bits per axis for this reason.
 

--- a/demo/main.cpp
+++ b/demo/main.cpp
@@ -1045,6 +1045,53 @@ void encodeMeshletsDXR(const Mesh& mesh, size_t max_triangles, int min_exp, int 
 	    int(meshlets.size()), int(packed.size()),
 	    double(packed.size()) / double(tris), double(stats_headers) / double(tris), double(stats_positions) / double(tris), double(stats_topology) / double(tris),
 	    double(mbc) / double(tris));
+
+#if !TRACE
+	double mbtime = 0;
+	size_t mbsize = 0;
+
+	for (int i = 0; i < 10; ++i)
+	{
+		unsigned char clp[12 + 256 * 6]; // up to 48 bits per vertex
+		unsigned char clt[256 * 3 + 4];  // +4 bytes for padding
+
+		double t0 = timestamp();
+		unsigned char* p = &packed[0];
+		for (size_t j = 0; j < meshlets.size(); ++j)
+		{
+			// decode cluster header
+			size_t vertex_count = p[0] + 1;
+			size_t triangle_count = p[1] + 1;
+			size_t topology_size = p[2] | (p[3] << 8);
+
+			// decode DXR header to establish position size
+			size_t position_bitsx = (p[8] & 15) + 1;
+			size_t position_bitsy = ((p[8] >> 4) & 15) + 1;
+			size_t position_bitsz = (p[12] & 15) + 1;
+			size_t position_size = (vertex_count * (position_bitsx + position_bitsy + position_bitsz) + 7) / 8;
+
+			// memcpy DXR Compressed1 portion as is
+			void* clpopt = topology_size ? clp : clt; // note: hack to ensure memcpy is not elided for benchmarking purposes; topology_size is always >0 so this always copies into clp
+			memcpy(clpopt, p + 4, 12 + position_size);
+
+			// decode topology as 3 bytes per triangle
+			int rc = meshopt_decodeMeshlet(static_cast<unsigned int*>(NULL), 0, clt, triangle_count, p + 16 + position_size, topology_size);
+			assert(rc == 0);
+			(void)rc;
+
+			p += 16 + position_size + topology_size;
+			if (i == 0) // stats for decode throughput
+				mbsize += position_size + triangle_count * 3;
+		}
+		double t1 = timestamp();
+
+		mbtime = (mbtime == 0 || t1 - t0 < mbtime) ? (t1 - t0) : mbtime;
+	}
+
+	printf("MeshletCodecDXR (%d): decode time %.3f msec, %.3fB tri/sec, %.3f GB/sec\n",
+	    int(max_triangles),
+	    mbtime * 1000, double(tris) / 1e9 / mbtime, double(mbsize) / mbtime * 1e-9);
+#endif
 }
 
 template <typename PV>

--- a/demo/main.cpp
+++ b/demo/main.cpp
@@ -935,7 +935,7 @@ void encodeMeshletsDXR(const Mesh& mesh, size_t max_triangles, int min_exp, int 
 
 	// compute shared exponent per mesh:
 	// - must be at most min_exp which should be set to maximum required precision (e.g. -10 for 1mm accuracy given metric units)
-	// - must accomodate each cluster to fit into Compressed1 DXR encoding (16-bit offsets from 24-bit anchors)
+	// - must accommodate each cluster to fit into Compressed1 DXR encoding (16-bit offsets from 24-bit anchors)
 	// note, for DGF parity min_exp should be set based on mesh AABB; we do not do this as we do not consider this rigorous.
 	int exponent = min_exp;
 
@@ -955,7 +955,7 @@ void encodeMeshletsDXR(const Mesh& mesh, size_t max_triangles, int min_exp, int 
 			}
 		}
 
-		int cexp = meshopt_computeClusterPositionExponent(minv, maxv, min_exp, /* max_bits= */ 16);
+		int cexp = meshopt_computePositionExponent(minv, maxv, min_exp, /* max_bits= */ 16);
 		exponent = (exponent > cexp) ? exponent : cexp;
 	}
 

--- a/demo/main.cpp
+++ b/demo/main.cpp
@@ -1,6 +1,7 @@
 #include "../src/meshoptimizer.h"
 
 #include <assert.h>
+#include <float.h>
 #include <math.h>
 #include <stdio.h>
 #include <string.h>
@@ -887,6 +888,165 @@ void encodeMeshlets(const Mesh& mesh, size_t max_vertices, size_t max_triangles,
 #endif
 }
 
+static void writeBits(std::vector<unsigned char>& data, unsigned int& acc, int& acc_bits, unsigned int value, int bits)
+{
+	assert(value < (1u << bits));
+	assert(acc_bits + bits <= 32);
+
+	acc |= value << acc_bits;
+	acc_bits += bits;
+
+	while (acc_bits >= 8)
+	{
+		data.push_back((unsigned char)(acc & 0xff));
+		acc >>= 8;
+		acc_bits -= 8;
+	}
+}
+
+void encodeMeshletsDXR(const Mesh& mesh, size_t max_triangles, int min_exp, int level = 3)
+{
+	// split mesh into clusters, optimized for RT
+	size_t min_triangles = max_triangles / 4;
+	size_t max_vertices = 256;
+	float fill_weight = 0.25f;
+	size_t max_meshlets = meshopt_buildMeshletsBound(mesh.indices.size(), max_vertices, min_triangles);
+
+	std::vector<meshopt_Meshlet> meshlets(max_meshlets);
+	std::vector<unsigned int> meshlet_vertices(mesh.indices.size());
+	std::vector<unsigned char> meshlet_triangles(mesh.indices.size());
+
+	meshlets.resize(meshopt_buildMeshletsSpatial(&meshlets[0], &meshlet_vertices[0], &meshlet_triangles[0], &mesh.indices[0], mesh.indices.size(), &mesh.vertices[0].px, mesh.vertices.size(), sizeof(Vertex), max_vertices, min_triangles, max_triangles, fill_weight));
+
+	if (meshlets.size())
+	{
+		const meshopt_Meshlet& last = meshlets.back();
+
+		// this is an example of how to trim the vertex/triangle arrays when copying data out to GPU storage
+		meshlet_vertices.resize(last.vertex_offset + last.vertex_count);
+		meshlet_triangles.resize(last.triangle_offset + last.triangle_count * 3);
+	}
+
+	// optimize each meshlet for locality; this is critical for good compression
+	for (size_t i = 0; i < meshlets.size(); ++i)
+		meshopt_optimizeMeshletLevel(&meshlet_vertices[meshlets[i].vertex_offset], meshlets[i].vertex_count, &meshlet_triangles[meshlets[i].triangle_offset], meshlets[i].triangle_count, level);
+
+	// compute shared exponent per mesh:
+	// - must be at most min_exp which should be set to maximum required precision (e.g. -10 for 1mm accuracy given metric units)
+	// - must accomodate each cluster to fit into Compressed1 DXR encoding (16-bit offsets from 24-bit anchors)
+	// note, for DGF parity min_exp should be set based on mesh AABB; we do not do this as we do not consider this rigorous.
+	int exponent = min_exp;
+
+	for (const meshopt_Meshlet& meshlet : meshlets)
+	{
+		float minv[3] = {FLT_MAX, FLT_MAX, FLT_MAX}, maxv[3] = {-FLT_MAX, -FLT_MAX, -FLT_MAX};
+
+		for (size_t j = 0; j < meshlet.vertex_count; ++j)
+		{
+			unsigned int v = meshlet_vertices[meshlet.vertex_offset + j];
+			const float* p = &mesh.vertices[v].px;
+
+			for (int k = 0; k < 3; ++k)
+			{
+				minv[k] = fminf(minv[k], p[k]);
+				maxv[k] = fmaxf(maxv[k], p[k]);
+			}
+		}
+
+		int cexp = meshopt_computeClusterPositionExponent(minv, maxv, min_exp, /* max_bits= */ 16);
+		exponent = (exponent > cexp) ? exponent : cexp;
+	}
+
+	std::vector<unsigned char> packed;
+	size_t stats_headers = 0, stats_positions = 0, stats_topology = 0;
+
+	for (size_t i = 0; i < meshlets.size(); ++i)
+	{
+		const meshopt_Meshlet& meshlet = meshlets[i];
+
+		// for each cluster, use meshopt codec for meshlet topology; will need to decode using meshopt_decodeMeshlet at runtime
+		unsigned char topology[1024];
+		assert(meshopt_encodeMeshletBound(0, max_triangles) <= sizeof(topology));
+
+		size_t tops = meshopt_encodeMeshlet(topology, sizeof(topology), NULL, 0, &meshlet_triangles[meshlet.triangle_offset], meshlet.triangle_count);
+		assert(tops > 0);
+
+		// for each cluster, positions are encoded using 24-bit anchor and up-to-16-bit offset per axis
+		float scale = ldexpf(1.f, exponent);
+
+		int positions[256][3];
+		int anchor[3] = {INT_MAX, INT_MAX, INT_MAX};
+
+		for (size_t j = 0; j < meshlet.vertex_count; ++j)
+		{
+			unsigned int v = meshlet_vertices[meshlet.vertex_offset + j];
+			const float* p = &mesh.vertices[v].px;
+
+			for (int k = 0; k < 3; ++k)
+			{
+				positions[j][k] = int(roundf(p[k] / scale));
+				anchor[k] = anchor[k] < positions[j][k] ? anchor[k] : positions[j][k];
+			}
+		}
+
+		// compute optimal per-cluster per-axis bit count
+		int bits[3] = {1, 1, 1};
+
+		for (size_t j = 0; j < meshlet.vertex_count; ++j)
+			for (int k = 0; k < 3; ++k)
+			{
+				int v = positions[j][k] - anchor[k];
+				assert(v >= 0 && v < (1 << 16));
+
+				while (v >= (1 << bits[k]))
+					bits[k]++;
+			}
+
+		// prepare cluster header: 1 word with cluster sizes, and 3 words for DXR-compatible cluster position header
+		// see https://microsoft.github.io/DirectX-Specs/d3d/Raytracing2.html#compressed1-position-encoding
+		unsigned int header[4] = {
+		    (meshlet.vertex_count - 1) | ((meshlet.triangle_count - 1) << 8) | (unsigned(tops) << 16),
+		    (unsigned(anchor[0]) << 8) | (exponent + 127),
+		    (unsigned(anchor[1]) << 8) | (unsigned(bits[1] - 1) << 4) | unsigned(bits[0] - 1),
+		    (unsigned(anchor[2]) << 8) | unsigned(bits[2] - 1),
+		};
+
+		// write cluster header, cluster positions, and cluster topology
+		// note: we write the data in a way that is easiest to consume for the decoding; however, for best post-deflate compression consider reordering it
+		// (by grouping headers, positions, and topology into three separate streams)
+		// maximum post-deflate compression can be achieved by interleaving the cluster position bits per axis (all X => all Y => all Z), but that requires extra decoding work
+		// this layout can be decoded using `meshopt_decodeMeshlet` + `memcpy` when the consumer is DXR2-compatible.
+		for (unsigned int word : header)
+			for (int k = 0; k < 4; ++k)
+				packed.push_back((unsigned char)((word >> (k * 8)) & 0xff));
+
+		unsigned int acc = 0;
+		int acc_bits = 0;
+
+		for (size_t j = 0; j < meshlet.vertex_count; ++j)
+			for (int k = 0; k < 3; ++k)
+				writeBits(packed, acc, acc_bits, positions[j][k] - anchor[k], bits[k]);
+
+		if (acc_bits)
+			packed.push_back((unsigned char)(acc & 0xff));
+
+		packed.insert(packed.end(), topology, topology + tops);
+
+		stats_headers += 4 * 4;
+		stats_positions += (meshlet.vertex_count * (bits[0] + bits[1] + bits[2]) + 7) / 8;
+		stats_topology += tops;
+	}
+
+	size_t mbc = compress(packed);
+	size_t tris = mesh.indices.size() / 3;
+
+	printf("MeshletCodecDXR (%d@%d): %d meshlets, %d bytes; %.1f bytes/triangle (%.1f headers, %.1f positions, %.1f topology); post-deflate: %.1f bytes/triangle\n",
+	    int(max_triangles), exponent,
+	    int(meshlets.size()), int(packed.size()),
+	    double(packed.size()) / double(tris), double(stats_headers) / double(tris), double(stats_positions) / double(tris), double(stats_topology) / double(tris),
+	    double(mbc) / double(tris));
+}
+
 template <typename PV>
 void packVertex(const Mesh& mesh, const char* pvn)
 {
@@ -1627,6 +1787,7 @@ void process(const char* path)
 	encodeVertex<PackedVertexOct>(copy, "O");
 
 	encodeMeshlets(mesh, 64, 96);
+	encodeMeshletsDXR(mesh, 128, /* min_exp= */ -14);
 
 	simplify(mesh);
 	simplify(mesh, 0.1f, meshopt_SimplifyPrune);
@@ -1658,7 +1819,7 @@ void processDev(const char* path)
 	if (!loadMesh(mesh, path))
 		return;
 
-	tangents(mesh);
+	encodeMeshletsDXR(mesh, 128, /* min_exp= */ -14);
 }
 
 void processNanite(const char* path)

--- a/demo/main.cpp
+++ b/demo/main.cpp
@@ -912,11 +912,13 @@ void encodeMeshletsDXR(const Mesh& mesh, size_t max_triangles, int min_exp, int 
 	float fill_weight = 0.25f;
 	size_t max_meshlets = meshopt_buildMeshletsBound(mesh.indices.size(), max_vertices, min_triangles);
 
+	std::vector<unsigned int> shadow_indices(mesh.indices.size());
+	meshopt_generateShadowIndexBuffer(&shadow_indices[0], &mesh.indices[0], mesh.indices.size(), &mesh.vertices[0].px, mesh.vertices.size(), sizeof(float) * 3, sizeof(Vertex));
+
 	std::vector<meshopt_Meshlet> meshlets(max_meshlets);
 	std::vector<unsigned int> meshlet_vertices(mesh.indices.size());
 	std::vector<unsigned char> meshlet_triangles(mesh.indices.size());
-
-	meshlets.resize(meshopt_buildMeshletsSpatial(&meshlets[0], &meshlet_vertices[0], &meshlet_triangles[0], &mesh.indices[0], mesh.indices.size(), &mesh.vertices[0].px, mesh.vertices.size(), sizeof(Vertex), max_vertices, min_triangles, max_triangles, fill_weight));
+	meshlets.resize(meshopt_buildMeshletsSpatial(&meshlets[0], &meshlet_vertices[0], &meshlet_triangles[0], &shadow_indices[0], mesh.indices.size(), &mesh.vertices[0].px, mesh.vertices.size(), sizeof(Vertex), max_vertices, min_triangles, max_triangles, fill_weight));
 
 	if (meshlets.size())
 	{

--- a/demo/tests.cpp
+++ b/demo/tests.cpp
@@ -2739,6 +2739,112 @@ static void dequantizeHalf()
 	assert(nanf != nanf);
 }
 
+static int validatePositionExponent(const float minv[3], const float maxv[3], int min_exponent, int max_bits)
+{
+	int exponent = meshopt_computePositionExponent(minv, maxv, min_exponent, max_bits);
+
+	const int anchor_min = -(1 << 23);
+	const int anchor_max = (1 << 23) - 1;
+	const unsigned int range_max = (1 << max_bits) - 1;
+
+	float scale = ldexpf(1.f, -exponent);
+
+	for (int k = 0; k < 3; ++k)
+	{
+		float lo = minv[k] * scale;
+		float hi = maxv[k] * scale;
+
+		// lo must fit in 24-bit signed under both round-to-nearest tie-break choices
+		int lo_neg = int(ceilf(lo - 0.5f));  // round half toward -inf
+		int lo_pos = int(floorf(lo + 0.5f)); // round half toward +inf
+		assert(anchor_min <= lo_neg);
+		assert(lo_neg <= lo_pos);
+		assert(lo_pos <= anchor_max);
+
+		// hi must fit in 24-bit signed under both round-to-nearest tie-break choices
+		int hi_neg = int(ceilf(hi - 0.5f));  // round half toward -inf
+		int hi_pos = int(floorf(hi + 0.5f)); // round half toward +inf
+		assert(anchor_min <= hi_neg);
+		assert(hi_neg <= hi_pos);
+		assert(hi_pos <= anchor_max);
+
+		// largest hi - smallest lo must fit in max_bits (covers both round-to-nearest tie-break choices)
+		assert(unsigned(hi_pos - lo_neg) <= range_max);
+	}
+
+	return exponent;
+}
+
+static void computePositionExponent()
+{
+	const float minv[3] = {-1.f, 2.f, 10.f};
+	const float maxv[3] = {1.f, 2.5f, 20.f};
+
+	assert(validatePositionExponent(minv, maxv, -16, 16) == -12);
+	assert(validatePositionExponent(minv, maxv, -10, 16) == -10);
+
+	const float minirr[3] = {-3.14159265f, -2.7182818f, -1.41321356f};
+	const float maxirr[3] = {3.14159265f, 2.7182818f, 1.41321356f};
+
+	assert(validatePositionExponent(minirr, maxirr, -16, 16) == -13);
+
+	const float point[3] = {1000000.f, 0.f, 0.f};
+	assert(validatePositionExponent(point, point, -16, 16) == -3);
+
+	const float negpoint[3] = {-1000000.f, 0.f, 0.f};
+	assert(validatePositionExponent(negpoint, negpoint, -16, 16) == -3);
+
+	const float asym_min[3] = {0.f, -1000.f, 0.f};
+	const float asym_max[3] = {1e-3f, 1000.f, 1.f};
+	assert(validatePositionExponent(asym_min, asym_max, -16, 16) == -5);
+
+	const float zero[3] = {0.f, 0.f, 0.f};
+	assert(validatePositionExponent(zero, zero, -16, 16) == -16);
+
+	const float range_min[3] = {0.f, 0.f, 0.f};
+	const float range_max[3] = {65535.f, 0.f, 0.f};
+	assert(validatePositionExponent(range_min, range_max, 0, 16) == 0);
+
+	const float range_over[3] = {65536.f, 0.f, 0.f};
+	assert(validatePositionExponent(range_min, range_over, 0, 16) == 1);
+
+	const float range_dgf_min[3] = {0.4f, 0.f, 0.f};
+	const float range_dgf_max[3] = {65535.5625f, 0.f, 0.f};
+	assert(validatePositionExponent(range_dgf_min, range_dgf_max, 0, 16) == 1);
+
+	const float range_half_min[3] = {-1.f, 0.f, 0.f};
+	const float range_half_max[3] = {131069.f, 0.f, 0.f};
+	assert(validatePositionExponent(range_half_min, range_half_max, 0, 16) == 2);
+
+	const float anchor_max[3] = {8388607.f, 0.f, 0.f};
+	assert(validatePositionExponent(anchor_max, anchor_max, 0, 16) == 0);
+
+	const float anchor_over[3] = {8388608.f, 0.f, 0.f};
+	assert(validatePositionExponent(anchor_over, anchor_over, 0, 16) == 1);
+
+	const float anchor_min[3] = {-8388608.f, 0.f, 0.f};
+	assert(validatePositionExponent(anchor_min, anchor_min, 0, 16) == 1); // note: symmetric range; 0 would be acceptable
+
+	const float posunit[3] = {1.f, 0.f, 0.f};
+	assert(validatePositionExponent(posunit, posunit, -23, 16) == -22);
+
+	const float negunit[3] = {-1.f, 0.f, 0.f};
+	assert(validatePositionExponent(negunit, negunit, -23, 16) == -22); // note: symmetric range; -23 would be acceptable
+
+	const float ties[3] = {0.5f, -0.5f, 2.5f};
+	assert(validatePositionExponent(ties, ties, 0, 16) == 0);
+
+	const float tie_min[3] = {-0.5f, 0.f, 0.f};
+	const float tie_max[3] = {0.5f, 0.f, 0.f};
+	assert(validatePositionExponent(tie_min, tie_max, 0, 16) == 0);
+
+	const float bits21_max[3] = {2097151.f, 0.f, 0.f};
+	assert(validatePositionExponent(range_min, bits21_max, 0, 21) == 0);
+
+	const float anchor_half[3] = {8388607.5f, 0.f, 0.f};
+	assert(validatePositionExponent(anchor_half, anchor_half, 0, 16) == 1);
+}
+
 static void encodeMeshletBound()
 {
 	const unsigned char triangles[5 * 3] = {
@@ -3300,6 +3406,7 @@ void runTests()
 	quantizeFloat();
 	quantizeHalf();
 	dequantizeHalf();
+	computePositionExponent();
 
 	encodeMeshletBound();
 	decodeMeshletSafety();

--- a/src/meshoptimizer.h
+++ b/src/meshoptimizer.h
@@ -947,6 +947,22 @@ MESHOPTIMIZER_API float meshopt_quantizeFloat(float v, int N);
 MESHOPTIMIZER_API float meshopt_dequantizeHalf(unsigned short h);
 
 /**
+ * Experimental: Compute shared exponent suitable for mesh/cluster position quantization
+ * Given mesh or cluster bounds, compute a shared exponent that can be used to quantize any position inside the bounds to a 24-bit integer grid.
+ * The resulting output can be stored as a compact bit-stream to be decoded directly in shaders, or to be used as an input to RT BVH builders,
+ * for example via D3D12_VERTEX_FORMAT_COMPRESSED1 in DXR2 (max_bits=16).
+ *
+ * To quantize positions, compute:
+ *   scale = 2 ** exponent
+ *   iv = int(round(v / scale))
+ * The resulting integer can be stored as signed 24-bit, or as an unsigned offset from a signed 24-bit anchor value, shared between all positions
+ *
+ * min_exp specifies the minimum value for the returned exponent, which allows to limit the precision; e.g. min_exp = -10 will produce minimum error of 1mm given metric units
+ * max_bits specifies the maximum allowed number of bits for the quantized integer range (offset from anchor is an unsigned integer up to 2^max_bits-1)
+ */
+MESHOPTIMIZER_EXPERIMENTAL int meshopt_computeClusterPositionExponent(const float* minv, const float* maxv, int min_exp, int max_bits);
+
+/**
  * Set allocation callbacks
  * These callbacks will be used instead of the default operator new/operator delete for all temporary allocations in the library.
  * Note that all algorithms only allocate memory for temporary use.

--- a/src/meshoptimizer.h
+++ b/src/meshoptimizer.h
@@ -953,14 +953,15 @@ MESHOPTIMIZER_API float meshopt_dequantizeHalf(unsigned short h);
  * for example via D3D12_VERTEX_FORMAT_COMPRESSED1 in DXR2 (max_bits=16).
  *
  * To quantize positions, compute:
- *   scale = 2 ** exponent
+ *   scale = pow(2, exponent)
  *   iv = int(round(v / scale))
- * The resulting integer can be stored as signed 24-bit, or as an unsigned offset from a signed 24-bit anchor value, shared between all positions
+ * The resulting integer can be stored as signed 24-bit, or as an unsigned offset from a signed 24-bit anchor value, shared between all positions.
  *
- * min_exp specifies the minimum value for the returned exponent, which allows to limit the precision; e.g. min_exp = -10 will produce minimum error of 1mm given metric units
+ * minv/maxv specify the axis-aligned bounding box of the mesh or cluster; each should refer to a float3 value
+ * min_exp specifies the minimum value for the returned exponent, limiting precision to reduce size; e.g. min_exp = -10 will produce minimum error of 1mm given metric units
  * max_bits specifies the maximum allowed number of bits for the quantized integer range (offset from anchor is an unsigned integer up to 2^max_bits-1)
  */
-MESHOPTIMIZER_EXPERIMENTAL int meshopt_computeClusterPositionExponent(const float* minv, const float* maxv, int min_exp, int max_bits);
+MESHOPTIMIZER_EXPERIMENTAL int meshopt_computePositionExponent(const float* minv, const float* maxv, int min_exp, int max_bits);
 
 /**
  * Set allocation callbacks

--- a/src/quantization.cpp
+++ b/src/quantization.cpp
@@ -80,7 +80,7 @@ float meshopt_dequantizeHalf(unsigned short h)
 int meshopt_computeClusterPositionExponent(const float* minv, const float* maxv, int min_exp, int max_bits)
 {
 	assert(min_exp >= -126);
-	assert(max_bits >= 1 && max_bits <= 24);
+	assert(max_bits >= 2 && max_bits <= 24);
 
 	int exp = min_exp;
 
@@ -99,27 +99,29 @@ int meshopt_computeClusterPositionExponent(const float* minv, const float* maxv,
 	// maxc is representable as 2^(maxc_exp-24) * 24-bit *unsigned* integer
 	// we have to use a 24-bit *signed* grid, so we have to chop off the last bit
 	// however, rounding in the corner case (mantissa is 1.111...) may increase the exponent by 1 so we need to offset it
-	int maxc_off = 23 - (maxc_fr == 1.f - FLT_EPSILON / 2);
+	int maxc_off = 23 - (maxc_fr >= 1.f - FLT_EPSILON / 2);
 
 	exp = exp < maxc_exp - maxc_off ? maxc_exp - maxc_off : exp;
 
-	// compute conservative anchor with floor rounding, to allow for some ambiguity in the caller's rounding direction
+	// compute effective range with conservative rounding, to allow for some ambiguity in the caller's rounding direction
 	float scale = ldexpf(1.f, -exp);
-	float anchor[3] = {floorf(minv[0] * scale), floorf(minv[1] * scale), floorf(minv[2] * scale)};
-
-	// compute effective range in 24-bit integer space, with conservative ceil rounding
 	float range = 0.f;
+
 	for (int k = 0; k < 3; ++k)
 	{
-		float v = ceilf(maxv[k] * scale) - anchor[k];
-		range = range < v ? v : range;
+		float a = floorf(minv[k] * scale);
+		float v = ceilf(maxv[k] * scale);
+		range = range < v - a ? v - a : range;
 	}
 
 	// range must be representable as max_bits unsigned integer
 	int range_exp = 0;
-	(void)frexpf(range, &range_exp);
+	float range_fr = frexpf(range, &range_exp);
 
 	exp += (range_exp > max_bits) ? range_exp - max_bits : 0;
+
+	// correct range if we are at the rounding boundary that would push us to overflow max_bits
+	exp += range_exp > max_bits && range_fr >= 1.f - 1.f / float((1 << max_bits) - 1);
 
 	return exp;
 }

--- a/src/quantization.cpp
+++ b/src/quantization.cpp
@@ -2,6 +2,7 @@
 #include "meshoptimizer.h"
 
 #include <assert.h>
+#include <math.h>
 
 union FloatBits
 {
@@ -73,4 +74,46 @@ float meshopt_dequantizeHalf(unsigned short h)
 	FloatBits u;
 	u.ui = s | r;
 	return u.f;
+}
+
+int meshopt_computeClusterPositionExponent(const float* minv, const float* maxv, int min_exp, int max_bits)
+{
+	assert(min_exp >= -126);
+	assert(max_bits >= 1 && max_bits <= 24);
+
+	int exp = min_exp;
+
+	// compute max absolute component to ensure that individual endpoints fit on a 24-bit signed grid
+	float maxc = 0.f;
+
+	for (int k = 0; k < 3; ++k)
+	{
+		maxc = maxc < fabsf(minv[k]) ? fabsf(minv[k]) : maxc;
+		maxc = maxc < fabsf(maxv[k]) ? fabsf(maxv[k]) : maxc;
+	}
+
+	int maxc_exp = 0;
+	float maxc_fr = frexpf(maxc, &maxc_exp);
+
+	exp = exp < maxc_exp - 23 ? maxc_exp - 23 : exp;
+
+	// compute conservative anchor with floor rounding, to allow for some ambiguity in the caller's rounding direction
+	float scale = ldexpf(1.f, -exp);
+	float anchor[3] = {floorf(minv[0] * scale), floorf(minv[1] * scale), floorf(minv[2] * scale)};
+
+	// compute effective range in 24-bit integer space, with conservative ceil rounding
+	float range = 0.f;
+	for (int k = 0; k < 3; ++k)
+	{
+		float v = ceilf(maxv[k] * scale) - anchor[k];
+		range = range < v ? v : range;
+	}
+
+	// range must be representable as max_bits unsigned integer
+	int range_exp = 0;
+	(void)frexpf(range, &range_exp);
+
+	exp += (range_exp > max_bits) ? range_exp - max_bits : 0;
+
+	return exp;
 }

--- a/src/quantization.cpp
+++ b/src/quantization.cpp
@@ -2,6 +2,7 @@
 #include "meshoptimizer.h"
 
 #include <assert.h>
+#include <float.h>
 #include <math.h>
 
 union FloatBits
@@ -95,7 +96,12 @@ int meshopt_computeClusterPositionExponent(const float* minv, const float* maxv,
 	int maxc_exp = 0;
 	float maxc_fr = frexpf(maxc, &maxc_exp);
 
-	exp = exp < maxc_exp - 23 ? maxc_exp - 23 : exp;
+	// maxc is representable as 2^(maxc_exp-24) * 24-bit *unsigned* integer
+	// we have to use a 24-bit *signed* grid, so we have to chop off the last bit
+	// however, rounding in the corner case (mantissa is 1.111...) may increase the exponent by 1 so we need to offset it
+	int maxc_off = 23 - (maxc_fr == 1.f - FLT_EPSILON / 2);
+
+	exp = exp < maxc_exp - maxc_off ? maxc_exp - maxc_off : exp;
 
 	// compute conservative anchor with floor rounding, to allow for some ambiguity in the caller's rounding direction
 	float scale = ldexpf(1.f, -exp);

--- a/src/quantization.cpp
+++ b/src/quantization.cpp
@@ -77,7 +77,7 @@ float meshopt_dequantizeHalf(unsigned short h)
 	return u.f;
 }
 
-int meshopt_computeClusterPositionExponent(const float* minv, const float* maxv, int min_exp, int max_bits)
+int meshopt_computePositionExponent(const float* minv, const float* maxv, int min_exp, int max_bits)
 {
 	assert(min_exp >= -126);
 	assert(max_bits >= 2 && max_bits <= 24);


### PR DESCRIPTION
When compressing cluster positions, it is convenient to use shared
exponent encoding where all cluster vertices are quantized to the same
integer grid. This exponent needs to be shared across all transitively
connected clusters to avoid gaps in the mesh.

The resulting integers can be stored directly as 24-bit (9 bytes per
vertex), as fixed bit count offsets from the anchor (if m`ax_bits` is 16
this would add up to 6 bytes per vertex plus a per-cluster or per-mesh
anchor), or as variable bit count offsets from the per-cluster anchor.

The latter format is part of an [upcoming DXR2 specification](https://microsoft.github.io/DirectX-Specs/d3d/Raytracing2.html#compressed1-position-encoding), exposed as
D3D12_VERTEX_FORMAT_COMPRESSED1 (for which `max_bits` would be set to 16).

In addition to `meshopt_computePositionExponent` which computes the
exponent that ensures anchors/deltas fit within the specified limits, this change
also adds an example (`encodeMeshletsDXR`) which uses meshlet encoder
to encode topology and Compressed1 encoding to encode positions.

*This contribution is sponsored by Valve.*