### PR TITLE
vertexcodec: Optimize SSSE3 decoding

### DIFF
--- a/demo/tests.cpp
+++ b/demo/tests.cpp
@@ -623,6 +623,31 @@ static void decodeVertexBitGroupSentinels()
 	assert(memcmp(decoded, data, sizeof(data)) == 0);
 }
 
+static void decodeVertexBitGroupSentinelCount()
+{
+	const unsigned char expected[13 * 4] = {
+	    0xff, 0, 0, 0, 0xfe, 0, 0, 0, 0xfd, 0, 0, 0, 0xfd, 0, 0, 0,
+	    0xfd, 0, 0, 0, 0xfc, 0, 0, 0, 0xfb, 0, 0, 0, 0xfb, 0, 0, 0,
+	    0xfa, 0, 0, 0, 0xfa, 0, 0, 0, 0xf9, 0, 0, 0, 0xf9, 0, 0, 0,
+	    0xf8, 0, 0, 0 //
+	};
+
+	// encodes several 2-bit sentinels including lane 12; lane 3 is clear so bit 30 does not alias bit 0 during counting
+	const unsigned char input[] = {
+	    0xa1, 0xa9,
+	    0x01, 0xfc, 0x3c, 0xcc, 0xcc,
+	    0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01,
+	    0x00, 0x00, 0x00, 0x00,
+	    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+	    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+	    0x00, 0x00, 0x00, 0x00 //
+	};
+
+	unsigned char decoded[sizeof(expected)];
+	assert(meshopt_decodeVertexBuffer(decoded, 13, 4, input, sizeof(input)) == 0);
+	assert(memcmp(decoded, expected, sizeof(expected)) == 0);
+}
+
 static void decodeVertexDeltas()
 {
 	unsigned short data[16 * 4];
@@ -3416,6 +3441,7 @@ void runTests()
 		decodeVertexRejectMalformedHeaders();
 		decodeVertexBitGroups();
 		decodeVertexBitGroupSentinels();
+		decodeVertexBitGroupSentinelCount();
 		decodeVertexDeltas();
 		decodeVertexBitXor();
 		decodeVertexLarge();

--- a/src/vertexcodec.cpp
+++ b/src/vertexcodec.cpp
@@ -815,17 +815,17 @@ static bool gDecodeBytesGroupInitialized = decodeBytesGroupBuildTables();
 #endif
 
 #ifdef SIMD_SSE
-// sent mask, mult, shuf0/shuf1 for multishift emulation
+// sent mask, replicating shuffle, mulhi/mullo multipliers for multishift emulation
 static const __m128i kDecodeBytesGroupConfig[9][4] = {
-    {_mm_set1_epi8(1), _mm_setzero_si128(), _mm_set1_epi8(-128), _mm_set1_epi8(-128)},
-    {_mm_set1_epi8(3), _mm_setr_epi16(4, 16, 64, 256, 4, 16, 64, 256), _mm_setr_epi8(1, 0, 1, 0, 1, 0, 1, 0, 2, 1, 2, 1, 2, 1, 2, 1), _mm_setr_epi8(3, 2, 3, 2, 3, 2, 3, 2, 4, 3, 4, 3, 4, 3, 4, 3)},
-    {_mm_set1_epi8(15), _mm_setr_epi16(16, 256, 16, 256, 16, 256, 16, 256), _mm_setr_epi8(1, 0, 1, 0, 2, 1, 2, 1, 3, 2, 3, 2, 4, 3, 4, 3), _mm_setr_epi8(5, 4, 5, 4, 6, 5, 6, 5, 7, 6, 7, 6, 8, 7, 8, 7)},
-    {_mm_setzero_si128(), _mm_setzero_si128(), _mm_set1_epi8(-128), _mm_set1_epi8(-128)},
-    {_mm_set1_epi8(1), _mm_setzero_si128(), _mm_set1_epi8(-128), _mm_set1_epi8(-128)},
-    {_mm_set1_epi8(1), _mm_setr_epi16(256, 128, 64, 32, 16, 8, 4, 2), _mm_setr_epi8(1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0), _mm_setr_epi8(2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1)},
-    {_mm_set1_epi8(3), _mm_setr_epi16(4, 16, 64, 256, 4, 16, 64, 256), _mm_setr_epi8(1, 0, 1, 0, 1, 0, 1, 0, 2, 1, 2, 1, 2, 1, 2, 1), _mm_setr_epi8(3, 2, 3, 2, 3, 2, 3, 2, 4, 3, 4, 3, 4, 3, 4, 3)},
-    {_mm_set1_epi8(15), _mm_setr_epi16(16, 256, 16, 256, 16, 256, 16, 256), _mm_setr_epi8(1, 0, 1, 0, 2, 1, 2, 1, 3, 2, 3, 2, 4, 3, 4, 3), _mm_setr_epi8(5, 4, 5, 4, 6, 5, 6, 5, 7, 6, 7, 6, 8, 7, 8, 7)},
-    {_mm_setzero_si128(), _mm_setzero_si128(), _mm_set1_epi8(-128), _mm_set1_epi8(-128)},
+    {_mm_set1_epi8(1), _mm_set1_epi8(-128), _mm_setzero_si128(), _mm_setzero_si128()},
+    {_mm_set1_epi8(3), _mm_setr_epi8(0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3), _mm_setr_epi16(4, 64, 4, 64, 4, 64, 4, 64), _mm_setr_epi16(16, 256, 16, 256, 16, 256, 16, 256)},
+    {_mm_set1_epi8(15), _mm_setr_epi8(0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7), _mm_set1_epi16(16), _mm_set1_epi16(256)},
+    {_mm_setzero_si128(), _mm_set1_epi8(-128), _mm_setzero_si128(), _mm_setzero_si128()},
+    {_mm_set1_epi8(1), _mm_set1_epi8(-128), _mm_setzero_si128(), _mm_setzero_si128()},
+    {_mm_set1_epi8(1), _mm_setr_epi8(0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1), _mm_setr_epi16(256, 64, 16, 4, 256, 64, 16, 4), _mm_setr_epi16(128, 32, 8, 2, 128, 32, 8, 2)},
+    {_mm_set1_epi8(3), _mm_setr_epi8(0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3), _mm_setr_epi16(4, 64, 4, 64, 4, 64, 4, 64), _mm_setr_epi16(16, 256, 16, 256, 16, 256, 16, 256)},
+    {_mm_set1_epi8(15), _mm_setr_epi8(0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7), _mm_set1_epi16(16), _mm_set1_epi16(256)},
+    {_mm_setzero_si128(), _mm_set1_epi8(-128), _mm_setzero_si128(), _mm_setzero_si128()},
 };
 
 SIMD_TARGET
@@ -854,14 +854,16 @@ inline const unsigned char* decodeBytesGroupSimd(const unsigned char* data, unsi
 	__m128i selb = _mm_loadl_epi64(reinterpret_cast<const __m128i*>(data));
 	__m128i rest = _mm_loadu_si128(reinterpret_cast<const __m128i*>(skip));
 
-	// unpack 1, 2 or 4-bit values; shuffle moves bytes into place and mul pushes the correct bits into the 3-rd byte of uint32 product
-	__m128i mult = kDecodeBytesGroupConfig[hbits][1];
-	__m128i val0 = _mm_mulhi_epu16(_mm_shuffle_epi8(selb, kDecodeBytesGroupConfig[hbits][2]), mult);
-	__m128i val1 = _mm_mulhi_epu16(_mm_shuffle_epi8(selb, kDecodeBytesGroupConfig[hbits][3]), mult);
+	// unpack 1, 2 or 4-bit values: shuffle replicates each source byte into both halves of a 16-bit lane
+	// mulhi extracts the field for the low output byte and mullo the field for the high output byte (interleaved in place)
+	__m128i selw = _mm_shuffle_epi8(selb, kDecodeBytesGroupConfig[hbits][1]);
+	__m128i val0 = _mm_mulhi_epu16(selw, kDecodeBytesGroupConfig[hbits][2]);
+	__m128i val1 = _mm_mullo_epi16(selw, kDecodeBytesGroupConfig[hbits][3]);
+	__m128i seli = _mm_or_si128(val0, _mm_and_si128(val1, _mm_set1_epi16(0xff00)));
 
-	// the resulting products are masked by the bit count (special handling: for 0/8-bit values, mul produces 0)
+	// the interleaved fields are masked by the bit count (special handling: for 0/8-bit values, mul produces 0)
 	__m128i sent = kDecodeBytesGroupConfig[hbits][0];
-	__m128i sel = _mm_and_si128(_mm_packus_epi16(val0, val1), sent);
+	__m128i sel = _mm_and_si128(seli, sent);
 
 	// compare sel to sentinel; returns 0 for 0-bit (mul produces 0, sent is 1), 1 for 8-bit (mul produces 0, sent is 0)
 	__m128i mask = _mm_cmpeq_epi8(sel, sent);

--- a/src/vertexcodec.cpp
+++ b/src/vertexcodec.cpp
@@ -7,18 +7,18 @@
 // The block below auto-detects SIMD ISA that can be used on the target platform
 #ifndef MESHOPTIMIZER_NO_SIMD
 
-// The SIMD implementation requires SSSE3, which can be enabled unconditionally through compiler settings
-#if defined(__AVX__) || defined(__SSSE3__)
+// The SIMD implementation requires SSSE3+POPCNT, which can be enabled unconditionally through compiler settings
+#if defined(__AVX__) || (defined(__SSSE3__) && defined(__POPCNT__))
 #define SIMD_SSE
 #endif
 
 // An experimental implementation using AVX512 instructions; it's only enabled when AVX512 is enabled through compiler settings
-#if defined(__AVX512VBMI2__) && defined(__AVX512VBMI__) && defined(__AVX512VL__) && defined(__POPCNT__)
+#if defined(__AVX512VBMI2__) && defined(__AVX512VBMI__) && defined(__AVX512VL__)
 #undef SIMD_SSE
 #define SIMD_AVX
 #endif
 
-// MSVC supports compiling SSSE3 code regardless of compile options; we use a cpuid-based scalar fallback
+// MSVC supports compiling SSSE3+POPCNT code regardless of compile options; we use a cpuid-based scalar fallback
 #if !defined(SIMD_SSE) && !defined(SIMD_AVX) && defined(_MSC_VER) && !defined(__clang__) && (defined(_M_IX86) || (defined(_M_X64) && !defined(_M_ARM64EC)))
 #define SIMD_SSE
 #define SIMD_FALLBACK
@@ -28,7 +28,7 @@
 #if !defined(SIMD_SSE) && !defined(SIMD_AVX) && ((defined(__clang__) && __clang_major__ * 100 + __clang_minor__ >= 308) || (defined(__GNUC__) && __GNUC__ * 100 + __GNUC_MINOR__ >= 409)) && (defined(__i386__) || defined(__x86_64__))
 #define SIMD_SSE
 #define SIMD_FALLBACK
-#define SIMD_TARGET __attribute__((target("ssse3")))
+#define SIMD_TARGET __attribute__((target("ssse3,popcnt")))
 #endif
 
 // GCC/clang define these when NEON support is available
@@ -72,7 +72,7 @@
 #endif // !MESHOPTIMIZER_NO_SIMD
 
 #ifdef SIMD_SSE
-#include <tmmintrin.h>
+#include <nmmintrin.h>
 #endif
 
 #if defined(SIMD_SSE) && defined(SIMD_FALLBACK)
@@ -1857,7 +1857,8 @@ int meshopt_decodeVertexBuffer(void* destination, size_t vertex_count, size_t ve
 	const unsigned char* (*decode)(const unsigned char*, const unsigned char*, unsigned char*, size_t, size_t, unsigned char[256], const unsigned char*, int) = NULL;
 
 #if defined(SIMD_SSE) && defined(SIMD_FALLBACK)
-	decode = (cpuid & (1 << 9)) ? decodeVertexBlockSimd : decodeVertexBlock;
+	const unsigned int cpumask = (1 << 9) | (1 << 23); // SSSE3+POPCNT
+	decode = (cpuid & cpumask) == cpumask ? decodeVertexBlockSimd : decodeVertexBlock;
 #elif defined(SIMD_SSE) || defined(SIMD_AVX) || defined(SIMD_NEON) || defined(SIMD_WASM)
 	decode = decodeVertexBlockSimd;
 #else

--- a/src/vertexcodec.cpp
+++ b/src/vertexcodec.cpp
@@ -813,6 +813,19 @@ static bool gDecodeBytesGroupInitialized = decodeBytesGroupBuildTables();
 #endif
 
 #ifdef SIMD_SSE
+// sent mask, mult, shuf0/shuf1 for multishift emulation
+static const __m128i kDecodeBytesGroupConfig[9][4] = {
+    {_mm_set1_epi8(1), _mm_setzero_si128(), _mm_set1_epi8(-128), _mm_set1_epi8(-128)},
+    {_mm_set1_epi8(3), _mm_setr_epi16(4, 16, 64, 256, 4, 16, 64, 256), _mm_setr_epi8(1, 0, 1, 0, 1, 0, 1, 0, 2, 1, 2, 1, 2, 1, 2, 1), _mm_setr_epi8(3, 2, 3, 2, 3, 2, 3, 2, 4, 3, 4, 3, 4, 3, 4, 3)},
+    {_mm_set1_epi8(15), _mm_setr_epi16(16, 256, 16, 256, 16, 256, 16, 256), _mm_setr_epi8(1, 0, 1, 0, 2, 1, 2, 1, 3, 2, 3, 2, 4, 3, 4, 3), _mm_setr_epi8(5, 4, 5, 4, 6, 5, 6, 5, 7, 6, 7, 6, 8, 7, 8, 7)},
+    {_mm_setzero_si128(), _mm_setzero_si128(), _mm_set1_epi8(-128), _mm_set1_epi8(-128)},
+    {_mm_set1_epi8(1), _mm_setzero_si128(), _mm_set1_epi8(-128), _mm_set1_epi8(-128)},
+    {_mm_set1_epi8(1), _mm_setr_epi16(256, 128, 64, 32, 16, 8, 4, 2), _mm_setr_epi8(1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0), _mm_setr_epi8(2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1)},
+    {_mm_set1_epi8(3), _mm_setr_epi16(4, 16, 64, 256, 4, 16, 64, 256), _mm_setr_epi8(1, 0, 1, 0, 1, 0, 1, 0, 2, 1, 2, 1, 2, 1, 2, 1), _mm_setr_epi8(3, 2, 3, 2, 3, 2, 3, 2, 4, 3, 4, 3, 4, 3, 4, 3)},
+    {_mm_set1_epi8(15), _mm_setr_epi16(16, 256, 16, 256, 16, 256, 16, 256), _mm_setr_epi8(1, 0, 1, 0, 2, 1, 2, 1, 3, 2, 3, 2, 4, 3, 4, 3), _mm_setr_epi8(5, 4, 5, 4, 6, 5, 6, 5, 7, 6, 7, 6, 8, 7, 8, 7)},
+    {_mm_setzero_si128(), _mm_setzero_si128(), _mm_set1_epi8(-128), _mm_set1_epi8(-128)},
+};
+
 SIMD_TARGET
 inline __m128i decodeShuffleMask(unsigned char mask0, unsigned char mask1)
 {
@@ -834,125 +847,57 @@ typedef int unaligned_int;
 SIMD_TARGET
 inline const unsigned char* decodeBytesGroupSimd(const unsigned char* data, unsigned char* buffer, int hbits)
 {
-	switch (hbits)
-	{
-	case 0:
-	case 4:
-	{
-		__m128i result = _mm_setzero_si128();
+	// 0 for 1-bit, 1 for 2-bit, 2 for 4-bit, 3 for 8-bit, and 4 for 0-bit as it makes some of the uses easier
+	static const int hbtn[9] = {4, 1, 2, 3, 4, 0, 1, 2, 3};
 
-		_mm_storeu_si128(reinterpret_cast<__m128i*>(buffer), result);
+	int n = hbtn[hbits];
 
-		return data;
-	}
-
-	case 1:
-	case 6:
-	{
 #ifdef SIMD_LATENCYOPT
-		unsigned int data32;
-		memcpy(&data32, data, 4);
-		data32 &= data32 >> 1;
+	unsigned long long data64;
+	memcpy(&data64, data, 8);
+	data64 &= data64 >> n;
+	data64 &= data64 >> (n >> 1);
 
-		// arrange bits such that low bits of nibbles of data64 contain all 2-bit elements of data32
-		unsigned long long data64 = ((unsigned long long)data32 << 30) | data32;
-
-		// adds all 1-bit nibbles together; the sum fits in 4 bits because datacnt=16 would have used mode 3
-		int datacnt = int(((data64 & 0x1111111111111111ull) * 0x1111111111111111ull) >> 60);
+	// mask out one bit per group that is set if all group bits were 1
+	static const unsigned long long lanes[5] = {0xffff, 0x55555555, 0x1111111111111111ull, 0, 0};
+	int datacnt = _mm_popcnt_u64(data64 & lanes[n]);
 #endif
 
-		__m128i sel2 = _mm_cvtsi32_si128(*reinterpret_cast<const unaligned_int*>(data));
-		__m128i rest = _mm_loadu_si128(reinterpret_cast<const __m128i*>(data + 4));
+	// for 8-bit groups, instead of loading the bytes through 'data', we load them through 'skip' as they are easier to preserve
+	// for 0-bit groups, we use a masked load so that we load zero bytes; in both cases the shift wraps to zero
+	const unsigned char* skip = data + ((2 << n) & 15);
 
-		__m128i sel22 = _mm_unpacklo_epi8(_mm_srli_epi16(sel2, 4), sel2);
-		__m128i sel2222 = _mm_unpacklo_epi8(_mm_srli_epi16(sel22, 2), sel22);
-		__m128i sel = _mm_and_si128(sel2222, _mm_set1_epi8(3));
+	__m128i selb = _mm_loadl_epi64(reinterpret_cast<const __m128i*>(data));
+	__m128i rest = _mm_loadu_si128(reinterpret_cast<const __m128i*>(skip));
 
-		__m128i mask = _mm_cmpeq_epi8(sel, _mm_set1_epi8(3));
-		int mask16 = _mm_movemask_epi8(mask);
-		unsigned char mask0 = (unsigned char)(mask16 & 255);
-		unsigned char mask1 = (unsigned char)(mask16 >> 8);
+	__m128i mult = kDecodeBytesGroupConfig[hbits][1];
+	__m128i val0 = _mm_mulhi_epu16(_mm_shuffle_epi8(selb, kDecodeBytesGroupConfig[hbits][2]), mult);
+	__m128i val1 = _mm_mulhi_epu16(_mm_shuffle_epi8(selb, kDecodeBytesGroupConfig[hbits][3]), mult);
 
-		__m128i shuf = decodeShuffleMask(mask0, mask1);
-		__m128i result = _mm_or_si128(_mm_shuffle_epi8(rest, shuf), _mm_andnot_si128(mask, sel));
+	__m128i sent = kDecodeBytesGroupConfig[hbits][0];
+	__m128i sel = _mm_and_si128(_mm_packus_epi16(val0, val1), sent);
 
-		_mm_storeu_si128(reinterpret_cast<__m128i*>(buffer), result);
+	__m128i mask = _mm_cmpeq_epi8(sel, sent);
+	int mask16 = _mm_movemask_epi8(mask);
+	unsigned char mask0 = (unsigned char)(mask16 & 255);
+	unsigned char mask1 = (unsigned char)(mask16 >> 8);
+
+	__m128i shuf = decodeShuffleMask(mask0, mask1);
+	__m128i result = _mm_or_si128(_mm_shuffle_epi8(rest, shuf), _mm_andnot_si128(mask, sel));
+
+	_mm_storeu_si128(reinterpret_cast<__m128i*>(buffer), result);
 
 #ifdef SIMD_LATENCYOPT
-		return data + 4 + datacnt;
+	// datacnt is 0 for 8-bit groups so we can't use skip to advance; 0-bit groups wrap the shift to zero
+	return data + ((2 << n) & 31) + datacnt;
 #else
-		return data + 4 + kDecodeBytesGroupCount[mask0] + kDecodeBytesGroupCount[mask1];
+	return skip + _mm_popcnt_u32(mask16);
 #endif
-	}
-
-	case 2:
-	case 7:
-	{
-#ifdef SIMD_LATENCYOPT
-		unsigned long long data64;
-		memcpy(&data64, data, 8);
-		data64 &= data64 >> 1;
-		data64 &= data64 >> 2;
-
-		// adds all 1-bit nibbles together; the sum fits in 4 bits because datacnt=16 would have used mode 3
-		int datacnt = int(((data64 & 0x1111111111111111ull) * 0x1111111111111111ull) >> 60);
-#endif
-
-		__m128i sel4 = _mm_loadl_epi64(reinterpret_cast<const __m128i*>(data));
-		__m128i rest = _mm_loadu_si128(reinterpret_cast<const __m128i*>(data + 8));
-
-		__m128i sel44 = _mm_unpacklo_epi8(_mm_srli_epi16(sel4, 4), sel4);
-		__m128i sel = _mm_and_si128(sel44, _mm_set1_epi8(15));
-
-		__m128i mask = _mm_cmpeq_epi8(sel, _mm_set1_epi8(15));
-		int mask16 = _mm_movemask_epi8(mask);
-		unsigned char mask0 = (unsigned char)(mask16 & 255);
-		unsigned char mask1 = (unsigned char)(mask16 >> 8);
-
-		__m128i shuf = decodeShuffleMask(mask0, mask1);
-		__m128i result = _mm_or_si128(_mm_shuffle_epi8(rest, shuf), _mm_andnot_si128(mask, sel));
-
-		_mm_storeu_si128(reinterpret_cast<__m128i*>(buffer), result);
-
-#ifdef SIMD_LATENCYOPT
-		return data + 8 + datacnt;
-#else
-		return data + 8 + kDecodeBytesGroupCount[mask0] + kDecodeBytesGroupCount[mask1];
-#endif
-	}
-
-	case 3:
-	case 8:
-	{
-		__m128i result = _mm_loadu_si128(reinterpret_cast<const __m128i*>(data));
-
-		_mm_storeu_si128(reinterpret_cast<__m128i*>(buffer), result);
-
-		return data + 16;
-	}
-
-	case 5:
-	{
-		__m128i rest = _mm_loadu_si128(reinterpret_cast<const __m128i*>(data + 2));
-
-		unsigned char mask0 = data[0];
-		unsigned char mask1 = data[1];
-
-		__m128i shuf = decodeShuffleMask(mask0, mask1);
-		__m128i result = _mm_shuffle_epi8(rest, shuf);
-
-		_mm_storeu_si128(reinterpret_cast<__m128i*>(buffer), result);
-
-		return data + 2 + kDecodeBytesGroupCount[mask0] + kDecodeBytesGroupCount[mask1];
-	}
-
-	default:
-		SIMD_UNREACHABLE(); // unreachable
-	}
 }
 #endif
 
 #ifdef SIMD_AVX
+// sent mask, multishift control
 static const __m128i kDecodeBytesGroupConfig[9][2] = {
     {_mm_setzero_si128(), _mm_setzero_si128()},
     {_mm_set1_epi8(3), _mm_setr_epi8(6, 4, 2, 0, 14, 12, 10, 8, 22, 20, 18, 16, 30, 28, 26, 24)},

--- a/src/vertexcodec.cpp
+++ b/src/vertexcodec.cpp
@@ -827,24 +827,6 @@ static const __m128i kDecodeBytesGroupConfig[9][4] = {
 };
 
 SIMD_TARGET
-inline __m128i decodeShuffleMask(unsigned char mask0, unsigned char mask1)
-{
-	__m128i sm0 = _mm_loadl_epi64(reinterpret_cast<const __m128i*>(&kDecodeBytesGroupShuffle[mask0]));
-	__m128i sm1 = _mm_loadl_epi64(reinterpret_cast<const __m128i*>(&kDecodeBytesGroupShuffle[mask1]));
-	__m128i sm1off = _mm_set1_epi8(kDecodeBytesGroupCount[mask0]);
-
-	__m128i sm1r = _mm_add_epi8(sm1, sm1off);
-
-	return _mm_unpacklo_epi64(sm0, sm1r);
-}
-
-#ifdef __GNUC__
-typedef int __attribute__((aligned(1))) unaligned_int;
-#else
-typedef int unaligned_int;
-#endif
-
-SIMD_TARGET
 inline const unsigned char* decodeBytesGroupSimd(const unsigned char* data, unsigned char* buffer, int hbits)
 {
 	// 0 for 1-bit, 1 for 2-bit, 2 for 4-bit, 3 for 8-bit, and 4 for 0-bit as it makes some of the uses easier
@@ -885,8 +867,15 @@ inline const unsigned char* decodeBytesGroupSimd(const unsigned char* data, unsi
 	unsigned char mask0 = (unsigned char)(mask16 & 255);
 	unsigned char mask1 = (unsigned char)(mask16 >> 8);
 
-	// decode shuffle mask and combine rest+sel accordingly
-	__m128i shuf = decodeShuffleMask(mask0, mask1);
+	// decode shuffle mask from two halves; second half needs to be shifted by popcount(mask0)
+	__m128i sm0 = _mm_loadl_epi64(reinterpret_cast<const __m128i*>(&kDecodeBytesGroupShuffle[mask0]));
+	__m128i sm1 = _mm_loadl_epi64(reinterpret_cast<const __m128i*>(&kDecodeBytesGroupShuffle[mask1]));
+	__m128i sm1off = _mm_set1_epi8(kDecodeBytesGroupCount[mask0]);
+
+	__m128i sm1r = _mm_add_epi8(sm1, sm1off);
+	__m128i shuf = _mm_unpacklo_epi64(sm0, sm1r);
+
+	// expand rest via shuffle mask and combine with sel; shuffle mask zeroes out bytes that are replaced by sel
 	__m128i result = _mm_or_si128(_mm_shuffle_epi8(rest, shuf), _mm_andnot_si128(mask, sel));
 
 	_mm_storeu_si128(reinterpret_cast<__m128i*>(buffer), result);

--- a/src/vertexcodec.cpp
+++ b/src/vertexcodec.cpp
@@ -806,8 +806,6 @@ decodeBytesGroupBuildTables()
 		kDecodeBytesGroupCount[mask] = count;
 	}
 
-	(void)kDecodeBytesGroupCount; // table may not be used in some builds where shuffle table is still necessary
-
 	return true;
 }
 
@@ -816,16 +814,16 @@ static bool gDecodeBytesGroupInitialized = decodeBytesGroupBuildTables();
 
 #ifdef SIMD_SSE
 // sent mask, replicating shuffle, and two multipliers (even/odd) for multishift emulation
-static const __m128i kDecodeBytesGroupConfig[9][4] = {
-    {_mm_set1_epi8(1), _mm_set1_epi8(-128), _mm_setzero_si128(), _mm_setzero_si128()},
-    {_mm_set1_epi8(3), _mm_setr_epi8(0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3), _mm_setr_epi16(4, 64, 4, 64, 4, 64, 4, 64), _mm_setr_epi16(16, 256, 16, 256, 16, 256, 16, 256)},
-    {_mm_set1_epi8(15), _mm_setr_epi8(0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7), _mm_set1_epi16(16), _mm_set1_epi16(256)},
-    {_mm_setzero_si128(), _mm_set1_epi8(-128), _mm_setzero_si128(), _mm_setzero_si128()},
-    {_mm_set1_epi8(1), _mm_set1_epi8(-128), _mm_setzero_si128(), _mm_setzero_si128()},
-    {_mm_set1_epi8(1), _mm_setr_epi8(0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1), _mm_setr_epi16(256, 64, 16, 4, 256, 64, 16, 4), _mm_setr_epi16(128, 32, 8, 2, 128, 32, 8, 2)},
-    {_mm_set1_epi8(3), _mm_setr_epi8(0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3), _mm_setr_epi16(4, 64, 4, 64, 4, 64, 4, 64), _mm_setr_epi16(16, 256, 16, 256, 16, 256, 16, 256)},
-    {_mm_set1_epi8(15), _mm_setr_epi8(0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7), _mm_set1_epi16(16), _mm_set1_epi16(256)},
-    {_mm_setzero_si128(), _mm_set1_epi8(-128), _mm_setzero_si128(), _mm_setzero_si128()},
+static const unsigned char kDecodeBytesGroupConfig[9][4][16] = {
+    {{1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1}, {128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128}, {0}, {0}},
+    {{3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3}, {0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3}, {4, 0, 64, 0, 4, 0, 64, 0, 4, 0, 64, 0, 4, 0, 64, 0}, {16, 0, 0, 1, 16, 0, 0, 1, 16, 0, 0, 1, 16, 0, 0, 1}},
+    {{15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15}, {0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7}, {16, 0, 16, 0, 16, 0, 16, 0, 16, 0, 16, 0, 16, 0, 16, 0}, {0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1}},
+    {{0}, {128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128}, {0}, {0}},
+    {{1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1}, {128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128}, {0}, {0}},
+    {{1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1}, {0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1}, {0, 1, 64, 0, 16, 0, 4, 0, 0, 1, 64, 0, 16, 0, 4, 0}, {128, 0, 32, 0, 8, 0, 2, 0, 128, 0, 32, 0, 8, 0, 2, 0}},
+    {{3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3}, {0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3}, {4, 0, 64, 0, 4, 0, 64, 0, 4, 0, 64, 0, 4, 0, 64, 0}, {16, 0, 0, 1, 16, 0, 0, 1, 16, 0, 0, 1, 16, 0, 0, 1}},
+    {{15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15}, {0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7}, {16, 0, 16, 0, 16, 0, 16, 0, 16, 0, 16, 0, 16, 0, 16, 0}, {0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1}},
+    {{0}, {128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128}, {0}, {0}},
 };
 
 SIMD_TARGET
@@ -856,13 +854,13 @@ inline const unsigned char* decodeBytesGroupSimd(const unsigned char* data, unsi
 
 	// unpack 1, 2 or 4-bit values: shuffle replicates each source byte into both halves of a 16-bit lane
 	// mulhi extracts even and odd fields into the low byte; the results are interleaved back with shift/or
-	__m128i selw = _mm_shuffle_epi8(selb, kDecodeBytesGroupConfig[hbits][1]);
-	__m128i sel0 = _mm_mulhi_epu16(selw, kDecodeBytesGroupConfig[hbits][2]);
-	__m128i sel1 = _mm_mulhi_epu16(selw, kDecodeBytesGroupConfig[hbits][3]);
+	__m128i selw = _mm_shuffle_epi8(selb, _mm_loadu_si128(reinterpret_cast<const __m128i*>(kDecodeBytesGroupConfig[hbits][1])));
+	__m128i sel0 = _mm_mulhi_epu16(selw, _mm_loadu_si128(reinterpret_cast<const __m128i*>(kDecodeBytesGroupConfig[hbits][2])));
+	__m128i sel1 = _mm_mulhi_epu16(selw, _mm_loadu_si128(reinterpret_cast<const __m128i*>(kDecodeBytesGroupConfig[hbits][3])));
 	__m128i seli = _mm_or_si128(sel0, _mm_slli_epi16(sel1, 8));
 
 	// the interleaved fields are masked by the bit count (special handling: for 0/8-bit values, mul produces 0)
-	__m128i sent = kDecodeBytesGroupConfig[hbits][0];
+	__m128i sent = _mm_loadu_si128(reinterpret_cast<const __m128i*>(kDecodeBytesGroupConfig[hbits][0]));
 	__m128i sel = _mm_and_si128(seli, sent);
 
 	// compare sel to sentinel; returns 0 for 0-bit (mul produces 0, sent is 1), 1 for 8-bit (mul produces 0, sent is 0)
@@ -896,16 +894,16 @@ inline const unsigned char* decodeBytesGroupSimd(const unsigned char* data, unsi
 
 #ifdef SIMD_AVX
 // sent mask, multishift control
-static const __m128i kDecodeBytesGroupConfig[9][2] = {
-    {_mm_setzero_si128(), _mm_setzero_si128()},
-    {_mm_set1_epi8(3), _mm_setr_epi8(6, 4, 2, 0, 14, 12, 10, 8, 22, 20, 18, 16, 30, 28, 26, 24)},
-    {_mm_set1_epi8(15), _mm_setr_epi8(4, 0, 12, 8, 20, 16, 28, 24, 36, 32, 44, 40, 52, 48, 60, 56)},
-    {_mm_setzero_si128(), _mm_setzero_si128()},
-    {_mm_setzero_si128(), _mm_setzero_si128()},
-    {_mm_set1_epi8(1), _mm_setr_epi8(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)},
-    {_mm_set1_epi8(3), _mm_setr_epi8(6, 4, 2, 0, 14, 12, 10, 8, 22, 20, 18, 16, 30, 28, 26, 24)},
-    {_mm_set1_epi8(15), _mm_setr_epi8(4, 0, 12, 8, 20, 16, 28, 24, 36, 32, 44, 40, 52, 48, 60, 56)},
-    {_mm_setzero_si128(), _mm_setzero_si128()},
+static const unsigned char kDecodeBytesGroupConfig[9][2][16] = {
+    {{0}, {0}},
+    {{3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3}, {6, 4, 2, 0, 14, 12, 10, 8, 22, 20, 18, 16, 30, 28, 26, 24}},
+    {{15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15}, {4, 0, 12, 8, 20, 16, 28, 24, 36, 32, 44, 40, 52, 48, 60, 56}},
+    {{0}, {0}},
+    {{0}, {0}},
+    {{1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1}, {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}},
+    {{3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3}, {6, 4, 2, 0, 14, 12, 10, 8, 22, 20, 18, 16, 30, 28, 26, 24}},
+    {{15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15}, {4, 0, 12, 8, 20, 16, 28, 24, 36, 32, 44, 40, 52, 48, 60, 56}},
+    {{0}, {0}},
 };
 
 SIMD_TARGET
@@ -934,8 +932,8 @@ inline const unsigned char* decodeBytesGroupSimd(const unsigned char* data, unsi
 	__m128i selb = _mm_loadl_epi64(reinterpret_cast<const __m128i*>(data));
 	__m128i rest = _mm_maskz_loadu_epi8(__mmask16((n >> 2) - 1), skip);
 
-	__m128i sent = kDecodeBytesGroupConfig[hbits][0];
-	__m128i ctrl = kDecodeBytesGroupConfig[hbits][1];
+	__m128i sent = _mm_loadu_si128(reinterpret_cast<const __m128i*>(kDecodeBytesGroupConfig[hbits][0]));
+	__m128i ctrl = _mm_loadu_si128(reinterpret_cast<const __m128i*>(kDecodeBytesGroupConfig[hbits][1]));
 
 	// unpack 1, 2 or 4-bit values using multishift and mask the result; for 0/8-bit values, sel is always 0
 	__m128i selw = _mm_shuffle_epi32(selb, 0x44);

--- a/src/vertexcodec.cpp
+++ b/src/vertexcodec.cpp
@@ -1384,12 +1384,18 @@ static const unsigned char* decodeBytesSimd(const unsigned char* data, const uns
 		size_t header_offset = i / kByteGroupSize;
 		unsigned char header_byte = header[header_offset / 4];
 
-#ifdef SIMD_AVX
-		// v0 streams encode zero groups explicitly (no control bytes), which results in long predictable runs
-		// that branchless group decoding handles less optimally; never taken for v1 streams (hshift > 0)
-		if ((hshift | header_byte) == 0)
+#if defined(SIMD_SSE) || defined(SIMD_AVX)
+		// very-fast-path: for consecutive 4 groups that are all 0-bit (v0/0, v1/0/0000) or 8-bit (v0/3333, v1/1/3333),
+		// the branchless decoders are slower than branching over the decoding of 4 groups and issuing a few load/store ops
+		if (hshift != 5 && header_byte == 0)
 		{
 			memset(buffer + i, 0, kByteGroupSize * 4);
+			continue;
+		}
+		else if (hshift != 4 && header_byte == 255)
+		{
+			memcpy(buffer + i, data, kByteGroupSize * 4);
+			data += kByteGroupSize * 4;
 			continue;
 		}
 #endif

--- a/src/vertexcodec.cpp
+++ b/src/vertexcodec.cpp
@@ -864,24 +864,28 @@ inline const unsigned char* decodeBytesGroupSimd(const unsigned char* data, unsi
 #endif
 
 	// for 8-bit groups, instead of loading the bytes through 'data', we load them through 'skip' as they are easier to preserve
-	// for 0-bit groups, we use a masked load so that we load zero bytes; in both cases the shift wraps to zero
+	// for 0-bit groups, the load results get discarded because mask is always 0; in both cases the shift wraps to zero
 	const unsigned char* skip = data + ((2 << n) & 15);
 
 	__m128i selb = _mm_loadl_epi64(reinterpret_cast<const __m128i*>(data));
 	__m128i rest = _mm_loadu_si128(reinterpret_cast<const __m128i*>(skip));
 
+	// unpack 1, 2 or 4-bit values; shuffle moves bytes into place and mul pushes the correct bits into the 3-rd byte of uint32 product
 	__m128i mult = kDecodeBytesGroupConfig[hbits][1];
 	__m128i val0 = _mm_mulhi_epu16(_mm_shuffle_epi8(selb, kDecodeBytesGroupConfig[hbits][2]), mult);
 	__m128i val1 = _mm_mulhi_epu16(_mm_shuffle_epi8(selb, kDecodeBytesGroupConfig[hbits][3]), mult);
 
+	// the resulting products are masked by the bit count (special handling: for 0/8-bit values, mul produces 0)
 	__m128i sent = kDecodeBytesGroupConfig[hbits][0];
 	__m128i sel = _mm_and_si128(_mm_packus_epi16(val0, val1), sent);
 
+	// compare sel to sentinel; returns 0 for 0-bit (mul produces 0, sent is 1), 1 for 8-bit (mul produces 0, sent is 0)
 	__m128i mask = _mm_cmpeq_epi8(sel, sent);
 	int mask16 = _mm_movemask_epi8(mask);
 	unsigned char mask0 = (unsigned char)(mask16 & 255);
 	unsigned char mask1 = (unsigned char)(mask16 >> 8);
 
+	// decode shuffle mask and combine rest+sel accordingly
 	__m128i shuf = decodeShuffleMask(mask0, mask1);
 	__m128i result = _mm_or_si128(_mm_shuffle_epi8(rest, shuf), _mm_andnot_si128(mask, sel));
 
@@ -939,10 +943,12 @@ inline const unsigned char* decodeBytesGroupSimd(const unsigned char* data, unsi
 	__m128i sent = kDecodeBytesGroupConfig[hbits][0];
 	__m128i ctrl = kDecodeBytesGroupConfig[hbits][1];
 
+	// unpack 1, 2 or 4-bit values using multishift and mask the result; for 0/8-bit values, sel is always 0
 	__m128i selw = _mm_shuffle_epi32(selb, 0x44);
 	__m128i sel = _mm_and_si128(sent, _mm_multishift_epi64_epi8(ctrl, selw));
-	__mmask16 mask16 = _mm_cmp_epi8_mask(sel, sent, _MM_CMPINT_EQ);
 
+	// compare sel to sentinel and combine; mask is 0 for 0/8-bit as sent is 0
+	__mmask16 mask16 = _mm_cmp_epi8_mask(sel, sent, _MM_CMPINT_EQ);
 	__m128i result = _mm_mask_expand_epi8(sel, mask16, rest);
 
 	_mm_storeu_si128(reinterpret_cast<__m128i*>(buffer), result);

--- a/src/vertexcodec.cpp
+++ b/src/vertexcodec.cpp
@@ -806,6 +806,8 @@ decodeBytesGroupBuildTables()
 		kDecodeBytesGroupCount[mask] = count;
 	}
 
+	(void)kDecodeBytesGroupCount; // table may not be used in some builds where shuffle table is still necessary
+
 	return true;
 }
 
@@ -870,9 +872,10 @@ inline const unsigned char* decodeBytesGroupSimd(const unsigned char* data, unsi
 	// decode shuffle mask from two halves; second half needs to be shifted by popcount(mask0)
 	__m128i sm0 = _mm_loadl_epi64(reinterpret_cast<const __m128i*>(&kDecodeBytesGroupShuffle[mask0]));
 	__m128i sm1 = _mm_loadl_epi64(reinterpret_cast<const __m128i*>(&kDecodeBytesGroupShuffle[mask1]));
-	__m128i sm1off = _mm_set1_epi8(kDecodeBytesGroupCount[mask0]);
 
-	__m128i sm1r = _mm_add_epi8(sm1, sm1off);
+	// each lane of mask is 0x00 or 0xff; sad yields 255*popcount(mask0) in low word => low byte is -popcount(mask0)
+	__m128i npops = _mm_sad_epu8(mask, _mm_setzero_si128());
+	__m128i sm1r = _mm_sub_epi8(sm1, _mm_shuffle_epi8(npops, _mm_setzero_si128()));
 	__m128i shuf = _mm_unpacklo_epi64(sm0, sm1r);
 
 	// expand rest via shuffle mask and combine with sel; shuffle mask zeroes out bytes that are replaced by sel

--- a/src/vertexcodec.cpp
+++ b/src/vertexcodec.cpp
@@ -843,8 +843,8 @@ inline const unsigned char* decodeBytesGroupSimd(const unsigned char* data, unsi
 	data64 &= data64 >> (n >> 1);
 
 	// mask out one bit per group that is set if all group bits were 1
-	static const unsigned long long lanes[5] = {0xffff, 0x55555555, 0x1111111111111111ull, 0, 0};
-	int datacnt = _mm_popcnt_u64(data64 & lanes[n]);
+	static const unsigned long long lanes[9] = {0, 0x55555555, 0x1111111111111111ull, 0, 0, 0xffff, 0x55555555, 0x1111111111111111ull, 0};
+	int datacnt = int(_mm_popcnt_u64(data64 & lanes[hbits]));
 #endif
 
 	// for 8-bit groups, instead of loading the bytes through 'data', we load them through 'skip' as they are easier to preserve
@@ -923,8 +923,8 @@ inline const unsigned char* decodeBytesGroupSimd(const unsigned char* data, unsi
 	data64 &= data64 >> (n >> 1);
 
 	// mask out one bit per group that is set if all group bits were 1
-	static const unsigned long long lanes[5] = {0xffff, 0x55555555, 0x1111111111111111ull, 0, 0};
-	int datacnt = _mm_popcnt_u64(data64 & lanes[n]);
+	static const unsigned long long lanes[9] = {0, 0x55555555, 0x1111111111111111ull, 0, 0, 0xffff, 0x55555555, 0x1111111111111111ull, 0};
+	int datacnt = int(_mm_popcnt_u64(data64 & lanes[hbits]));
 #endif
 
 	// for 8-bit groups, instead of loading the bytes through 'data', we load them through 'skip' as they are easier to preserve

--- a/src/vertexcodec.cpp
+++ b/src/vertexcodec.cpp
@@ -815,7 +815,7 @@ static bool gDecodeBytesGroupInitialized = decodeBytesGroupBuildTables();
 #endif
 
 #ifdef SIMD_SSE
-// sent mask, replicating shuffle, mulhi/mullo multipliers for multishift emulation
+// sent mask, replicating shuffle, and two multipliers (even/odd) for multishift emulation
 static const __m128i kDecodeBytesGroupConfig[9][4] = {
     {_mm_set1_epi8(1), _mm_set1_epi8(-128), _mm_setzero_si128(), _mm_setzero_si128()},
     {_mm_set1_epi8(3), _mm_setr_epi8(0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3), _mm_setr_epi16(4, 64, 4, 64, 4, 64, 4, 64), _mm_setr_epi16(16, 256, 16, 256, 16, 256, 16, 256)},
@@ -855,11 +855,11 @@ inline const unsigned char* decodeBytesGroupSimd(const unsigned char* data, unsi
 	__m128i rest = _mm_loadu_si128(reinterpret_cast<const __m128i*>(skip));
 
 	// unpack 1, 2 or 4-bit values: shuffle replicates each source byte into both halves of a 16-bit lane
-	// mulhi extracts the field for the low output byte and mullo the field for the high output byte (interleaved in place)
+	// mulhi extracts even and odd fields into the low byte; the results are interleaved back with shift/or
 	__m128i selw = _mm_shuffle_epi8(selb, kDecodeBytesGroupConfig[hbits][1]);
-	__m128i val0 = _mm_mulhi_epu16(selw, kDecodeBytesGroupConfig[hbits][2]);
-	__m128i val1 = _mm_mullo_epi16(selw, kDecodeBytesGroupConfig[hbits][3]);
-	__m128i seli = _mm_or_si128(val0, _mm_and_si128(val1, _mm_set1_epi16(0xff00)));
+	__m128i sel0 = _mm_mulhi_epu16(selw, kDecodeBytesGroupConfig[hbits][2]);
+	__m128i sel1 = _mm_mulhi_epu16(selw, kDecodeBytesGroupConfig[hbits][3]);
+	__m128i seli = _mm_or_si128(sel0, _mm_slli_epi16(sel1, 8));
 
 	// the interleaved fields are masked by the bit count (special handling: for 0/8-bit values, mul produces 0)
 	__m128i sent = kDecodeBytesGroupConfig[hbits][0];


### PR DESCRIPTION
This change significantly reworks SSSE3 decoding implementation to increase performance.

The core idea behind this rewrite is the same as the recently-rewritten AVX-512 implementation: on real workloads, our decoding was branch heavy and this branches predicted poorly; so instead of doing a switch dispatch per byte group, we use a unified SIMD decoder that can simultaneously handle any group type in a data-dependent way.

The latency bypass is taken as is from AVX-512 implementation. It requires a fast popcount, so as part of this change we now require SSSE3+POPCNT for the decoding path; CPUs without POPCNT will fall back to scalar decoding. In practice, all AMD CPUs with SSSE3 also have POPCNT, and this only excludes very early Intel CPUs (Core 2/2006 and Penryn/2007) on Intel side; Nehalem (2008) and later CPUs have POPCNT. We check the CPUID bit at runtime for the fallback or rely on compiler having defined the macros for unconditional inclusion.

The most notable change is the emulation of multishift (which was itself used to emulate multigetbits). We don't have it but we can synthesize something similar by using a mode-dependent shuffle/multiply-high: `pmulhuw` allows us to effectively emulate per-lane right shift for 8 lanes, as multiplying by a power of two and then taking the high 16 bits of the product is equivalent to a right shift. We need to do this twice and combine the results, and some variations are possible here; for now we settle on `pmulhuw`x2 + `psllw` + `por`, but this is also doable with `pmulhuw` + `pmullw` + `pand` + `por`, or with two shuffles `pshufb`x2` + `pmulhuw`x2 + `packuswb` - but we make do with one shuffle as it makes things a little faster on early Intel chips.

Byte expand is mostly taken from our earlier SSSE3 code, and would work as is, but we use a different trick to make this a little faster (which buys ~2%): instead of computing the shuffle adjustment for the second half via a table lookup, `psadw` is used to compute `-popcount(mask0)` in the low byte, so a subtract performs the add we need.

With all of this, we end up with mechanically the same change as AVX-512; however, we use more SIMD resources and so by itself, it's not as fast and can end up losing vs branchy implementation on long runs of 0s or 8s which were trivial to decode. So this change also extends the previous very-fast-path that was limited to zero runs on v0, to handle any four consecutive 0-bit or 8-bit groups regardless of codec version. With this, this change seems to never be slower than the original SSSE3 implementation, on either codec version or on any data set. Of course it should be possible to construct an artificial case where the old implementation never hit branch mispredictions and decoded more quickly (e.g. a long run of 1-bit data), but in practice this is a massive win (data in comments below).

Notably this makes AVX-512 a bit faster (due to new fast path) but also shortens the SSSE-AVX512 gap significantly, which now sits at around 10% on Zen 4 - making runtime dispatch for AVX-512 much less of a priority as the default implementation is now quite fast indeed too.

Thanks to Fabian Giesen for productive discussions and suggestions!

*This contribution is sponsored by Valve.*