### PR TITLE
gltfpack: Fix corner cases in texture coordinate processing

### DIFF
--- a/gltf/gltfpack.cpp
+++ b/gltf/gltfpack.cpp
@@ -350,6 +350,23 @@ struct hash<std::pair<uint64_t, uint64_t> >
 };
 } // namespace std
 
+struct PrimitiveCacheEntry
+{
+	size_t offset;
+	size_t size;
+	QuantizationTexture qt;
+};
+
+static bool sameQuantization(const QuantizationTexture& lhs, const QuantizationTexture& rhs, const Settings& settings)
+{
+	if (!settings.quantize || settings.tex_float)
+		return true;
+
+	return lhs.offset[0] == rhs.offset[0] && lhs.offset[1] == rhs.offset[1] &&
+	       lhs.scale[0] == rhs.scale[0] && lhs.scale[1] == rhs.scale[1] &&
+	       lhs.bits == rhs.bits && lhs.normalized == rhs.normalized;
+}
+
 static size_t process(cgltf_data* data, const char* input_path, const char* output_path, const char* report_path, std::vector<Mesh>& meshes, std::vector<Animation>& animations, const Settings& settings, std::string& json, std::string& bin, std::string& fallback, size_t& fallback_size, const char* meshopt_ext)
 {
 	if (settings.verbose)
@@ -582,7 +599,7 @@ static size_t process(cgltf_data* data, const char* input_path, const char* outp
 		ext_texture_transform = ext_texture_transform || mi.uses_texture_transform;
 	}
 
-	std::unordered_map<std::pair<uint64_t, uint64_t>, std::pair<size_t, size_t> > primitive_cache;
+	std::unordered_map<std::pair<uint64_t, uint64_t>, PrimitiveCacheEntry> primitive_cache;
 
 	for (size_t i = 0; i < meshes.size(); ++i)
 	{
@@ -614,18 +631,19 @@ static size_t process(cgltf_data* data, const char* input_path, const char* outp
 
 			if (prim.geometry_duplicate)
 			{
-				std::pair<size_t, size_t>& primitive_json = primitive_cache[std::make_pair(prim.geometry_hash[0], prim.geometry_hash[1])];
+				PrimitiveCacheEntry& entry = primitive_cache[std::make_pair(prim.geometry_hash[0], prim.geometry_hash[1])];
 
-				if (primitive_json.second)
+				if (entry.size && sameQuantization(entry.qt, qt, settings))
 				{
 					// reuse previously written accessors
-					json_meshes.append(json_meshes, primitive_json.first, primitive_json.second);
+					json_meshes.append(json_meshes, entry.offset, entry.size);
 				}
 				else
 				{
-					primitive_json.first = json_meshes.size();
+					entry.offset = json_meshes.size();
 					writeMeshGeometry(json_meshes, views, json_accessors, accr_offset, prim, qp, qt, settings);
-					primitive_json.second = json_meshes.size() - primitive_json.first;
+					entry.size = json_meshes.size() - entry.offset;
+					entry.qt = qt;
 				}
 			}
 			else

--- a/gltf/write.cpp
+++ b/gltf/write.cpp
@@ -2,6 +2,7 @@
 #include "gltfpack.h"
 
 #include <float.h>
+#include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -195,8 +196,11 @@ static void writeTextureInfo(std::string& json, const cgltf_data* data, const cg
 
 	if (qt)
 	{
-		transform.offset[0] += qt->offset[0];
-		transform.offset[1] += qt->offset[1];
+		float rcos = cosf(transform.rotation), rsin = sinf(transform.rotation);
+		float ox = transform.scale[0] * qt->offset[0], oy = transform.scale[1] * qt->offset[1];
+
+		transform.offset[0] += rcos * ox + rsin * oy;
+		transform.offset[1] += -rsin * ox + rcos * oy;
 		transform.scale[0] *= qt->scale[0] / float((1 << qt->bits) - 1) * (qt->normalized ? 65535.f : 1.f);
 		transform.scale[1] *= qt->scale[1] / float((1 << qt->bits) - 1) * (qt->normalized ? 65535.f : 1.f);
 		needs_transform = true;


### PR DESCRIPTION
When UV quantization was enabled (by default) and the input had two
identical meshes with two different materials that required different UV
bounds, we could mistakenly reuse the encoded mesh data through accessor
deduplication; the first mesh that was serialized used the quantization
settings.

Also, if the input file had `KHR_texture_transform` objects, the quantization
transform was not combined correctly with the existing transform: to
preserve the offset, it needs to be transformed according to offset/scale.
This could be masked by the quantization offset being 0.