### PR TITLE
simplifier: Use double precision for quadric storage and evaluation

### DIFF
--- a/demo/tests.cpp
+++ b/demo/tests.cpp
@@ -1799,6 +1799,62 @@ static void simplifyStuck()
 	assert(meshopt_simplify(ib5, ib5, 6, vb5, 5, 12, 3, 1e-3f) == 6);
 }
 
+static void simplifyPrecision()
+{
+	// two identical flat plates, one at z=0 and one at z=900, in a mesh of extent 1000
+	// (the extra sliver triangle pins the extent so the far plate rescales to z=0.9,
+	// which is inexact in binary). the far plate must simplify just as well as the near
+	// one: with single precision quadrics the expanded form cancels catastrophically for
+	// geometry far from the bounding box minimum (residual ~1e-7*w*d^2), so the far
+	// plate stalls at a fraction of the requested reduction while the near plate
+	// reaches the minimum.
+	const int N = 150;
+
+	std::vector<float> vb;
+	std::vector<unsigned int> ib;
+
+	float corner[] = {1000, 1000, 1000, 990, 1000, 1000, 1000, 990, 1000};
+	vb.insert(vb.end(), corner, corner + 9);
+	ib.push_back(0);
+	ib.push_back(1);
+	ib.push_back(2);
+
+	for (int p = 0; p < 2; ++p)
+	{
+		unsigned int base = unsigned(vb.size() / 3);
+
+		for (int i = 0; i <= N; ++i)
+			for (int j = 0; j <= N; ++j)
+			{
+				vb.push_back(float(i));
+				vb.push_back(float(j));
+				vb.push_back(p ? 900.f : 0.f);
+			}
+
+		for (int i = 0; i < N; ++i)
+			for (int j = 0; j < N; ++j)
+			{
+				unsigned int a = base + i * (N + 1) + j, b = a + N + 1;
+
+				ib.push_back(a);
+				ib.push_back(b);
+				ib.push_back(a + 1);
+				ib.push_back(a + 1);
+				ib.push_back(b);
+				ib.push_back(b + 1);
+			}
+	}
+
+	std::vector<unsigned int> res(ib.size());
+	float error = 0;
+	size_t result = meshopt_simplify(&res[0], &ib[0], ib.size(), &vb[0], vb.size() / 3, 12, 12, 5e-5f, 0, &error);
+
+	// both plates must collapse to a handful of triangles; with float32 quadrics the
+	// far plate is left with tens of thousands
+	assert(result <= 24);
+	assert(error < 5e-5f);
+}
+
 static void simplifySloppyStuck()
 {
 	const float vb[] = {0, 0, 0, 0, 0, 0, 0, 0, 0};
@@ -3534,6 +3590,7 @@ void runTests()
 
 	simplify();
 	simplifyStuck();
+	simplifyPrecision();
 	simplifySloppyStuck();
 	simplifySloppyLocks();
 	simplifyPointsStuck();

--- a/src/simplifier.cpp
+++ b/src/simplifier.cpp
@@ -667,16 +667,19 @@ static const size_t kMaxAttributes = 32;
 struct Quadric
 {
 	// a00*x^2 + a11*y^2 + a22*z^2 + 2*a10*xy + 2*a20*xz + 2*a21*yz + 2*b0*x + 2*b1*y + 2*b2*z + c
-	float a00, a11, a22;
-	float a10, a20, a21;
-	float b0, b1, b2, c;
-	float w;
+	// note: the expanded form cancels catastrophically in single precision; for a plane at
+	// offset d the b/c products carry independent rounding, leaving a residual of ~1e-7*w*d^2
+	// when evaluating on the plane. double keeps the error metric position-independent.
+	double a00, a11, a22;
+	double a10, a20, a21;
+	double b0, b1, b2, c;
+	double w;
 };
 
 struct QuadricGrad
 {
 	// gx*x + gy*y + gz*z + gw
-	float gx, gy, gz, gw;
+	double gx, gy, gz, gw;
 };
 
 struct Reservoir
@@ -747,11 +750,11 @@ static void quadricAdd(QuadricGrad* G, const QuadricGrad* R, size_t attribute_co
 	}
 }
 
