### PR TITLE
 indexcodec: Optimize decoding for GCC/Clang on x64

### DIFF
--- a/src/indexcodec.cpp
+++ b/src/indexcodec.cpp
@@ -7,11 +7,6 @@
 // This work is based on:
 // Fabian Giesen. Simple lossless index buffer compression & follow-up. 2013
 // Conor Stokes. Vertex Cache Optimised Index Buffer Compression. 2014
-
-#ifndef __has_builtin
-#define __has_builtin(x) 0
-#endif
-
 namespace meshopt
 {
 
@@ -450,12 +445,14 @@ int meshopt_decodeIndexBuffer(void* destination, size_t index_count, size_t inde
 				// fifo reads are wrapped around 16 entry buffer
 				unsigned int cf = vertexfifo[(vertexfifooffset - 1 - fec) & 15];
 
-				// clang needs the branch annotation because cf[] comes from "memory" and x86-cmov-conversion pass removes cmov otherwise
-#if defined(__clang__) && __has_builtin(__builtin_unpredictable)
-				c = __builtin_unpredictable(fec == 0) ? next : cf;
-#else
-				c = (fec == 0) ? next : cf;
+#if (defined(__GNUC__) || defined(__clang__)) && (defined(__x86_64__) || defined(__aarch64__))
+				// on clang, x86-cmov-conversion pass emits a branch since cf is a load from memory; asm barrier defeats this
+				// this can be fixed with __builtin_unpredictable, but gcc doesn't support it and has a similar problem due to if-conversion
+				// additionally, gcc can fuse a/b into one 64-bit load but use 32-bit edgefifo[] stores, which breaks load store forwarding
+				__asm__("" : "+r"(a) : "r"(cf));
 #endif
+
+				c = (fec == 0) ? next : cf;
 
 				int fec0 = fec == 0;
 				next += fec0;

--- a/src/indexcodec.cpp
+++ b/src/indexcodec.cpp
@@ -7,6 +7,11 @@
 // This work is based on:
 // Fabian Giesen. Simple lossless index buffer compression & follow-up. 2013
 // Conor Stokes. Vertex Cache Optimised Index Buffer Compression. 2014
+
+#ifndef __has_builtin
+#define __has_builtin(x) 0
+#endif
+
 namespace meshopt
 {
 
@@ -441,7 +446,13 @@ int meshopt_decodeIndexBuffer(void* destination, size_t index_count, size_t inde
 			{
 				// fifo reads are wrapped around 16 entry buffer
 				unsigned int cf = vertexfifo[(vertexfifooffset - 1 - fec) & 15];
+
+				// clang needs the branch annotation because cf[] comes from "memory" and x86-cmov-conversion pass removes cmov otherwise
+#if defined(__clang__) && __has_builtin(__builtin_unpredictable)
+				c = __builtin_unpredictable(fec == 0) ? next : cf;
+#else
 				c = (fec == 0) ? next : cf;
+#endif
 
 				int fec0 = fec == 0;
 				next += fec0;

--- a/src/indexcodec.cpp
+++ b/src/indexcodec.cpp
@@ -143,19 +143,25 @@ static int getCodeAuxIndex(unsigned char v, const unsigned char* table)
 	return -1;
 }
 
-static void writeTriangle(void* destination, size_t offset, size_t index_size, unsigned int a, unsigned int b, unsigned int c)
+static void* writeTriangle(void* destination, size_t index_size, unsigned int a, unsigned int b, unsigned int c)
 {
 	if (index_size == 2)
 	{
-		static_cast<unsigned short*>(destination)[offset + 0] = (unsigned short)(a);
-		static_cast<unsigned short*>(destination)[offset + 1] = (unsigned short)(b);
-		static_cast<unsigned short*>(destination)[offset + 2] = (unsigned short)(c);
+		unsigned short* tri = static_cast<unsigned short*>(destination);
+		tri[0] = (unsigned short)(a);
+		tri[1] = (unsigned short)(b);
+		tri[2] = (unsigned short)(c);
+
+		return tri + 3;
 	}
 	else
 	{
-		static_cast<unsigned int*>(destination)[offset + 0] = a;
-		static_cast<unsigned int*>(destination)[offset + 1] = b;
-		static_cast<unsigned int*>(destination)[offset + 2] = c;
+		unsigned int* tri = static_cast<unsigned int*>(destination);
+		tri[0] = a;
+		tri[1] = b;
+		tri[2] = c;
+
+		return tri + 3;
 	}
 }
 
@@ -414,19 +420,16 @@ int meshopt_decodeIndexBuffer(void* destination, size_t index_count, size_t inde
 
 	// since we store 16-byte codeaux table at the end, triangle data has to begin before data_safe_end
 	const unsigned char* code = buffer + 1;
-	const unsigned char* data = code + index_count / 3;
+	const unsigned char* code_end = code + index_count / 3;
+	const unsigned char* data = code_end;
+
+	// each triangle reads at most 16 bytes of data: 1b for codeaux and 5b for each free index
 	const unsigned char* data_safe_end = buffer + buffer_size - 16;
 
 	const unsigned char* codeaux_table = data_safe_end;
 
-	for (size_t i = 0; i < index_count; i += 3)
+	while (code < code_end)
 	{
-		// make sure we have enough data to read for a triangle
-		// each triangle reads at most 16 bytes of data: 1b for codeaux and 5b for each free index
-		// after this we can be sure we can read without extra bounds checks
-		if (data > data_safe_end)
-			return -2;
-
 		unsigned char codetri = *code++;
 
 		if (codetri < 0xf0)
@@ -462,9 +465,13 @@ int meshopt_decodeIndexBuffer(void* destination, size_t index_count, size_t inde
 			}
 			else
 			{
-				// fec - (fec ^ 3) decodes 13, 14 into -1, 1
+				// make sure we have enough data to read for a triangle; this check covers worst case advance
+				if (data > data_safe_end)
+					return -2;
+
+				// fec * 2 - 27 decodes 13, 14 into -1, 1
 				// note that we need to update the last index since free indices are delta-encoded
-				last = c = (fec != 15) ? last + (fec - (fec ^ 3)) : decodeIndex(data, last);
+				last = c = (fec != 15) ? last + (fec * 2 - 27) : decodeIndex(data, last);
 
 				// push vertex/edge fifo must match the encoding step *exactly* otherwise the data will not be decoded correctly
 				pushVertexFifo(vertexfifo, c, vertexfifooffset);
@@ -475,7 +482,7 @@ int meshopt_decodeIndexBuffer(void* destination, size_t index_count, size_t inde
 			pushEdgeFifo(edgefifo, a, c, edgefifooffset);
 
 			// output triangle
-			writeTriangle(destination, i, index_size, a, b, c);
+			destination = writeTriangle(destination, index_size, a, b, c);
 		}
 		else
 		{
@@ -505,7 +512,7 @@ int meshopt_decodeIndexBuffer(void* destination, size_t index_count, size_t inde
 				next += fec0;
 
 				// output triangle
-				writeTriangle(destination, i, index_size, a, b, c);
+				destination = writeTriangle(destination, index_size, a, b, c);
 
 				// push vertex/edge fifo must match the encoding step *exactly* otherwise the data will not be decoded correctly
 				pushVertexFifo(vertexfifo, a, vertexfifooffset);
@@ -518,6 +525,10 @@ int meshopt_decodeIndexBuffer(void* destination, size_t index_count, size_t inde
 			}
 			else
 			{
+				// make sure we have enough data to read for a triangle; this check covers worst case advance
+				if (data > data_safe_end)
+					return -2;
+
 				// slow path: read a full byte for codeaux instead of using a table lookup
 				unsigned char codeaux = *data++;
 
@@ -546,7 +557,7 @@ int meshopt_decodeIndexBuffer(void* destination, size_t index_count, size_t inde
 					last = c = decodeIndex(data, last);
 
 				// output triangle
-				writeTriangle(destination, i, index_size, a, b, c);
+				destination = writeTriangle(destination, index_size, a, b, c);
 
 				// push vertex/edge fifo must match the encoding step *exactly* otherwise the data will not be decoded correctly
 				pushVertexFifo(vertexfifo, a, vertexfifooffset);

--- a/tools/codecbench.cpp
+++ b/tools/codecbench.cpp
@@ -256,6 +256,7 @@ struct File
 	std::vector<unsigned char> data;
 	size_t stride;
 	size_t count;
+	bool index;
 };
 
 File readFile(const char* path)
@@ -266,11 +267,6 @@ File readFile(const char* path)
 	const char* name = strrchr(path, '/');
 	name = name ? name + 1 : path;
 
-	int vcnt, vsz;
-	int sr = sscanf(name, "v%d_s%d_", &vcnt, &vsz);
-	assert(sr == 2);
-	(void)sr;
-
 	std::vector<unsigned char> input;
 	unsigned char buffer[4096];
 	size_t bytes_read;
@@ -280,22 +276,42 @@ File readFile(const char* path)
 
 	fclose(file);
 
-	File result = {};
-	result.count = vcnt;
-	result.stride = vsz;
+	int vcnt, vsz, icnt;
 
-	std::vector<unsigned char> decoded(result.count * result.stride);
-	int res = meshopt_decodeVertexBuffer(&decoded[0], result.count, result.stride, &input[0], input.size());
-	if (res != 0 && input.size() == decoded.size())
+	if (sscanf(name, "v%d_s%d_", &vcnt, &vsz) == 2)
 	{
-		// some files are not encoded
-		memcpy(decoded.data(), input.data(), decoded.size());
+		File result = {};
+		result.count = vcnt;
+		result.stride = vsz;
+
+		std::vector<unsigned char> decoded(result.count * result.stride);
+		int res = meshopt_decodeVertexBuffer(&decoded[0], result.count, result.stride, &input[0], input.size());
+		if (res != 0 && input.size() == decoded.size())
+		{
+			// some files are not encoded
+			memcpy(decoded.data(), input.data(), decoded.size());
+		}
+
+		result.data.resize(meshopt_encodeVertexBufferBound(result.count, result.stride));
+		result.data.resize(meshopt_encodeVertexBuffer(result.data.data(), result.data.size(), decoded.data(), result.count, result.stride));
+
+		return result;
 	}
+	else if (sscanf(name, "i%d_", &icnt) == 1)
+	{
+		File result = {};
+		result.count = icnt;
+		result.stride = icnt <= 0xffff ? 2 : 4; // note: technically 2-byte indices can be used for larger meshes in some cases, but we simplify
+		result.index = true;
+		result.data = input;
 
-	result.data.resize(meshopt_encodeVertexBufferBound(result.count, result.stride));
-	result.data.resize(meshopt_encodeVertexBuffer(result.data.data(), result.data.size(), decoded.data(), result.count, result.stride));
-
-	return result;
+		return result;
+	}
+	else
+	{
+		assert(!"Unrecognized file name");
+		return {};
+	}
 }
 
 int main(int argc, char** argv)
@@ -344,11 +360,18 @@ int main(int argc, char** argv)
 			{
 				double t0 = timestamp();
 
-				for (size_t i = 0; i < files.size(); ++i)
+				for (const File& file : files)
 				{
-					int rv = meshopt_decodeVertexBuffer(&buffer[0], files[i].count, files[i].stride, &files[i].data[0], files[i].data.size());
-					assert(rv == 0);
-					(void)rv;
+					int rc =
+					    file.index
+					        ? meshopt_decodeIndexBuffer(&buffer[0], file.count, int(file.stride), &file.data[0], file.data.size())
+					        : meshopt_decodeVertexBuffer(&buffer[0], file.count, file.stride, &file.data[0], file.data.size());
+
+					if (rc != 0)
+					{
+						fprintf(stderr, "Failed to decode %zu bytes into %zu elements with stride %d (index %d)\n", file.data.size(), file.count, int(file.stride), int(file.index));
+						abort();
+					}
 				}
 
 				double t1 = timestamp();


### PR DESCRIPTION
This change implements several optimizations to existing index decoder,
mainly targeting Clang/GCC on x86-64.

`fec == 0` branch is difficult to predict; the fast path (edge reuse)
decoding is intentionally written in a way that promotes branchless code
generation, as reducing the mispredictions saves more time than the extra
executed instructions take.

Unfortunately, both clang and gcc compile it as a branch, for two different
(bad) reasons. clang uses x86-cmov-conversion pass that replaces select
with a branch because one of the sources is a memory load. This could be fixed
with `__builtin_unpredictable`; however, GCC doesn't support it. GCC takes
the code that loads `cf` and moves it into the ternary, which then makes the
ternary look like a branch where one side is expensive and one side is cheap.
Attempts to use `__builtin_expect_with_probability` do not help.

What does help is using an `asm` barrier that uses `cf`; this fixes both problems
on both compilers. Additionally, GCC has problems with `edgefifo` use on some
versions: it can fuse `a`/`b` loads into a single 64-bit load but keep `edgefifo`
stores as 32-bit, which breaks store-to-load forwarding and results in significant
performance loss too.

Once these issues are fixed, clang suffers from register pressure because of the
indexed load. So this change also reworks the loop structure so that we never
need the triangle index. Finally, the `data` bounds checks are only needed on
the paths that read from `data`, and these paths are fairly cold so we can move
these there too.

Altogether this makes index decoder ~10-20% faster depending on the compiler
and data set. MSVC performance is not affected to a significant degree; it already
correctly emitted `cmov` but has some other weaknesses that are more difficult
to fix, so Clang produces the fastest code. Clang can get up to 25% faster on
large meshes with few seams because the fast path is used for the majority of
the triangles.

*This contribution is sponsored by Valve.*