### PR TITLE
 demo: Implement hierarchy construction for clusterlod.h

### DIFF
--- a/demo/clusterlod.h
+++ b/demo/clusterlod.h
@@ -137,6 +137,21 @@ struct clodGroup
 // returned value gets saved for clusters emitted from this group (clodCluster::refined)
 typedef int (*clodOutput)(void* output_context, clodGroup group, const clodCluster* clusters, size_t cluster_count);
 
+// when using BVH to determine cluster visibility, traverse the tree into nodes while bounds is over error threshold; for leaves,
+// group clusters should be rendered if cluster.refined is -1 *or* clodGroup::simplified for groups[cluster.refined].simplified is at or under error threshold
+struct clodNode
+{
+	// BVH node bounds, reflecting worst case error for all groups in the subtree
+	clodBounds bounds;
+
+	// leaf node: index of the group this node represents (or -1 for internal nodes)
+	int group;
+
+	// internal node: children are at nodes[child_offset..child_offset+child_count)
+	unsigned int child_offset;
+	unsigned int child_count;
+};
+
 #ifdef __cplusplus
 extern "C"
 {
@@ -154,6 +169,19 @@ size_t clodBuild(clodConfig config, clodMesh mesh, void* output_context, clodOut
 // fills triangles[] and vertices[] such that vertices[triangles[i]] == indices[i]
 // returns number of unique vertices (which will be equal to clodCluster::vertex_count)
 size_t clodLocalIndices(unsigned int* vertices, unsigned char* triangles, const unsigned int* indices, size_t index_count);
+
+// upper bound on the number of nodes clodBuildHierarchy can produce
+// level_count is the number of levels in the group DAG (max(clodGroup::depth) + 1)
+size_t clodBuildHierarchyBound(size_t group_count, size_t node_width, size_t level_count);
+
+// build a spatial hierarchy over the groups produced by clodBuild for accelerating cluster visibility
+// level_count is the number of levels in the group DAG (max(clodGroup::depth) + 1)
+// the result is a forest:
+// - node 0 is the root that has per-level trees as children (level_count total)
+// - nodes 1..level_count are the roots of per-level trees, each covering groups with clodGroup::depth == level
+// - remaining nodes are per-level trees, each internal node has up to node_width children, and each leaf node refers to a single group
+// note that node 0 is purely organizational and does not store meaningful data, other than full mesh bounds
+size_t clodBuildHierarchy(clodNode* nodes, const clodGroup* groups, size_t group_count, size_t node_width, size_t level_count);
 
 #ifdef __cplusplus
 } // extern "C"
@@ -210,13 +238,9 @@ static clodBounds boundsCompute(const clodMesh& mesh, const std::vector<unsigned
 	return result;
 }
 
-static clodBounds boundsMerge(const std::vector<Cluster>& clusters, const std::vector<int>& group)
+static clodBounds boundsMerge(const clodBounds* bounds, size_t count, size_t stride)
 {
-	std::vector<clodBounds> bounds(group.size());
-	for (size_t j = 0; j < group.size(); ++j)
-		bounds[j] = clusters[group[j]].bounds;
-
-	meshopt_Bounds merged = meshopt_computeSphereBounds(&bounds[0].center[0], bounds.size(), sizeof(clodBounds), &bounds[0].radius, sizeof(clodBounds));
+	meshopt_Bounds merged = meshopt_computeSphereBounds(&bounds[0].center[0], count, stride, &bounds[0].radius, stride);
 
 	clodBounds result = {};
 	result.center[0] = merged.center[0];
@@ -226,10 +250,19 @@ static clodBounds boundsMerge(const std::vector<Cluster>& clusters, const std::v
 
 	// merged bounds error must be conservative wrt cluster errors
 	result.error = 0.f;
-	for (size_t j = 0; j < group.size(); ++j)
-		result.error = std::max(result.error, clusters[group[j]].bounds.error);
+	for (size_t j = 0; j < count; ++j)
+		result.error = std::max(result.error, reinterpret_cast<const clodBounds*>(reinterpret_cast<const char*>(bounds) + j * stride)->error);
 
 	return result;
+}
+
+static clodBounds mergeGroups(const std::vector<Cluster>& clusters, const std::vector<int>& group)
+{
+	std::vector<clodBounds> bounds(group.size());
+	for (size_t j = 0; j < group.size(); ++j)
+		bounds[j] = clusters[group[j]].bounds;
+
+	return boundsMerge(bounds.data(), bounds.size(), sizeof(clodBounds));
 }
 
 static std::vector<Cluster> clusterize(const clodConfig& config, const clodMesh& mesh, const unsigned int* indices, size_t index_count)
@@ -506,6 +539,16 @@ static int outputGroup(const clodConfig& config, const clodMesh& mesh, const std
 	return output_callback ? output_callback(output_context, {depth, simplified}, group_clusters.data(), group_clusters.size()) : -1;
 }
 
+static clodNode mergeNodes(const clodNode* nodes, size_t offset, size_t count)
+{
+	clodNode result = {};
+	result.bounds = boundsMerge(&nodes[offset].bounds, count, sizeof(clodNode));
+	result.group = -1;
+	result.child_offset = unsigned(offset);
+	result.child_count = unsigned(count);
+	return result;
+}
+
 } // namespace clod
 
 clodConfig clodDefaultConfig(size_t max_triangles)
@@ -621,7 +664,7 @@ size_t clodBuild(clodConfig config, clodMesh mesh, void* output_context, clodOut
 
 			// enforce bounds and error monotonicity
 			// note: it is incorrect to use the precise bounds of the merged or simplified mesh, because this may violate monotonicity
-			clodBounds bounds = boundsMerge(clusters, groups[i]);
+			clodBounds bounds = mergeGroups(clusters, groups[i]);
 
 			float error = 0.f;
 			std::vector<unsigned int> simplified = simplify(config, mesh, merged, locks, target_size, &error);
@@ -677,6 +720,72 @@ size_t clodBuild(clodConfig config, clodMesh mesh, void* output_context, clodOut
 size_t clodLocalIndices(unsigned int* vertices, unsigned char* triangles, const unsigned int* indices, size_t index_count)
 {
 	return meshopt_extractMeshletIndices(vertices, triangles, indices, index_count);
+}
+
+size_t clodBuildHierarchyBound(size_t group_count, size_t node_width, size_t level_count)
+{
+	// count nodes for each tree depth; we pad by level_count at each iteration to account for unknown level distribution in the forest
+	size_t total = level_count;
+	for (size_t frontier = group_count; frontier > 1; frontier = (frontier + node_width - 1) / node_width)
+		total += frontier + level_count;
+
+	// ... plus a single root
+	return total + 1;
+}
+
+size_t clodBuildHierarchy(clodNode* nodes, const clodGroup* groups, size_t group_count, size_t node_width, size_t level_count)
+{
+	using namespace clod;
+
+	// reserve space for node 0 (flat root) and per-level roots
+	size_t offset = level_count + 1;
+
+	std::vector<clodNode> row(group_count);
+	std::vector<unsigned int> order(group_count);
+
+	for (size_t level = 0; level < level_count; ++level)
+	{
+		// start each tree hierarchy from the groups of that level as leaves
+		row.clear();
+		for (size_t i = 0; i < group_count; ++i)
+			if (groups[i].depth == int(level))
+			{
+				clodNode node = {};
+				node.bounds = groups[i].simplified;
+				node.group = int(i);
+				row.push_back(node);
+			}
+
+		// build the tree going up one level at a time, using spatial grouping of centers as a proxy for locality
+		while (row.size() > 1)
+		{
+			size_t count = row.size();
+			meshopt_spatialClusterPoints(order.data(), row[0].bounds.center, count, sizeof(clodNode), node_width);
+
+			for (size_t i = 0; i < count; ++i)
+				nodes[offset + i] = row[order[i]];
+
+			row.clear();
+			for (size_t i = 0; i < count; i += node_width)
+			{
+				// spatialClusterPoints guarantees that each cluster except for last one is full
+				size_t children = std::min(node_width, count - i);
+				row.push_back(mergeNodes(nodes, offset + i, children));
+			}
+
+			offset += count;
+		}
+
+		// the root of the current level goes into the shared root section in the beginning of the output
+		assert(row.size() == 1);
+		nodes[1 + level] = row[0];
+	}
+
+	// build flat root with all levels as children; it's redundant but simplifies traversal
+	nodes[0] = mergeNodes(nodes, 1, level_count);
+	nodes[0].bounds.error = FLT_MAX; // root node should never be culled
+
+	return offset;
 }
 #endif
 

--- a/demo/clusterlod.h
+++ b/demo/clusterlod.h
@@ -176,11 +176,9 @@ size_t clodBuildHierarchyBound(size_t group_count, size_t node_width, size_t lev
 
 // build a spatial hierarchy over the groups produced by clodBuild for accelerating cluster visibility
 // level_count is the number of levels in the group DAG (max(clodGroup::depth) + 1)
-// the result is a forest:
-// - node 0 is the root that has per-level trees as children (level_count total)
-// - nodes 1..level_count are the roots of per-level trees, each covering groups with clodGroup::depth == level
-// - remaining nodes are per-level trees, each internal node has up to node_width children, and each leaf node refers to a single group
-// note that node 0 is purely organizational and does not store meaningful data, other than full mesh bounds
+// the result is a forest with one tree per DAG level:
+// - nodes 0..level_count-1 are the roots of per-level trees, each covering groups with clodGroup::depth == level
+// - remaining nodes are the tree nodes; each internal node has up to node_width children, and each leaf node refers to a single group
 size_t clodBuildHierarchy(clodNode* nodes, const clodGroup* groups, size_t group_count, size_t node_width, size_t level_count);
 
 #ifdef __cplusplus
@@ -729,16 +727,15 @@ size_t clodBuildHierarchyBound(size_t group_count, size_t node_width, size_t lev
 	for (size_t frontier = group_count; frontier > 1; frontier = (frontier + node_width - 1) / node_width)
 		total += frontier + level_count;
 
-	// ... plus a single root
-	return total + 1;
+	return total;
 }
 
 size_t clodBuildHierarchy(clodNode* nodes, const clodGroup* groups, size_t group_count, size_t node_width, size_t level_count)
 {
 	using namespace clod;
 
-	// reserve space for node 0 (flat root) and per-level roots
-	size_t offset = level_count + 1;
+	// reserve space for per-level roots
+	size_t offset = level_count;
 
 	std::vector<clodNode> row(group_count);
 	std::vector<unsigned int> order(group_count);
@@ -776,15 +773,12 @@ size_t clodBuildHierarchy(clodNode* nodes, const clodGroup* groups, size_t group
 			offset += count;
 		}
 
-		// the root of the current level goes into the shared root section in the beginning of the output
+		// the root of the current level goes into the fixed section at the beginning
 		assert(row.size() == 1);
-		nodes[1 + level] = row[0];
+		nodes[level] = row[0];
 	}
 
-	// build flat root with all levels as children; it's redundant but simplifies traversal
-	nodes[0] = mergeNodes(nodes, 1, level_count);
-	nodes[0].bounds.error = FLT_MAX; // root node should never be culled
-
+	assert(offset <= clodBuildHierarchyBound(group_count, node_width, level_count));
 	return offset;
 }
 #endif

--- a/demo/nanite.cpp
+++ b/demo/nanite.cpp
@@ -38,6 +38,35 @@ static float sahOverhead(const std::vector<std::vector<unsigned int> >& clusters
 void dumpObj(const std::vector<Vertex>& vertices, const std::vector<unsigned int>& indices, bool recomputeNormals = false);
 void dumpObj(const char* section, const std::vector<unsigned int>& indices);
 
+// simulate BVH based LOD cut and return triangle count
+static size_t countTriangles(const std::vector<clodNode>& nodes, unsigned int index, const std::vector<clodGroup>& groups, const std::vector<std::pair<unsigned int, unsigned int> >& group_clusters, const std::vector<std::pair<int, unsigned int> >& clusters, float cx, float cy, float cz, float proj, float znear, float threshold)
+{
+	const clodNode& node = nodes[index];
+
+	// prune the subtree once it's too detailed
+	if (boundsError(node.bounds, cx, cy, cz, proj, znear) <= threshold)
+		return 0;
+
+	size_t tris = 0;
+
+	if (node.group < 0)
+	{
+		// internal node: recurse into children
+		for (unsigned int i = 0; i < node.child_count; ++i)
+			tris += countTriangles(nodes, node.child_offset + i, groups, group_clusters, clusters, cx, cy, cz, proj, znear, threshold);
+	}
+	else
+	{
+		// leaf node: keep each cluster that is the least detailed one passing the threshold
+		std::pair<unsigned int, unsigned int> range = group_clusters[node.group];
+		for (unsigned int i = range.first; i < range.first + range.second; ++i)
+			if (clusters[i].first < 0 || boundsError(groups[clusters[i].first].simplified, cx, cy, cz, proj, znear) <= threshold)
+				tris += clusters[i].second;
+	}
+
+	return tris;
+}
+
 void nanite(const std::vector<Vertex>& vertices, const std::vector<unsigned int>& indices)
 {
 #ifdef _MSC_VER
@@ -89,7 +118,10 @@ void nanite(const std::vector<Vertex>& vertices, const std::vector<unsigned int>
 	};
 
 	std::vector<Stats> stats;
-	std::vector<clodBounds> groups;
+	std::vector<clodGroup> groups;
+
+	std::vector<std::pair<unsigned int, unsigned int> > group_clusters; // per group: (offset, count) into cluster_data
+	std::vector<std::pair<int, unsigned int> > cluster_data;            // per cluster: (clodCluster::refined, triangle count)
 
 	std::vector<std::vector<unsigned int> > cut;
 	int cut_level = dump ? atoi(dump) : -2;
@@ -120,9 +152,13 @@ void nanite(const std::vector<Vertex>& vertices, const std::vector<unsigned int>
 			level.stuck_clusters += cluster_count;
 		level.singleton_groups += cluster_count == 1;
 
+		group_clusters.push_back(std::make_pair(unsigned(cluster_data.size()), unsigned(cluster_count)));
+
 		for (size_t i = 0; i < cluster_count; ++i)
 		{
 			const clodCluster& cluster = clusters[i];
+
+			cluster_data.push_back(std::make_pair(cluster.refined, unsigned(cluster.index_count / 3)));
 
 			level.triangles += cluster.index_count / 3;
 			if (group.simplified.error == FLT_MAX)
@@ -139,13 +175,13 @@ void nanite(const std::vector<Vertex>& vertices, const std::vector<unsigned int>
 				cut.push_back(std::vector<unsigned int>(cluster.indices, cluster.indices + cluster.index_count));
 
 			// when requesting DAG cut from a viewpoint, we need to check if each cluster is the least detailed cluster that passes the error threshold
-			if (cut_level == -1 && (cluster.refined < 0 || boundsError(groups[cluster.refined], maxx, maxy, maxz, proj, znear) <= threshold) && boundsError(group.simplified, maxx, maxy, maxz, proj, znear) > threshold)
+			if (cut_level == -1 && (cluster.refined < 0 || boundsError(groups[cluster.refined].simplified, maxx, maxy, maxz, proj, znear) <= threshold) && boundsError(group.simplified, maxx, maxy, maxz, proj, znear) > threshold)
 				cut.push_back(std::vector<unsigned int>(cluster.indices, cluster.indices + cluster.index_count));
 		}
 
 		level.indices.push_back(std::vector<unsigned int>()); // mark end of group for measureBoundary
 
-		groups.push_back(group.simplified);
+		groups.push_back(group);
 		return int(groups.size() - 1);
 	});
 
@@ -187,6 +223,18 @@ void nanite(const std::vector<Vertex>& vertices, const std::vector<unsigned int>
 	}
 
 	printf("lowest lod: %d clusters, %d triangles\n", int(lowest_clusters), int(lowest_triangles));
+
+	// build a spatial hierarchy over the groups and use it to compute the cut size from a given viewpoint
+	{
+		size_t node_width = 8;
+		size_t levels = groups.back().depth + 1; // groups are generated in order of increasing depth
+
+		std::vector<clodNode> nodes(clodBuildHierarchyBound(groups.size(), node_width, levels));
+		nodes.resize(clodBuildHierarchy(nodes.data(), groups.data(), groups.size(), node_width, levels));
+
+		size_t bvh_tris = countTriangles(nodes, 0, groups, group_clusters, cluster_data, maxx, maxy, maxz, proj, znear, threshold);
+		printf("bvh cut (error %.3f): %d triangles\n", threshold, int(bvh_tris));
+	}
 
 	if (cut_level >= -1)
 	{

--- a/demo/nanite.cpp
+++ b/demo/nanite.cpp
@@ -232,7 +232,9 @@ void nanite(const std::vector<Vertex>& vertices, const std::vector<unsigned int>
 		std::vector<clodNode> nodes(clodBuildHierarchyBound(groups.size(), node_width, levels));
 		nodes.resize(clodBuildHierarchy(nodes.data(), groups.data(), groups.size(), node_width, levels));
 
-		size_t bvh_tris = countTriangles(nodes, 0, groups, group_clusters, cluster_data, maxx, maxy, maxz, proj, znear, threshold);
+		size_t bvh_tris = 0;
+		for (size_t i = 0; i < levels; ++i) // the hierarchy is a forest with one root per level
+			bvh_tris += countTriangles(nodes, unsigned(i), groups, group_clusters, cluster_data, maxx, maxy, maxz, proj, znear, threshold);
 		printf("bvh cut (error %.3f): %d triangles\n", threshold, int(bvh_tris));
 	}
 


### PR DESCRIPTION
As an alternative to flat cluster culling (where for each cluster the
error of cluster vs group is evaluated), we now support BVH based culling
and level selection where the same decisions are evaluated
hierarchically.

`clodBuildHierarchy` builds a forest of trees: each level is represented as
a tree with the requested width that's organized spatially. The tree roots
are located in the first nodes of the output array.

A recursive traversal can descend into the tree while `clodNode::bounds`
is *over* error threshold; this traverses down to leaves, where each
leaf corresponds to a group of clusters; all clusters in the leaves that
have `refined = -1` or `groups[cluster.refined].simplified` at or under
error threshold should be rendered, which creates the correct DAG cut.

~Note that the root is flat for now; there are other ways to construct
the forest but it's likely that an optimal runtime implementation should
special-case the top level traversal anyway, which is made easier by the
flat root as the application could extract errors from nodes 1..level_count
and store them separately to simplify traversal. Nanite uses a slightly
deeper hierarchy with only the coarsest 3 levels at the top, which still
produces a BVH4 but requires a little more traversal to get to more
detailed levels.~

> The forest structure and the construction algorithm follows the
> approach used in NVIDIA's [vk_lod_clusters](https://github.com/nvpro-samples/vk_lod_clusters).

*This contribution is sponsored by Valve.*