### PR TITLE
 vertexfilter: Fix shared exponent degradation due to zeroes

### DIFF
--- a/demo/tests.cpp
+++ b/demo/tests.cpp
@@ -1044,6 +1044,59 @@ static void encodeFilterExpZero()
 		assert(decoded[i] == 0);
 }
 
+static void encodeFilterExpZeroShared()
+{
+	const float data[4] = {
+	    0.f,
+	    0.1f,
+	    -0.025f,
+	    -0.f,
+	};
+
+	// shared exponents (vector)
+	const unsigned int expected1[4] = {
+	    0xef000000,
+	    0xef003333,
+	    0xedffcccd,
+	    0xed000000,
+	};
+
+	// shared exponents (component)
+	const unsigned int expected2[4] = {
+	    0xed000000,
+	    0xef003333,
+	    0xedffcccd,
+	    0xef000000,
+	};
+
+	unsigned int encoded1[4];
+	meshopt_encodeFilterExp(encoded1, 2, 8, 15, data, meshopt_EncodeExpSharedVector);
+
+	unsigned int encoded2[4];
+	meshopt_encodeFilterExp(encoded2, 2, 8, 15, data, meshopt_EncodeExpSharedComponent);
+
+	assert(memcmp(encoded1, expected1, sizeof(expected1)) == 0);
+	assert(memcmp(encoded2, expected2, sizeof(expected2)) == 0);
+
+	float decoded1[4];
+	memcpy(decoded1, encoded1, sizeof(decoded1));
+	meshopt_decodeFilterExp(decoded1, 2, 8);
+
+	float decoded2[4];
+	memcpy(decoded2, encoded2, sizeof(decoded2));
+	meshopt_decodeFilterExp(decoded2, 2, 8);
+
+	for (size_t i = 0; i < 4; ++i)
+	{
+		assert(fabsf(decoded1[i] - data[i]) < 1e-5f);
+		assert(fabsf(decoded2[i] - data[i]) < 1e-5f);
+	}
+
+	// zeroes should be preserved exactly
+	assert(decoded1[0] == 0 && decoded1[3] == 0);
+	assert(decoded2[0] == 0 && decoded2[3] == 0);
+}
+
 static void encodeFilterExpAlias()
 {
 	const float data[4] = {
@@ -3383,6 +3436,7 @@ void runTests()
 	encodeFilterQuat12();
 	encodeFilterExp();
 	encodeFilterExpZero();
+	encodeFilterExpZeroShared();
 	encodeFilterExpAlias();
 	encodeFilterExpClamp();
 	encodeFilterColor8();

--- a/gltf/stream.cpp
+++ b/gltf/stream.cpp
@@ -582,9 +582,11 @@ StreamFormat writeVertexStream(std::string& bin, const Stream& stream, const Qua
 			return writeVertexStreamRaw(bin, stream, cgltf_type_vec3, 3);
 
 		// expand the encoded range to ensure it covers [0..1) interval
+		// for unit length vectors, SharedComponent results in a slightly smaller encoding vs Clamped
+		// for morph deltas, we could use SharedComponent but it may preserve noisy small inputs redundantly
 		if (settings.nrm_float)
 			return writeVertexStreamFloat(bin, stream, cgltf_type_vec3, 3, settings.compress && filters, settings.nrm_bits,
-			    (settings.compressmore || stream.target) ? meshopt_EncodeExpSharedComponent : meshopt_EncodeExpClamped);
+			    settings.compressmore && stream.target == 0 ? meshopt_EncodeExpSharedComponent : meshopt_EncodeExpClamped);
 
 		bool oct = filters && settings.compressmore && stream.target == 0;
 		int bits = settings.nrm_bits;

--- a/src/meshoptimizer.h
+++ b/src/meshoptimizer.h
@@ -408,7 +408,7 @@ MESHOPTIMIZER_API int meshopt_decodeVertexVersion(const unsigned char* buffer, s
  * Each component is stored as an 8-bit or 16-bit normalized integer; stride must be equal to 4 or 8. W is preserved as is.
  *
  * meshopt_decodeFilterQuat decodes 3-component quaternion encoding with K-bit component encoding and a 2-bit component index indicating which component to reconstruct.
- * Each component is stored as an 16-bit integer; stride must be equal to 8.
+ * Each component is stored as a 16-bit integer; stride must be equal to 8.
  *
  * meshopt_decodeFilterExp decodes exponential encoding of floating-point data with 8-bit exponent and 24-bit integer mantissa as 2^E*M.
  * Each 32-bit component is decoded in isolation; stride must be divisible by 4.
@@ -426,19 +426,19 @@ MESHOPTIMIZER_API void meshopt_decodeFilterColor(void* buffer, size_t count, siz
  * These functions can be used to encode data in a format that meshopt_decodeFilter can decode
  *
  * meshopt_encodeFilterOct encodes unit vectors with K-bit (2 <= K <= 16) signed X/Y as an output.
- * Each component is stored as an 8-bit or 16-bit normalized integer; stride must be equal to 4 or 8. Z will store 1.0f, W is preserved as is.
+ * Each component is stored as an 8-bit or 16-bit normalized integer; stride must be equal to 4 (K <= 8) or 8 (K <= 16). Z will store 1.0f, W is preserved as is.
  * Input data must contain 4 floats for every vector (count*4 total).
  *
  * meshopt_encodeFilterQuat encodes unit quaternions with K-bit (4 <= K <= 16) component encoding.
- * Each component is stored as an 16-bit integer; stride must be equal to 8.
+ * Each component is stored as a 16-bit integer; stride must be equal to 8.
  * Input data must contain 4 floats for every quaternion (count*4 total).
  *
  * meshopt_encodeFilterExp encodes arbitrary (finite) floating-point data with 8-bit exponent and K-bit integer mantissa (1 <= K <= 24).
- * Exponent can be shared between all components of a given vector as defined by stride or all values of a given component; stride must be divisible by 4.
+ * Exponent can be shared between all components of a given vector as defined by stride or all values of a given component; stride must be divisible by 4 (and <= 256).
  * Input data must contain stride/4 floats for every vector (count*stride/4 total).
  *
  * meshopt_encodeFilterColor encodes RGBA color data by converting RGB to YCoCg color space with K-bit (2 <= K <= 16) component encoding; A is stored using K-1 bits.
- * Each component is stored as an 8-bit or 16-bit integer; stride must be equal to 4 or 8.
+ * Each component is stored as an 8-bit or 16-bit integer; stride must be equal to 4 (K <= 8) or 8 (K <= 16).
  * Input data must contain 4 floats for every color (count*4 total).
  */
 enum meshopt_EncodeExpMode

--- a/src/vertexfilter.cpp
+++ b/src/vertexfilter.cpp
@@ -1188,8 +1188,9 @@ inline int optlog2(float v)
 	} u;
 
 	u.f = v;
-	// +1 accounts for implicit 1. in mantissa; denormalized numbers will end up clamped to min_exp by calling code
-	return v == 0 ? 0 : int((u.ui >> 23) & 0xff) - 127 + 1;
+	// +1 accounts for implicit 1. in mantissa; zero and denormalized numbers will end up clamped to min_exp by calling code
+	// this is important for shared exponent modes, as a zero component should not inflate the shared exponent
+	return int((u.ui >> 23) & 0xff) - 127 + 1;
 }
 
 // optimized variant of ldexp
@@ -1367,11 +1368,12 @@ void meshopt_encodeFilterExp(void* destination_, size_t count, size_t stride, in
 
 	const int min_exp = -100;
 
+	// used to track maximum exponent for EncodeExpSharedComponent and zero exponent reuse for EncodeExpSeparate
+	for (size_t j = 0; j < stride_float; ++j)
+		component_exp[j] = (mode == meshopt_EncodeExpSeparate) ? 0 : min_exp;
+
 	if (mode == meshopt_EncodeExpSharedComponent)
 	{
-		for (size_t j = 0; j < stride_float; ++j)
-			component_exp[j] = min_exp;
-
 		for (size_t i = 0; i < count; ++i)
 		{
 			const float* v = &data[i * stride_float];
@@ -1409,7 +1411,9 @@ void meshopt_encodeFilterExp(void* destination_, size_t count, size_t stride, in
 			{
 				int e = optlog2(v[j]);
 
-				component_exp[j] = (min_exp < e) ? e : min_exp;
+				// zero values inherit the last encoded exponent to keep the encoded data more compressible
+				if (v[j] != 0)
+					component_exp[j] = (min_exp < e) ? e : min_exp;
 			}
 		}
 		else if (mode == meshopt_EncodeExpClamped)

--- a/src/vertexfilter.cpp
+++ b/src/vertexfilter.cpp
@@ -894,7 +894,7 @@ static void decodeFilterOctSimd8(signed char* data, size_t count)
 		v128_t z = wasm_f32x4_sub(wasm_f32x4_convert_i32x4(zf), wasm_f32x4_add(wasm_f32x4_abs(x), wasm_f32x4_abs(y)));
 
 		// fixup octahedral coordinates for z<0
-		// note: i32x4_min with 0 is equvalent to f32x4_min
+		// note: i32x4_min with 0 is equivalent to f32x4_min
 		v128_t t = wasm_i32x4_min(z, wasm_i32x4_splat(0));
 
 		x = wasm_f32x4_add(x, wasm_v128_xor(t, wasm_v128_and(x, sign)));
@@ -949,7 +949,7 @@ static void decodeFilterOctSimd16(short* data, size_t count)
 		v128_t z = wasm_f32x4_sub(wasm_f32x4_convert_i32x4(zf), wasm_f32x4_add(wasm_f32x4_abs(x), wasm_f32x4_abs(y)));
 
 		// fixup octahedral coordinates for z<0
-		// note: i32x4_min with 0 is equvalent to f32x4_min
+		// note: i32x4_min with 0 is equivalent to f32x4_min
 		v128_t t = wasm_i32x4_min(z, wasm_i32x4_splat(0));
 
 		x = wasm_f32x4_add(x, wasm_v128_xor(t, wasm_v128_and(x, sign)));
@@ -1276,6 +1276,7 @@ void meshopt_encodeFilterOct(void* destination, size_t count, size_t stride, int
 {
 	assert(stride == 4 || stride == 8);
 	assert(bits >= 2 && bits <= 16);
+	assert(stride == 8 || bits <= 8);
 
 	signed char* d8 = static_cast<signed char*>(destination);
 	short* d16 = static_cast<short*>(destination);
@@ -1446,6 +1447,7 @@ void meshopt_encodeFilterColor(void* destination, size_t count, size_t stride, i
 {
 	assert(stride == 4 || stride == 8);
 	assert(bits >= 2 && bits <= 16);
+	assert(stride == 8 || bits <= 8);
 
 	unsigned char* d8 = static_cast<unsigned char*>(destination);
 	unsigned short* d16 = static_cast<unsigned short*>(destination);


### PR DESCRIPTION
If the input data contained zero values, SharedComponent and SharedVector
would clamp the exponent to 0; this is fine for values that are in [1,inf)
range, however it can degrade the quality significantly for small values.

This is not expected or intentional; the idea of shared modes was that
they adapt to the magnitude of vectors/components, and work well across
arbitrary scales - but the presence of zeroes thwarted that. Notably,
very small values or even denormals would be fine. This behavior was
inherited from frexp() that returns 0 for zero inputs.

Instead, we now preserve the "raw" value of the exponent throughout the
pipeline. This fixes the problem, but may make occasional zeroes more
expensive in Separate mode, as their exponent would need to jump from a
small exponent to -126 and back. Since the exponent value does not
matter when mantissa is zero, we now encode these by preserving the last
seen exponent; this makes some existing streams compress a little
better.

Also make assertions/documentation on `K` in oct/color filters stricter for
byte storage, and fix some comment grammar.