### PR TITLE
Handle RISC-V targets via the portable scalar backend

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,11 @@ endif()
 
 project(meshoptimizer VERSION 1.1 LANGUAGES CXX)
 
+if(CMAKE_SYSTEM_PROCESSOR MATCHES "^[Rr][Ii][Ss][Cc][Vv]")
+    set(MESHOPT_TARGET_RISCV TRUE)
+    message(STATUS "RISC-V target detected; meshoptimizer will use the portable scalar backend")
+endif()
+
 option(MESHOPT_BUILD_DEMO "Build demo" OFF)
 option(MESHOPT_BUILD_GLTFPACK "Build gltfpack" OFF)
 option(MESHOPT_BUILD_SHARED_LIBS "Build shared libraries" OFF)
@@ -89,6 +94,10 @@ if(MESHOPT_BUILD_SHARED_LIBS)
     add_library(meshoptimizer SHARED ${SOURCES})
 else()
     add_library(meshoptimizer STATIC ${SOURCES})
+endif()
+
+if(MESHOPT_TARGET_RISCV)
+    target_compile_definitions(meshoptimizer PUBLIC MESHOPTIMIZER_NO_SIMD)
 endif()
 
 target_include_directories(meshoptimizer INTERFACE "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>")

--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ The source files are organized in such a way that you don't need to change your 
 
 To use meshoptimizer functions, simply `#include` the header `meshoptimizer.h`; the library source is C++, but the header is C-compatible.
 
+When targeting `riscv64`, the CMake build explicitly defines `MESHOPTIMIZER_NO_SIMD` so that the library uses the existing portable scalar backend instead of inheriting host-only SSE/NEON/Wasm SIMD paths during generic cross-configuration. Source builds can use the same define manually when a conservative portable build is desired.
+
 ## Core pipeline
 
 When optimizing a mesh, to maximize rendering efficiency you should typically feed it through a set of optimizations (the order is important!):

--- a/src/meshoptimizer.h
+++ b/src/meshoptimizer.h
@@ -33,6 +33,13 @@
 #define MESHOPTIMIZER_EXPERIMENTAL MESHOPTIMIZER_API
 #endif
 
+#if defined(__riscv)
+#define MESHOPTIMIZER_RISCV 1
+#if defined(__riscv_xlen) && __riscv_xlen == 64
+#define MESHOPTIMIZER_RISCV64 1
+#endif
+#endif
+
 /* C interface */
 #ifdef __cplusplus
 extern "C"


### PR DESCRIPTION
## Why

`meshoptimizer` already has portable scalar implementations for its core algorithms, and the library does not fundamentally require a new RISC-V-specific backend to build correctly.

The real gap is in target handling during generic cross-configuration:

- the SIMD-heavy translation units auto-detect `SSE` / `NEON` / `Wasm SIMD` from compiler-provided target macros;
- when a `riscv64` configure step is simulated with a host compiler, those host-only SIMD paths can still leak into the build and make the result look more portable than it really is;
- the public header also did not expose an explicit `RISC-V` architecture marker, even though similar markers are commonly useful when downstream users validate target selection.

This patch makes the conservative path explicit for `riscv64`: use the existing portable scalar backend, avoid host SIMD leakage during generic cross-configuration, and document the intended build behavior.

## What changed

- Updated `CMakeLists.txt`:
  - detect `riscv*` from `CMAKE_SYSTEM_PROCESSOR`;
  - emit an explicit status message for RISC-V targets;
  - define `MESHOPTIMIZER_NO_SIMD` for the `meshoptimizer` target on RISC-V so the build stays on the portable scalar backend.
- Updated `src/meshoptimizer.h`:
  - add public `MESHOPTIMIZER_RISCV`;
  - add public `MESHOPTIMIZER_RISCV64` when `__riscv_xlen == 64`.
- Updated `README.md`:
  - document that `riscv64` builds should use the existing portable scalar backend and may define `MESHOPTIMIZER_NO_SIMD` explicitly for conservative source builds.