-static float quadricEval(const Quadric& Q, const Vector3& v)
+static double quadricEval(const Quadric& Q, const Vector3& v)
 {
-	float rx = Q.b0;
-	float ry = Q.b1;
-	float rz = Q.b2;
+	double rx = Q.b0;
+	double ry = Q.b1;
+	double rz = Q.b2;
 
 	rx += Q.a10 * v.y;
 	ry += Q.a21 * v.z;
@@ -765,7 +768,7 @@ static float quadricEval(const Quadric& Q, const Vector3& v)
 	ry += Q.a11 * v.y;
 	rz += Q.a22 * v.z;
 
-	float r = Q.c;
+	double r = Q.c;
 	r += rx * v.x;
 	r += ry * v.y;
 	r += rz * v.z;
@@ -775,15 +778,15 @@ static float quadricEval(const Quadric& Q, const Vector3& v)
 
 static float quadricError(const Quadric& Q, const Vector3& v)
 {
-	float r = quadricEval(Q, v);
-	float s = Q.w == 0.f ? 0.f : 1.f / Q.w;
+	double r = quadricEval(Q, v);
+	double s = Q.w == 0. ? 0. : 1. / Q.w;
 
-	return fabsf(r) * s;
+	return float(fabs(r) * s);
 }
 
 static float quadricError(const Quadric& Q, const QuadricGrad* G, size_t attribute_count, const Vector3& v, const float* va)
 {
-	float r = quadricEval(Q, v);
+	double r = quadricEval(Q, v);
 
 	// see quadricFromAttributes for general derivation; here we need to add the parts of (eval(pos) - attr)^2 that depend on attr
 	for (size_t k = 0; k < attribute_count; ++k)
@@ -795,15 +798,15 @@ static float quadricError(const Quadric& Q, const QuadricGrad* G, size_t attribu
 	}
 
 	// note: unlike position error, we do not normalize by Q.w to retain edge scaling as described in quadricFromAttributes
-	return fabsf(r);
+	return float(fabs(r));
 }
 
 static void quadricFromPlane(Quadric& Q, float a, float b, float c, float d, float w)
 {
-	float aw = a * w;
-	float bw = b * w;
-	float cw = c * w;
-	float dw = d * w;
+	double aw = double(a) * w;
+	double bw = double(b) * w;
+	double cw = double(c) * w;
+	double dw = double(d) * w;
 
 	Q.a00 = a * aw;
 	Q.a11 = b * bw;


### PR DESCRIPTION
`meshopt_simplify` has a position-dependent floor on `target_error`: geometry
far from the mesh bounding-box minimum cannot be simplified below an error of
roughly `3e-4 × extent`, while identical geometry near the bbox minimum
simplifies to completion.

## Cause

The expanded quadric form `r = vᵀAv + 2bᵀv + c` cancels catastrophically in
single precision. For a plane with offset `d` (after internal rescale),
`quadricFromPlane` computes `b = d·w` and `c = d²·w`, whose independent
float32 roundings don't cancel — evaluating at a point **on** the plane
leaves a residual `r ≈ 1e-7·w·d²` instead of 0, i.e. a distance-error noise
floor of `~3e-4·extent·d`. Since the internal rescale anchors at the bbox
minimum, `d` — and the floor — grows with distance from the min corner.
Collapse candidates on exactly flat, exactly coplanar surfaces then rank
above tight error limits and the region never simplifies.

## Repro

Two identical 150×150 flat plates, one at z=0 and one at z=900, in a mesh of
extent 1000 (the offset must be along the plate **normal**, and the far
plate's rescaled offset must be inexact in binary — z=0.9 here; a tangential
offset leaves `b = c = 0` exactly and hides the effect). Simplify with
`target_index_count = index_count/100`, `target_error = 5e-5`:

| | master (float) | this PR (double) |
|---|---|---|
| plate A (z=0) | 2 tris | 446 tris |
| plate B (z=900) | **38,602 tris** | 454 tris |
| total vs target | 38,604 / 900 | 900 / 900 |
| reported error | 4.75e-05 (noise floor) | 2.56e-06 (true geometric) |

Master, unable to make progress on plate B, spends the entire reduction
budget over-collapsing plate A; this PR reaches the requested target and
stops. Asked for the actual minimum (`target = 4` triangles), master still
returns 38,604 while this PR returns exactly 4 — 2 per plate.

Result meshes rendered with edges (master left/right = near/far plate, then
this PR):

![master: near plate collapses to 2 triangles, far plate frozen at render density](meshopt_repro_float32_result.png)

![this PR: both plates collapse symmetrically](meshopt_repro_double_result.png)

Found in the wild on a 127mm CAD part where one exactly-planar box wall kept
~17M render-resolution triangles at tight `target_error` while the
geometrically identical opposite wall collapsed to a handful; with this
change the whole part reaches 16k triangles with measured surface deviation
of 2e-4 mm.

## Change

Confined to the Quadric/QuadricGrad fields, the products in
`quadricFromPlane`, and the accumulation in `quadricEval`/`quadricError`
(22 insertions, 19 deletions). Storing double without computing the `b`/`c`
products in double is not sufficient — the coefficients are already rounded
at construction. Plane fitting from vertex positions stays in single
precision; its per-triangle rounding is second-order for this effect.

Includes a regression test (`simplifyPrecision` in demo/tests.cpp) that
builds the two-plate geometry procedurally and asserts symmetric collapse —
it fails on master and passes with this change.

`make test` passes; builds warning-free with `-Wall -Wextra -Wshadow`.

## Trade-off

This doubles quadric array memory (per remap-unique vertex) and may
measurably affect simplification throughput on some targets. If that's
unacceptable for game-LOD workloads — which never request errors below the
noise floor and are unaffected by the bug — the same change works gated
behind a compile-time define, or I'm happy to rework it in whatever
direction you prefer (recentring the internal rescale only halves the worst
case, so some precision change appears necessary for a full fix).