## Verification

- Verified native configure/build:
  - `cmake -S . -B build-native -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_EXPORT_COMPILE_COMMANDS=ON`
  - `cmake --build build-native --parallel 4`
- Verified simulated `riscv64` configure/build:
  - `cmake -S . -B build-riscv-sim -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_SYSTEM_NAME=Linux -DCMAKE_SYSTEM_PROCESSOR=riscv64 -DCMAKE_TRY_COMPILE_TARGET_TYPE=STATIC_LIBRARY`
  - `cmake --build build-riscv-sim --parallel 4`
- Confirmed the simulated `riscv64` configuration now prints:
  - `RISC-V target detected; meshoptimizer will use the portable scalar backend`
- Confirmed `build-riscv-sim/build.ninja` and `build-riscv-sim/compile_commands.json`:
  - inject `-DMESHOPTIMIZER_NO_SIMD` for all `meshoptimizer` translation units;
  - do not contain `-msse*`, `-mavx*`, `wasm_simd128`, or `arm_neon`.
- Verified public RISC-V arch classification:
  - forced `__riscv=1` / `__riscv_xlen=64` preprocessing confirms `MESHOPTIMIZER_RISCV` and `MESHOPTIMIZER_RISCV64`.
- Verified key SIMD-heavy source files compile on the conservative RISC-V path:
  - `src/vertexcodec.cpp`
  - `src/vertexfilter.cpp`
  - both compile successfully with forced `__riscv=1` / `__riscv_xlen=64` and `MESHOPTIMIZER_NO_SIMD`.
- Verified native minimal consumer execution:
  - linked a small program against the built static library and ran it successfully with exit code `0`.
- Verified a real `riscv64` cross-build and runtime path in `dockcross/linux-riscv64`:
  - configured with `CMAKE_CXX_COMPILER="$CXX"`, `CMAKE_SYSTEM_NAME=Linux`, `CMAKE_SYSTEM_PROCESSOR=riscv64`, `CMAKE_TRY_COMPILE_TARGET_TYPE=STATIC_LIBRARY`, `MESHOPT_BUILD_DEMO=OFF`, `MESHOPT_BUILD_GLTFPACK=OFF`, and `MESHOPT_INSTALL=OFF`;
  - built the `meshoptimizer` static library successfully with `/usr/xcc/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-g++`.
- Verified the real `riscv64` build remains on the portable scalar backend:
  - `build.ninja` contains `-DMESHOPTIMIZER_NO_SIMD` for the library translation units;
  - `build.ninja` does not contain `-msse*`, `-mavx*`, `wasm_simd128`, or `arm_neon`.
- Verified a real `riscv64` smoke consumer against the built library:
  - cross-compiled a custom consumer that exercises `meshopt_generateVertexRemap`, `meshopt_optimizeVertexCache`, index/vertex encode-decode, and `meshopt_encodeFilterOct` / `meshopt_decodeFilterOct`;
  - linked the consumer with static `libstdc++`/`libgcc` to keep the QEMU runtime self-contained.
- Verified the produced smoke binary is a real RISC-V executable:
  - `file` reports `ELF 64-bit LSB executable, UCB RISC-V, RVC, double-float ABI`;
  - `readelf -h` reports `Machine: RISC-V`.
- Ran the resulting smoke binary under `qemu-riscv64` successfully:
  - output: `meshoptimizer-ok vertices=4 indices=6`.

## Notes

- This is a conservative portability patch. It does not add RVV or any RISC-V-specific SIMD optimization.
- The goal is to make the existing portable backend explicit and verifiable for `riscv64`, not to claim a dedicated optimized RISC-V implementation.
- Validation now includes a real `riscv64` cross-build and `qemu-riscv64` execution of a smoke consumer that exercises both codec and filter paths, but it still does not include RVV coverage or real RISC-V hardware testing.