### PR TITLE
demo: Rework remeshing demo with GPU repainting

### DIFF
--- a/demo/remesh.html
+++ b/demo/remesh.html
@@ -90,7 +90,7 @@
 			import { MeshBVH } from 'three-mesh-bvh';
 			import { MeshoptDecoder } from '../js/meshopt_decoder.mjs';
 			import { MeshoptSimplifier } from '../js/meshopt_simplifier.js';
-			import * as retexture from './retexture.js';
+			import * as repaint from './repaint.js';
 			import { Initialize as initializeWatlas, Atlas } from 'watlas';
 			import { GUI } from 'lil-gui';
 
@@ -289,7 +289,7 @@
 						var geometry = new THREE.BufferGeometry();
 						geometry.setAttribute('position', new THREE.BufferAttribute(positions, 3));
 
-						// we need original normal/uv/colors for gpu retexture
+						// we need original normal/uv/colors for gpu repaint
 						// for mergeGeometries to agree to merge everything, we maintain consistent attribute sets
 						geometry.setAttribute('normal', copyAttribute(object.geometry.attributes.normal, source.count, 3, 0));
 						geometry.setAttribute('uv', copyAttribute(object.geometry.attributes.uv, source.count, 2, 0));
@@ -674,14 +674,16 @@
 					remeshMaterial.vertexColors = false;
 
 					if (settings.paint.mode == 'vertex') {
-						transferColors(merged, geometry);
+						if (settings.paint.gpu) repaint.transferColors(renderer, geometry, merged.bvh, merged.thickness, merged.materials);
+						else transferColors(merged, geometry);
+
 						remeshMaterial.vertexColors = true;
 						remeshMaterial.color.set(0xffffff);
 					} else if (settings.paint.mode == 'texture') {
 						geometry = unwrapMesh(geometry, settings.paint.resolution, settings.paint.gutter);
 						remeshMaterial.color.set(0xffffff);
 						remeshMaterial.map = settings.paint.gpu
-							? retexture.transferTexture(
+							? repaint.transferTexture(
 									renderer,
 									geometry,
 									merged.bvh,

--- a/demo/remesh.html
+++ b/demo/remesh.html
@@ -52,13 +52,17 @@
 				font-size: 12px;
 				line-height: 1.4;
 			}
-			#texture-view {
+			#texture-view,
+			#normal-view {
 				position: fixed;
 				left: 10px;
 				bottom: 10px;
 				width: 256px;
 				height: 256px;
 				display: none;
+			}
+			#normal-view {
+				left: 276px;
 			}
 		</style>
 
@@ -78,6 +82,7 @@
 	<body>
 		<div id="container"></div>
 		<canvas id="texture-view"></canvas>
+		<canvas id="normal-view"></canvas>
 		<input type="file" id="fileInput" style="display: none" accept=".obj,.glb" />
 
 		<script type="module">
@@ -90,6 +95,7 @@
 			import { MeshBVH } from 'three-mesh-bvh';
 			import { MeshoptDecoder } from '../js/meshopt_decoder.mjs';
 			import { MeshoptSimplifier } from '../js/meshopt_simplifier.js';
+			import { MeshoptTangents } from '../js/meshopt_tangents.js';
 			import * as repaint from './repaint.js';
 			import { Initialize as initializeWatlas, Atlas } from 'watlas';
 			import { GUI } from 'lil-gui';
@@ -117,6 +123,7 @@
 					mode: 'vertex',
 					resolution: 1024,
 					gutter: 1,
+					normals: false,
 				},
 
 				loadFile: function () {
@@ -179,6 +186,7 @@
 			guiPaint.add(settings.paint, 'mode', ['none', 'vertex', 'texture']);
 			guiPaint.add(settings.paint, 'resolution', [256, 512, 1024, 2048, 4096]);
 			guiPaint.add(settings.paint, 'gutter', 0, 8, 1);
+			guiPaint.add(settings.paint, 'normals').name('normal map');
 
 			var guiLoad = gui.addFolder('Load');
 			guiLoad.add(settings, 'loadFile');
@@ -302,6 +310,15 @@
 							for (var i = 0; i < source.count; ++i) indices[i] = i;
 							geometry.setIndex(new THREE.BufferAttribute(indices, 1));
 						}
+
+						// we prefer to use the original tangents, but we need to generate them if not present so that normal baking works
+						if (object.geometry.attributes.tangent) {
+							geometry.setAttribute('tangent', copyAttribute(object.geometry.attributes.tangent, source.count, 4, 0));
+						} else {
+							geometry = generateTangents(geometry);
+							geometry = mergeVertices(geometry);
+						}
+
 						geometry.applyMatrix4(object.matrixWorld);
 						geometries.push(geometry);
 					}
@@ -340,14 +357,25 @@
 				}
 				atlas.delete();
 
+				// uvs are computed per corner, for simplicity we deindex the geometry and expect caller to reindex
 				geometry = geometry.toNonIndexed();
 				geometry.setAttribute('uv', new THREE.BufferAttribute(uv, 2));
-				geometry = mergeVertices(geometry);
 				return geometry;
 			}
 
-			function showTexture(texture) {
-				var canvas = document.getElementById('texture-view');
+			function generateTangents(geometry) {
+				var attr = geometry.attributes;
+				var indices = geometry.index ? new Uint32Array(geometry.index.array) : null;
+				var tangents = MeshoptTangents.generateTangents(indices, attr.position.array, 3, attr.normal.array, 3, attr.uv.array, 2);
+
+				// tangents are computed per corner, for simplicity we deindex the geometry and expect caller to reindex
+				if (indices) geometry = geometry.toNonIndexed();
+				geometry.setAttribute('tangent', new THREE.BufferAttribute(tangents, 4));
+				return geometry;
+			}
+
+			function showTexture(id, texture) {
+				var canvas = document.getElementById(id);
 				canvas.style.display = texture ? 'block' : 'none';
 				if (!texture) return;
 
@@ -366,7 +394,11 @@
 				if (remeshMaterial.map) remeshMaterial.map.dispose();
 				remeshMaterial.map = null;
 
-				showTexture(null);
+				if (remeshMaterial.normalMap) remeshMaterial.normalMap.dispose();
+				remeshMaterial.normalMap = null;
+
+				showTexture('texture-view', null);
+				showTexture('normal-view', null);
 			}
 
 			function simplifyMesh(geo, threshold, flags, solve) {
@@ -395,7 +427,7 @@
 			}
 
 			function remesh() {
-				MeshoptSimplifier.ready.then(initializeWatlas).then(function () {
+				Promise.all([MeshoptSimplifier.ready, MeshoptTangents.ready, initializeWatlas()]).then(function () {
 					if (!merged) return;
 
 					clearRemeshed();
@@ -419,6 +451,7 @@
 					geometry = mergeVertices(toCreasedNormals(geometry, THREE.MathUtils.degToRad(settings.debug ? 30 : settings.normalCrease)));
 
 					remeshMaterial.vertexColors = false;
+					remeshMaterial.roughness = 1;
 
 					if (settings.paint.mode != 'none') {
 						paintCache = paintCache || repaint.buildCache(merged.bvh, merged.materials);
@@ -430,15 +463,23 @@
 						remeshMaterial.color.set(0xffffff);
 					} else if (settings.paint.mode == 'texture') {
 						geometry = unwrapMesh(geometry, settings.paint.resolution, settings.paint.gutter);
-						remeshMaterial.color.set(0xffffff);
-						remeshMaterial.map = repaint.transferTexture(
+						if (settings.paint.normals) geometry = generateTangents(geometry);
+						geometry = mergeVertices(geometry);
+
+						var textures = repaint.transferTexture(
 							renderer,
 							geometry,
 							paintCache,
 							merged.thickness,
 							settings.paint.resolution,
-							settings.paint.gutter
+							settings.paint.gutter,
+							settings.paint.normals
 						);
+
+						remeshMaterial.color.set(0xffffff);
+						remeshMaterial.map = textures.map;
+						remeshMaterial.normalMap = textures.normalMap;
+						remeshMaterial.roughness = textures.normalMap ? 0.5 : 1;
 					} else {
 						remeshMaterial.color.set(0xdddddd);
 					}
@@ -451,7 +492,8 @@
 					remeshed = new THREE.Mesh(geometry, [remeshMaterial, wireframeMaterial]);
 					model.visible = false;
 					scene.add(remeshed);
-					showTexture(remeshMaterial.map);
+					showTexture('texture-view', remeshMaterial.map);
+					showTexture('normal-view', remeshMaterial.normalMap);
 					update();
 
 					var triangles = geometry.index.count / 3;

--- a/demo/remesh.html
+++ b/demo/remesh.html
@@ -651,7 +651,14 @@
 						geometry = unwrapMesh(geometry, settings.paint.resolution, settings.paint.gutter);
 						remeshMaterial.color.set(0xffffff);
 						remeshMaterial.map = settings.paint.gpu
-							? retexture.transferTexture(renderer, geometry, settings.paint.resolution, settings.paint.gutter)
+							? retexture.transferTexture(
+									renderer,
+									geometry,
+									merged.bvh,
+									merged.thickness,
+									settings.paint.resolution,
+									settings.paint.gutter
+								)
 							: transferTexture(merged, geometry, settings.paint.resolution, settings.paint.gutter);
 					} else {
 						remeshMaterial.color.set(0xdddddd);

--- a/demo/remesh.html
+++ b/demo/remesh.html
@@ -73,8 +73,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://cdn.jsdelivr.net/npm/three@0.183.0/build/three.module.js",
-					"three-examples/": "https://cdn.jsdelivr.net/npm/three@0.183.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.185.0/build/three.module.js",
+					"three-examples/": "https://cdn.jsdelivr.net/npm/three@0.185.0/examples/jsm/",
 					"three-mesh-bvh": "https://cdn.jsdelivr.net/npm/three-mesh-bvh@0.9.10/build/index.module.js",
 					"watlas": "https://cdn.jsdelivr.net/npm/watlas@1.0.1/dist/watlas.js",
 					"lil-gui": "https://cdn.jsdelivr.net/npm/lil-gui@0.20.0/dist/lil-gui.esm.js"
@@ -280,31 +280,39 @@
 				return new THREE.BufferAttribute(result, itemSize);
 			}
 
+			function skinAttribute(object, attribute, w) {
+				var v = new THREE.Vector4();
+
+				for (var i = 0; i < attribute.count; ++i) {
+					v.set(attribute.getX(i), attribute.getY(i), attribute.getZ(i), w);
+					object.applyBoneTransform(i, v);
+					if (w == 0) v.normalize();
+					attribute.setXYZ(i, v.x, v.y, v.z);
+				}
+			}
+
 			function mergeMesh(model) {
 				var geometries = [];
-				var vertex = new THREE.Vector3();
 				var materials = [];
 
 				model.updateMatrixWorld(true);
 				model.traverse(function (object) {
 					if (object.isMesh && object.geometry.attributes.position) {
 						var source = object.geometry.attributes.position;
-						var positions = new Float32Array(source.count * 3);
-
-						// getVertexPosition applies the skinning transform, if present
-						for (var i = 0; i < source.count; ++i) {
-							object.getVertexPosition(i, vertex);
-							vertex.toArray(positions, i * 3);
-						}
-
 						var geometry = new THREE.BufferGeometry();
-						geometry.setAttribute('position', new THREE.BufferAttribute(positions, 3));
+
+						geometry.setAttribute('position', copyAttribute(source, source.count, 3, 0));
 
 						// we need original normal/uv/colors for gpu repaint
 						// for mergeGeometries to agree to merge everything, we maintain consistent attribute sets
 						geometry.setAttribute('normal', copyAttribute(object.geometry.attributes.normal, source.count, 3, 0));
 						geometry.setAttribute('uv', copyAttribute(object.geometry.attributes.uv, source.count, 2, 0));
 						geometry.setAttribute('color', copyAttribute(object.geometry.attributes.color, source.count, 4, 1));
+
+						if (object.isSkinnedMesh) {
+							skinAttribute(object, geometry.attributes.position, 1);
+							skinAttribute(object, geometry.attributes.normal, 0);
+						}
 
 						var material = Array.isArray(object.material) ? object.material[0] : object.material;
 						if (materials.indexOf(material) < 0) materials.push(material);
@@ -323,6 +331,7 @@
 						// we prefer to use the original tangents, but we need to generate them if not present so that normal baking works
 						if (object.geometry.attributes.tangent) {
 							geometry.setAttribute('tangent', copyAttribute(object.geometry.attributes.tangent, source.count, 4, 0));
+							if (object.isSkinnedMesh) skinAttribute(object, geometry.attributes.tangent, 0);
 						} else {
 							geometry = generateTangents(geometry);
 							geometry = mergeVertices(geometry);

--- a/demo/remesh.html
+++ b/demo/remesh.html
@@ -96,6 +96,7 @@
 
 			var container;
 			var camera, renderer, scene, controls, model, merged, remeshed, remeshMaterial, wireframeMaterial, stats;
+			var paintCache = null;
 
 			var settings = {
 				wireframe: false,
@@ -419,8 +420,12 @@
 
 					remeshMaterial.vertexColors = false;
 
+					if (settings.paint.mode != 'none') {
+						paintCache = paintCache || repaint.buildCache(merged.bvh, merged.materials);
+					}
+
 					if (settings.paint.mode == 'vertex') {
-						repaint.transferColors(renderer, geometry, merged.bvh, merged.thickness, merged.materials);
+						repaint.transferColors(renderer, geometry, paintCache, merged.thickness);
 						remeshMaterial.vertexColors = true;
 						remeshMaterial.color.set(0xffffff);
 					} else if (settings.paint.mode == 'texture') {
@@ -429,9 +434,8 @@
 						remeshMaterial.map = repaint.transferTexture(
 							renderer,
 							geometry,
-							merged.bvh,
+							paintCache,
 							merged.thickness,
-							merged.materials,
 							settings.paint.resolution,
 							settings.paint.gutter
 						);
@@ -559,6 +563,9 @@
 			function load(path, ext) {
 				if (model) scene.remove(model);
 				clearRemeshed();
+
+				if (paintCache) paintCache.dispose();
+				paintCache = null;
 
 				model = undefined;
 				merged = undefined;

--- a/demo/remesh.html
+++ b/demo/remesh.html
@@ -128,6 +128,7 @@
 					mode: 'vertex',
 					resolution: 1024,
 					gutter: 1,
+					infill: true,
 					normals: false,
 					materials: false,
 				},
@@ -192,6 +193,7 @@
 			guiPaint.add(settings.paint, 'mode', ['none', 'vertex', 'texture']);
 			guiPaint.add(settings.paint, 'resolution', [256, 512, 1024, 2048]);
 			guiPaint.add(settings.paint, 'gutter', 0, 8, 1);
+			guiPaint.add(settings.paint, 'infill');
 			guiPaint.add(settings.paint, 'normals').name('normal map');
 			guiPaint.add(settings.paint, 'materials').name('material map');
 
@@ -487,6 +489,7 @@
 							merged.thickness,
 							settings.paint.resolution,
 							settings.paint.gutter,
+							settings.paint.infill,
 							settings.paint.normals,
 							settings.paint.materials
 						);

--- a/demo/remesh.html
+++ b/demo/remesh.html
@@ -53,7 +53,8 @@
 				line-height: 1.4;
 			}
 			#texture-view,
-			#normal-view {
+			#normal-view,
+			#material-view {
 				position: fixed;
 				left: 10px;
 				bottom: 10px;
@@ -63,6 +64,9 @@
 			}
 			#normal-view {
 				left: 276px;
+			}
+			#material-view {
+				left: 542px;
 			}
 		</style>
 
@@ -83,6 +87,7 @@
 		<div id="container"></div>
 		<canvas id="texture-view"></canvas>
 		<canvas id="normal-view"></canvas>
+		<canvas id="material-view"></canvas>
 		<input type="file" id="fileInput" style="display: none" accept=".obj,.glb" />
 
 		<script type="module">
@@ -124,6 +129,7 @@
 					resolution: 1024,
 					gutter: 1,
 					normals: false,
+					materials: false,
 				},
 
 				loadFile: function () {
@@ -184,9 +190,10 @@
 
 			var guiPaint = gui.addFolder('Paint');
 			guiPaint.add(settings.paint, 'mode', ['none', 'vertex', 'texture']);
-			guiPaint.add(settings.paint, 'resolution', [256, 512, 1024, 2048, 4096]);
+			guiPaint.add(settings.paint, 'resolution', [256, 512, 1024, 2048]);
 			guiPaint.add(settings.paint, 'gutter', 0, 8, 1);
 			guiPaint.add(settings.paint, 'normals').name('normal map');
+			guiPaint.add(settings.paint, 'materials').name('material map');
 
 			var guiLoad = gui.addFolder('Load');
 			guiLoad.add(settings, 'loadFile');
@@ -397,8 +404,14 @@
 				if (remeshMaterial.normalMap) remeshMaterial.normalMap.dispose();
 				remeshMaterial.normalMap = null;
 
+				// roughness and metalness share one texture, so we only dispose once
+				if (remeshMaterial.metalnessMap) remeshMaterial.metalnessMap.dispose();
+				remeshMaterial.metalnessMap = null;
+				remeshMaterial.roughnessMap = null;
+
 				showTexture('texture-view', null);
 				showTexture('normal-view', null);
+				showTexture('material-view', null);
 			}
 
 			function simplifyMesh(geo, threshold, flags, solve) {
@@ -451,6 +464,7 @@
 					geometry = mergeVertices(toCreasedNormals(geometry, THREE.MathUtils.degToRad(settings.debug ? 30 : settings.normalCrease)));
 
 					remeshMaterial.vertexColors = false;
+					remeshMaterial.metalness = 0;
 					remeshMaterial.roughness = 1;
 
 					if (settings.paint.mode != 'none') {
@@ -473,13 +487,22 @@
 							merged.thickness,
 							settings.paint.resolution,
 							settings.paint.gutter,
-							settings.paint.normals
+							settings.paint.normals,
+							settings.paint.materials
 						);
 
 						remeshMaterial.color.set(0xffffff);
 						remeshMaterial.map = textures.map;
 						remeshMaterial.normalMap = textures.normalMap;
-						remeshMaterial.roughness = textures.normalMap ? 0.5 : 1;
+
+						if (settings.paint.materials) {
+							remeshMaterial.metalnessMap = textures.materialMap;
+							remeshMaterial.roughnessMap = textures.materialMap;
+							remeshMaterial.metalness = 1;
+						} else if (settings.paint.normals) {
+							// we need this to have a specular response
+							remeshMaterial.roughness = 0.5;
+						}
 					} else {
 						remeshMaterial.color.set(0xdddddd);
 					}
@@ -494,6 +517,7 @@
 					scene.add(remeshed);
 					showTexture('texture-view', remeshMaterial.map);
 					showTexture('normal-view', remeshMaterial.normalMap);
+					showTexture('material-view', remeshMaterial.metalnessMap);
 					update();
 
 					var triangles = geometry.index.count / 3;

--- a/demo/remesh.html
+++ b/demo/remesh.html
@@ -90,6 +90,7 @@
 			import { MeshBVH } from 'three-mesh-bvh';
 			import { MeshoptDecoder } from '../js/meshopt_decoder.mjs';
 			import { MeshoptSimplifier } from '../js/meshopt_simplifier.js';
+			import * as retexture from './retexture.js';
 			import { Initialize as initializeWatlas, Atlas } from 'watlas';
 			import { GUI } from 'lil-gui';
 
@@ -117,6 +118,7 @@
 					mode: 'vertex',
 					resolution: 512,
 					gutter: 1,
+					gpu: false,
 				},
 
 				loadFile: function () {
@@ -180,6 +182,7 @@
 			guiPaint.add(settings.paint, 'mode', ['none', 'vertex', 'texture']);
 			guiPaint.add(settings.paint, 'resolution', [256, 512, 1024, 2048]);
 			guiPaint.add(settings.paint, 'gutter', 0, 8, 1);
+			guiPaint.add(settings.paint, 'gpu');
 
 			var guiLoad = gui.addFolder('Load');
 			guiLoad.add(settings, 'loadFile');
@@ -647,7 +650,9 @@
 					} else if (settings.paint.mode == 'texture') {
 						geometry = unwrapMesh(geometry, settings.paint.resolution, settings.paint.gutter);
 						remeshMaterial.color.set(0xffffff);
-						remeshMaterial.map = transferTexture(merged, geometry, settings.paint.resolution, settings.paint.gutter);
+						remeshMaterial.map = settings.paint.gpu
+							? retexture.transferTexture(renderer, geometry, settings.paint.resolution, settings.paint.gutter)
+							: transferTexture(merged, geometry, settings.paint.resolution, settings.paint.gutter);
 					} else {
 						remeshMaterial.color.set(0xdddddd);
 					}

--- a/demo/remesh.html
+++ b/demo/remesh.html
@@ -351,7 +351,7 @@
 					indexData: indices,
 					indexCount: indices.length,
 				});
-				atlas.generate({}, { resolution: resolution, padding: gutter });
+				atlas.generate({ normalSeamWeight: 0 }, { resolution: resolution, padding: gutter });
 
 				var mesh = atlas.getMesh(0);
 				var atlasIndices = new Uint32Array(mesh.indexCount);

--- a/demo/remesh.html
+++ b/demo/remesh.html
@@ -686,6 +686,7 @@
 									geometry,
 									merged.bvh,
 									merged.thickness,
+									merged.materials,
 									settings.paint.resolution,
 									settings.paint.gutter
 								)

--- a/demo/remesh.html
+++ b/demo/remesh.html
@@ -84,6 +84,7 @@
 			import * as THREE from 'three';
 			import { GLTFLoader } from 'three-examples/loaders/GLTFLoader.js';
 			import { OBJLoader } from 'three-examples/loaders/OBJLoader.js';
+			import { GLTFExporter } from 'three-examples/exporters/GLTFExporter.js';
 			import { OrbitControls } from 'three-examples/controls/OrbitControls.js';
 			import { mergeGeometries, mergeVertices, toCreasedNormals } from 'three-examples/utils/BufferGeometryUtils.js';
 			import { MeshBVH } from 'three-mesh-bvh';
@@ -139,6 +140,11 @@
 					revert();
 				},
 
+				exportFile: function () {
+					if (!remeshed) return;
+					exportGlb('remesh.glb');
+				},
+
 				updateModule: function () {
 					reload();
 					remesh();
@@ -162,6 +168,7 @@
 			guiRemesh.add(settings, 'normalCrease', 0, 180, 1).name('normal crease');
 			guiRemesh.add(settings, 'remesh');
 			guiRemesh.add(settings, 'revert');
+			guiRemesh.add(settings, 'exportFile');
 
 			var guiSimplify = gui.addFolder('Simplify');
 			guiSimplify.add(settings.simplify, 'enabled');
@@ -662,6 +669,30 @@
 					stats.ratio = (triangles / (merged.index.count / 3)) * 100;
 					updateStatsDisplay();
 				});
+			}
+
+			function exportGlb(name) {
+				// can't export remeshed directly as it uses debug materials for wireframe
+				var mesh = new THREE.Mesh(remeshed.geometry, remeshMaterial);
+
+				new GLTFExporter().parse(
+					mesh,
+					function (glb) {
+						var link = document.createElement('a');
+						link.href = URL.createObjectURL(new Blob([glb], { type: 'model/gltf-binary' }));
+						link.download = name;
+						link.click();
+
+						// may resolve rare race conditions
+						setTimeout(function () {
+							URL.revokeObjectURL(link.href);
+						}, 0);
+					},
+					function (e) {
+						console.log(e);
+					},
+					{ binary: true }
+				);
 			}
 
 			function revert() {

--- a/demo/remesh.html
+++ b/demo/remesh.html
@@ -97,7 +97,6 @@
 			import { GLTFExporter } from 'three-examples/exporters/GLTFExporter.js';
 			import { OrbitControls } from 'three-examples/controls/OrbitControls.js';
 			import { mergeGeometries, mergeVertices, toCreasedNormals } from 'three-examples/utils/BufferGeometryUtils.js';
-			import { MeshBVH } from 'three-mesh-bvh';
 			import { MeshoptDecoder } from '../js/meshopt_decoder.mjs';
 			import { MeshoptSimplifier } from '../js/meshopt_simplifier.js';
 			import { MeshoptTangents } from '../js/meshopt_tangents.js';
@@ -112,20 +111,20 @@
 			var settings = {
 				wireframe: false,
 				wireframeOverlay: false,
-				resolution: 64,
+				resolution: 100,
 				thicken: false,
 				shell: false,
 				solve: true,
 				debug: false,
 				normalCrease: 120,
 				simplify: {
-					enabled: false,
+					enabled: true,
 					regularize: true,
 					solve: true,
 					errorThresholdLog10: 2.5,
 				},
 				paint: {
-					mode: 'vertex',
+					mode: 'texture',
 					resolution: 1024,
 					gutter: 1,
 					infill: true,
@@ -345,7 +344,6 @@
 				var result = mergeGeometries(geometries);
 				result.computeBoundingBox();
 				result.materials = materials;
-				result.bvh = new MeshBVH(result, { indirect: true });
 				result.thickness = result.boundingBox.getSize(new THREE.Vector3()).length() * 0.01;
 				return result;
 			}
@@ -479,7 +477,7 @@
 					remeshMaterial.roughness = 1;
 
 					if (settings.paint.mode != 'none') {
-						paintCache = paintCache || repaint.buildCache(merged.bvh, merged.materials);
+						paintCache = paintCache || repaint.buildCache(merged, merged.materials);
 					}
 
 					if (settings.paint.mode == 'vertex') {

--- a/demo/remesh.html
+++ b/demo/remesh.html
@@ -252,11 +252,27 @@
 				updateRendererSizes();
 			}
 
+			function copyAttribute(attribute, count, itemSize, def) {
+				var result = new Float32Array(count * itemSize).fill(def);
+
+				if (attribute) {
+					var copy = Math.min(itemSize, attribute.itemSize);
+					for (var i = 0; i < count; ++i) {
+						for (var k = 0; k < copy; ++k) {
+							result[i * itemSize + k] = attribute.getComponent(i, k);
+						}
+					}
+				}
+
+				return new THREE.BufferAttribute(result, itemSize);
+			}
+
 			function mergeMesh(model) {
 				var geometries = [];
 				var vertex = new THREE.Vector3();
 				var sourceTriangle = [];
 				var sourceMesh = [];
+				var materials = [];
 
 				model.updateMatrixWorld(true);
 				model.traverse(function (object) {
@@ -272,6 +288,19 @@
 
 						var geometry = new THREE.BufferGeometry();
 						geometry.setAttribute('position', new THREE.BufferAttribute(positions, 3));
+
+						// we need original normal/uv/colors for gpu retexture
+						// for mergeGeometries to agree to merge everything, we maintain consistent attribute sets
+						geometry.setAttribute('normal', copyAttribute(object.geometry.attributes.normal, source.count, 3, 0));
+						geometry.setAttribute('uv', copyAttribute(object.geometry.attributes.uv, source.count, 2, 0));
+						geometry.setAttribute('color', copyAttribute(object.geometry.attributes.color, source.count, 4, 1));
+
+						var material = Array.isArray(object.material) ? object.material[0] : object.material;
+						if (materials.indexOf(material) < 0) materials.push(material);
+
+						var materialIndex = new Uint32Array(source.count).fill(materials.indexOf(material));
+						geometry.setAttribute('material', new THREE.BufferAttribute(materialIndex, 1));
+
 						if (object.geometry.index) {
 							geometry.setIndex(object.geometry.index);
 						} else {
@@ -293,6 +322,7 @@
 				result.computeBoundingBox();
 				result.sourceTriangle = sourceTriangle;
 				result.sourceMesh = sourceMesh;
+				result.materials = materials;
 				result.bvh = new MeshBVH(result, { indirect: true });
 				result.thickness = result.boundingBox.getSize(new THREE.Vector3()).length() * 0.01;
 				return result;

--- a/demo/remesh.html
+++ b/demo/remesh.html
@@ -96,13 +96,11 @@
 
 			var container;
 			var camera, renderer, scene, controls, model, merged, remeshed, remeshMaterial, wireframeMaterial, stats;
-			var textureImages = new WeakMap();
 
 			var settings = {
 				wireframe: false,
 				wireframeOverlay: false,
 				resolution: 64,
-				sloppy: false,
 				thicken: false,
 				shell: false,
 				solve: true,
@@ -116,9 +114,8 @@
 				},
 				paint: {
 					mode: 'vertex',
-					resolution: 512,
+					resolution: 1024,
 					gutter: 1,
-					gpu: false,
 				},
 
 				loadFile: function () {
@@ -162,7 +159,6 @@
 
 			var guiRemesh = gui.addFolder('Remesh');
 			guiRemesh.add(settings, 'resolution', 4, 256, 1);
-			guiRemesh.add(settings, 'sloppy');
 			guiRemesh.add(settings, 'thicken');
 			guiRemesh.add(settings, 'shell');
 			guiRemesh.add(settings, 'solve');
@@ -180,9 +176,8 @@
 
 			var guiPaint = gui.addFolder('Paint');
 			guiPaint.add(settings.paint, 'mode', ['none', 'vertex', 'texture']);
-			guiPaint.add(settings.paint, 'resolution', [256, 512, 1024, 2048]);
+			guiPaint.add(settings.paint, 'resolution', [256, 512, 1024, 2048, 4096]);
 			guiPaint.add(settings.paint, 'gutter', 0, 8, 1);
-			guiPaint.add(settings.paint, 'gpu');
 
 			var guiLoad = gui.addFolder('Load');
 			guiLoad.add(settings, 'loadFile');
@@ -270,8 +265,6 @@
 			function mergeMesh(model) {
 				var geometries = [];
 				var vertex = new THREE.Vector3();
-				var sourceTriangle = [];
-				var sourceMesh = [];
 				var materials = [];
 
 				model.updateMatrixWorld(true);
@@ -310,175 +303,15 @@
 						}
 						geometry.applyMatrix4(object.matrixWorld);
 						geometries.push(geometry);
-
-						for (var i = 0; i < geometry.index.count / 3; ++i) {
-							sourceTriangle.push(i);
-							sourceMesh.push(object);
-						}
 					}
 				});
 
 				var result = mergeGeometries(geometries);
 				result.computeBoundingBox();
-				result.sourceTriangle = sourceTriangle;
-				result.sourceMesh = sourceMesh;
 				result.materials = materials;
 				result.bvh = new MeshBVH(result, { indirect: true });
 				result.thickness = result.boundingBox.getSize(new THREE.Vector3()).length() * 0.01;
 				return result;
-			}
-
-			function getTextureImage(texture) {
-				if (!textureImages.has(texture.source)) {
-					var canvas = document.createElement('canvas');
-					canvas.width = texture.image.width;
-					canvas.height = texture.image.height;
-					var context = canvas.getContext('2d');
-					context.drawImage(texture.image, 0, 0);
-					textureImages.set(texture.source, context.getImageData(0, 0, texture.image.width, texture.image.height));
-				}
-				return textureImages.get(texture.source);
-			}
-
-			function sampleTexture(texture, uv) {
-				var image = getTextureImage(texture);
-				var point = texture.transformUv(uv.clone());
-				var x = Math.min(Math.floor(point.x * image.width), image.width - 1);
-				var y = Math.min(Math.floor(point.y * image.height), image.height - 1);
-
-				var offset = (y * image.width + x) * 4;
-				return new THREE.Color(image.data[offset] / 255, image.data[offset + 1] / 255, image.data[offset + 2] / 255);
-			}
-
-			function interpolate(attr, a, b, c, bary, comp) {
-				return attr.getComponent(a, comp) * bary.x + attr.getComponent(b, comp) * bary.y + attr.getComponent(c, comp) * bary.z;
-			}
-
-			function sampleColorBary(mesh, triangle, bary) {
-				var geometry = mesh.geometry;
-				var offset = triangle * 3,
-					indices = geometry.index;
-				var a = indices ? indices.array[offset] : offset,
-					b = indices ? indices.array[offset + 1] : offset + 1,
-					c = indices ? indices.array[offset + 2] : offset + 2;
-
-				var material = mesh.material;
-				if (Array.isArray(material)) {
-					var group = geometry.groups.find(function (group) {
-						return offset >= group.start && offset < group.start + group.count;
-					});
-					material = material[group ? group.materialIndex : 0];
-				}
-
-				var result = material.color.clone();
-
-				var uv = new THREE.Vector2();
-				if (geometry.attributes.uv) {
-					uv.x = interpolate(geometry.attributes.uv, a, b, c, bary, 0);
-					uv.y = interpolate(geometry.attributes.uv, a, b, c, bary, 1);
-				}
-
-				if (material.map) {
-					result.multiply(sampleTexture(material.map, uv).convertSRGBToLinear());
-				}
-
-				if (material.vertexColors) {
-					result.r *= interpolate(geometry.attributes.color, a, b, c, bary, 0);
-					result.g *= interpolate(geometry.attributes.color, a, b, c, bary, 1);
-					result.b *= interpolate(geometry.attributes.color, a, b, c, bary, 2);
-				}
-
-				if (material.aoMap) {
-					var ao = sampleTexture(material.aoMap, uv).r;
-					result.multiplyScalar(1 + material.aoMapIntensity * (ao - 1));
-				}
-
-				if (material.metalness) {
-					var metalness = material.metalness;
-					if (material.metalnessMap) metalness *= sampleTexture(material.metalnessMap, uv).b;
-					var roughness = material.roughness;
-					if (material.roughnessMap) roughness *= sampleTexture(material.roughnessMap, uv).g;
-					result.multiplyScalar(1 - metalness * (1 - roughness * roughness * roughness));
-				}
-
-				if (material.emissive) {
-					var emissive = material.emissive.clone().multiplyScalar(material.emissiveIntensity);
-					if (material.emissiveMap) emissive.multiply(sampleTexture(material.emissiveMap, uv).convertSRGBToLinear());
-					result.add(emissive);
-				}
-
-				return result;
-			}
-
-			function sampleColor(model, point, normal) {
-				var hit = undefined;
-				if (normal) {
-					var ray = new THREE.Ray();
-					ray.origin.copy(point).addScaledVector(normal, model.thickness);
-					ray.direction.copy(normal).negate();
-					hit = model.bvh.raycastFirst(ray, THREE.DoubleSide, 1e-12, model.thickness * 2);
-				}
-				if (!hit) hit = model.bvh.closestPointToPoint(point);
-
-				var a = new THREE.Vector3(),
-					b = new THREE.Vector3(),
-					c = new THREE.Vector3(),
-					bary = new THREE.Vector3();
-				a.fromBufferAttribute(model.attributes.position, model.index.array[hit.faceIndex * 3 + 0]);
-				b.fromBufferAttribute(model.attributes.position, model.index.array[hit.faceIndex * 3 + 1]);
-				c.fromBufferAttribute(model.attributes.position, model.index.array[hit.faceIndex * 3 + 2]);
-				THREE.Triangle.getBarycoord(hit.point, a, b, c, bary);
-
-				return sampleColorBary(model.sourceMesh[hit.faceIndex], model.sourceTriangle[hit.faceIndex], bary);
-			}
-
-			function transferColors(model, geometry) {
-				var colors = new Float32Array(geometry.attributes.position.count * 4);
-				var position = geometry.attributes.position,
-					normal = geometry.attributes.normal,
-					indices = geometry.index.array;
-				var query = new THREE.Vector3(),
-					direction = new THREE.Vector3(),
-					temp = new THREE.Vector3();
-
-				for (var i = 0; i < position.count; ++i) {
-					query.fromBufferAttribute(position, i);
-					direction.fromBufferAttribute(normal, i);
-
-					sampleColor(model, query, direction).toArray(colors, i * 4);
-					colors[i * 4 + 3] = 1;
-				}
-
-				for (var i = 0; i < indices.length; i += 3) {
-					query.fromBufferAttribute(position, indices[i]);
-					query.add(temp.fromBufferAttribute(position, indices[i + 1]));
-					query.add(temp.fromBufferAttribute(position, indices[i + 2]));
-					query.multiplyScalar(1 / 3);
-
-					direction.fromBufferAttribute(normal, indices[i]);
-					direction.add(temp.fromBufferAttribute(normal, indices[i + 1]));
-					direction.add(temp.fromBufferAttribute(normal, indices[i + 2]));
-					direction.normalize();
-
-					var color = sampleColor(model, query, direction);
-
-					for (var j = 0; j < 3; ++j) {
-						var v = indices[i + j];
-						colors[v * 4] += color.r;
-						colors[v * 4 + 1] += color.g;
-						colors[v * 4 + 2] += color.b;
-						colors[v * 4 + 3]++;
-					}
-				}
-
-				for (var i = 0; i < colors.length; i += 4) {
-					colors[i] /= colors[i + 3];
-					colors[i + 1] /= colors[i + 3];
-					colors[i + 2] /= colors[i + 3];
-					colors[i + 3] = 1;
-				}
-
-				geometry.setAttribute('color', new THREE.BufferAttribute(colors, 4));
 			}
 
 			function unwrapMesh(geometry, resolution, gutter) {
@@ -512,86 +345,6 @@
 				return geometry;
 			}
 
-			function transferTexture(model, geometry, size, gutter) {
-				var data = new Float32Array(size * size * 4);
-				var position = geometry.attributes.position,
-					normal = geometry.attributes.normal,
-					uv = geometry.attributes.uv,
-					indices = geometry.index.array;
-				var bary = new THREE.Vector3(),
-					point = new THREE.Vector3(),
-					direction = new THREE.Vector3();
-
-				for (var i = 0; i < indices.length; i += 3) {
-					var a = indices[i],
-						b = indices[i + 1],
-						c = indices[i + 2];
-					var x0 = uv.getX(a) * size,
-						y0 = uv.getY(a) * size;
-					var x1 = uv.getX(b) * size,
-						y1 = uv.getY(b) * size;
-					var x2 = uv.getX(c) * size,
-						y2 = uv.getY(c) * size;
-					var minX = Math.max(0, Math.floor(Math.min(x0, x1, x2) - gutter)),
-						maxX = Math.min(size - 1, Math.ceil(Math.max(x0, x1, x2) + gutter));
-					var minY = Math.max(0, Math.floor(Math.min(y0, y1, y2) - gutter)),
-						maxY = Math.min(size - 1, Math.ceil(Math.max(y0, y1, y2) + gutter));
-					var denominator = (y1 - y2) * (x0 - x2) + (x2 - x1) * (y0 - y2);
-					if (Math.abs(denominator) < 1e-7) continue;
-
-					var scale = gutter / Math.abs(denominator);
-					var epsilonX = 1e-4 + Math.hypot(x1 - x2, y1 - y2) * scale;
-					var epsilonY = 1e-4 + Math.hypot(x2 - x0, y2 - y0) * scale;
-					var epsilonZ = 1e-4 + Math.hypot(x0 - x1, y0 - y1) * scale;
-
-					for (var y = minY; y <= maxY; ++y) {
-						for (var x = minX; x <= maxX; ++x) {
-							bary.x = ((y1 - y2) * (x + 0.5 - x2) + (x2 - x1) * (y + 0.5 - y2)) / denominator;
-							bary.y = ((y2 - y0) * (x + 0.5 - x2) + (x0 - x2) * (y + 0.5 - y2)) / denominator;
-							bary.z = 1 - bary.x - bary.y;
-							if (bary.x < -epsilonX || bary.y < -epsilonY || bary.z < -epsilonZ) continue;
-
-							point.set(
-								interpolate(position, a, b, c, bary, 0),
-								interpolate(position, a, b, c, bary, 1),
-								interpolate(position, a, b, c, bary, 2)
-							);
-							direction.set(
-								interpolate(normal, a, b, c, bary, 0),
-								interpolate(normal, a, b, c, bary, 1),
-								interpolate(normal, a, b, c, bary, 2)
-							);
-							direction.normalize();
-
-							var color = sampleColor(model, point, direction).convertLinearToSRGB();
-
-							var offset = (y * size + x) * 4;
-							data[offset] += color.r * 255;
-							data[offset + 1] += color.g * 255;
-							data[offset + 2] += color.b * 255;
-							data[offset + 3]++;
-						}
-					}
-				}
-
-				for (var i = 0; i < data.length; i += 4) {
-					var count = data[i + 3];
-					if (count) {
-						data[i] = Math.min(data[i] / count, 255);
-						data[i + 1] = Math.min(data[i + 1] / count, 255);
-						data[i + 2] = Math.min(data[i + 2] / count, 255);
-						data[i + 3] = 255;
-					}
-				}
-
-				var texture = new THREE.DataTexture(new Uint8Array(data), size, size, THREE.RGBAFormat);
-				texture.colorSpace = THREE.SRGBColorSpace;
-				texture.magFilter = THREE.LinearFilter;
-				texture.minFilter = THREE.LinearFilter;
-				texture.needsUpdate = true;
-				return texture;
-			}
-
 			function showTexture(texture) {
 				var canvas = document.getElementById('texture-view');
 				canvas.style.display = texture ? 'block' : 'none';
@@ -615,14 +368,12 @@
 				showTexture(null);
 			}
 
-			function simplifyMesh(geo, threshold, flags, solve, sloppy) {
+			function simplifyMesh(geo, threshold, flags, solve) {
 				var positions = solve ? new Float32Array(geo.attributes.position.array) : geo.attributes.position.array;
 				var indices = solve ? new Uint32Array(geo.index.array) : geo.index.array;
 
 				var res;
-				if (sloppy) {
-					res = MeshoptSimplifier.simplifySloppy(indices, positions, 3, null, 0, threshold);
-				} else if (solve) {
+				if (solve) {
 					res = MeshoptSimplifier.simplifyWithUpdate(indices, positions, 3, new Float32Array(), 0, [], null, 0, threshold, flags);
 					res[0] = indices.slice(0, res[0]);
 				} else {
@@ -648,25 +399,20 @@
 
 					clearRemeshed();
 
-					var geometry;
-					if (settings.sloppy) {
-						geometry = simplifyMesh(merged, 1 / settings.resolution, [], false, true);
-					} else {
-						var flags = [];
-						if (settings.thicken) flags.push('Thicken');
-						if (settings.shell) flags.push('Shell');
-						if (settings.solve) flags.push('Solve');
-						if (settings.debug) flags.push('_InternalDebug');
+					var flags = [];
+					if (settings.thicken) flags.push('Thicken');
+					if (settings.shell) flags.push('Shell');
+					if (settings.solve) flags.push('Solve');
+					if (settings.debug) flags.push('_InternalDebug');
 
-						var result = MeshoptSimplifier.remesh(merged.index.array, merged.attributes.position.array, 3, settings.resolution, flags);
-						geometry = new THREE.BufferGeometry();
-						geometry.setAttribute('position', new THREE.BufferAttribute(result, 3));
-						geometry = mergeVertices(geometry);
-					}
+					var result = MeshoptSimplifier.remesh(merged.index.array, merged.attributes.position.array, 3, settings.resolution, flags);
+					var geometry = new THREE.BufferGeometry();
+					geometry.setAttribute('position', new THREE.BufferAttribute(result, 3));
+					geometry = mergeVertices(geometry);
 
 					if (settings.simplify.enabled) {
-						var flags = settings.simplify.regularize ? ['RegularizeLight'] : [];
-						geometry = simplifyMesh(geometry, Math.pow(10, -settings.simplify.errorThresholdLog10), flags, settings.simplify.solve);
+						var sflags = settings.simplify.regularize ? ['RegularizeLight'] : [];
+						geometry = simplifyMesh(geometry, Math.pow(10, -settings.simplify.errorThresholdLog10), sflags, settings.simplify.solve);
 					}
 
 					geometry = mergeVertices(toCreasedNormals(geometry, THREE.MathUtils.degToRad(settings.debug ? 30 : settings.normalCrease)));
@@ -674,25 +420,21 @@
 					remeshMaterial.vertexColors = false;
 
 					if (settings.paint.mode == 'vertex') {
-						if (settings.paint.gpu) repaint.transferColors(renderer, geometry, merged.bvh, merged.thickness, merged.materials);
-						else transferColors(merged, geometry);
-
+						repaint.transferColors(renderer, geometry, merged.bvh, merged.thickness, merged.materials);
 						remeshMaterial.vertexColors = true;
 						remeshMaterial.color.set(0xffffff);
 					} else if (settings.paint.mode == 'texture') {
 						geometry = unwrapMesh(geometry, settings.paint.resolution, settings.paint.gutter);
 						remeshMaterial.color.set(0xffffff);
-						remeshMaterial.map = settings.paint.gpu
-							? repaint.transferTexture(
-									renderer,
-									geometry,
-									merged.bvh,
-									merged.thickness,
-									merged.materials,
-									settings.paint.resolution,
-									settings.paint.gutter
-								)
-							: transferTexture(merged, geometry, settings.paint.resolution, settings.paint.gutter);
+						remeshMaterial.map = repaint.transferTexture(
+							renderer,
+							geometry,
+							merged.bvh,
+							merged.thickness,
+							merged.materials,
+							settings.paint.resolution,
+							settings.paint.gutter
+						);
 					} else {
 						remeshMaterial.color.set(0xdddddd);
 					}

--- a/demo/repaint.js
+++ b/demo/repaint.js
@@ -244,7 +244,7 @@ function createMaterialTexture(materials, layers) {
 	return texture;
 }
 
-var bakeMaterial = new THREE.ShaderMaterial({
+var bakeShader = new THREE.ShaderMaterial({
 	glslVersion: THREE.GLSL3,
 	uniforms: {
 		bvh: { value: null },
@@ -256,7 +256,8 @@ var bakeMaterial = new THREE.ShaderMaterial({
 		materials: { value: null },
 		textures: { value: null },
 		thickness: { value: 0 },
-		bakeNormal: { value: 0 },
+		bakeNormals: { value: 0 },
+		bakeMaterial: { value: 0 },
 	},
 	vertexShader: `
 attribute vec4 tangent;
@@ -293,7 +294,8 @@ uniform usampler2D attrMaterial;
 uniform sampler2D materials;
 uniform sampler2DArray textures;
 uniform float thickness;
-uniform float bakeNormal;
+uniform float bakeNormals;
+uniform float bakeMaterial;
 
 vec3 fromsrgb(vec3 c) {
 	return pow(c, vec3(2.2));
@@ -309,6 +311,7 @@ varying vec4 vTangent;
 
 layout(location = 0) out vec4 outColor;
 layout(location = 1) out vec4 outNormal;
+layout(location = 2) out vec4 outMaterial;
 
 void main() {
 	vec3 normal = normalize(vNormal);
@@ -357,8 +360,8 @@ void main() {
 	if (md1.w >= 0.0) roughness *= texture(textures, vec3(point, md1.w)).g;
 	if (md2.x >= 0.0) metalness *= texture(textures, vec3(point, md2.x)).b;
 
-	// for now, bake metalness/roughness into color as an approximation
-	color *= 1.0 - metalness * (1.0 - roughness * roughness * roughness);
+	// approximate metalness/roughness impact when material is not baked
+	if (bakeMaterial < 0.5) color *= 1.0 - metalness * (1.0 - roughness * roughness * roughness);
 
 	vec3 emissive = md4.rgb;
 	if (md1.z >= 0.0) emissive *= fromsrgb(texture(textures, vec3(point, md1.z)).rgb);
@@ -366,8 +369,9 @@ void main() {
 
 	outColor = vec4(tosrgb(color), 1.0);
 	outNormal = vec4(0.0);
+	outMaterial = vec4(0.0, roughness, metalness, 1.0);
 
-	if (bakeNormal > 0.5) {
+	if (bakeNormals > 0.5) {
 		vec3 snormal = textureSampleBarycoord(attrNormal, bary, face.xyz).xyz;
 
 		if (md2.y >= 0.0) {
@@ -393,17 +397,18 @@ void main() {
 	side: THREE.DoubleSide,
 });
 
-function bindCache(cache, thickness, normals) {
-	bakeMaterial.uniforms.bvh.value = cache.bvh;
-	bakeMaterial.uniforms.attrNormal.value = cache.attributes.normal;
-	bakeMaterial.uniforms.attrUv.value = cache.attributes.uv;
-	bakeMaterial.uniforms.attrColor.value = cache.attributes.color;
-	bakeMaterial.uniforms.attrTangent.value = cache.attributes.tangent;
-	bakeMaterial.uniforms.attrMaterial.value = cache.attributes.material;
-	bakeMaterial.uniforms.materials.value = cache.materials;
-	bakeMaterial.uniforms.textures.value = cache.textures;
-	bakeMaterial.uniforms.thickness.value = thickness;
-	bakeMaterial.uniforms.bakeNormal.value = normals ? 1 : 0;
+function bindCache(cache, thickness, bakeNormals, bakeMaterial) {
+	bakeShader.uniforms.bvh.value = cache.bvh;
+	bakeShader.uniforms.attrNormal.value = cache.attributes.normal;
+	bakeShader.uniforms.attrUv.value = cache.attributes.uv;
+	bakeShader.uniforms.attrColor.value = cache.attributes.color;
+	bakeShader.uniforms.attrTangent.value = cache.attributes.tangent;
+	bakeShader.uniforms.attrMaterial.value = cache.attributes.material;
+	bakeShader.uniforms.materials.value = cache.materials;
+	bakeShader.uniforms.textures.value = cache.textures;
+	bakeShader.uniforms.thickness.value = thickness;
+	bakeShader.uniforms.bakeNormals.value = bakeNormals ? 1 : 0;
+	bakeShader.uniforms.bakeMaterial.value = bakeMaterial ? 1 : 0;
 }
 
 function renderSamples(renderer, object, size, count) {
@@ -477,20 +482,22 @@ export function buildCache(bvh, materials) {
 	};
 }
 
-export function transferTexture(renderer, geometry, cache, thickness, size, gutter, normals) {
+export function transferTexture(renderer, geometry, cache, thickness, size, gutter, bakeNormals, bakeMaterial) {
 	var expanded = expandGeometry(geometry, size, gutter);
-	var mesh = new THREE.Mesh(expanded, bakeMaterial);
+	var mesh = new THREE.Mesh(expanded, bakeShader);
 	mesh.frustumCulled = false;
 
-	bindCache(cache, thickness, normals);
+	bindCache(cache, thickness, bakeNormals, bakeMaterial);
 
-	var data = renderSamples(renderer, mesh, size, normals ? 2 : 1);
+	var targets = bakeMaterial ? 3 : bakeNormals ? 2 : 1;
+	var data = renderSamples(renderer, mesh, size, targets);
 
 	expanded.dispose();
 
 	return {
 		map: createTexture(data[0], size, true),
-		normalMap: normals ? createTexture(data[1], size, false) : null,
+		normalMap: bakeNormals ? createTexture(data[1], size, false) : null,
+		materialMap: bakeMaterial ? createTexture(data[2], size, false) : null,
 	};
 }
 
@@ -500,10 +507,10 @@ export function transferColors(renderer, geometry, cache, thickness) {
 	var size = Math.ceil(Math.sqrt(vertices + triangles));
 
 	var samples = sampleGeometry(geometry, size);
-	var points = new THREE.Points(samples, bakeMaterial);
+	var points = new THREE.Points(samples, bakeShader);
 	points.frustumCulled = false;
 
-	bindCache(cache, thickness, false);
+	bindCache(cache, thickness, false, false);
 
 	var data = renderSamples(renderer, points, size, 1)[0];
 

--- a/demo/repaint.js
+++ b/demo/repaint.js
@@ -1,6 +1,9 @@
-// GPU texture transfer for remeshing demo
+// GPU color/texture transfer for remeshing demo
 //
 // Remeshed atlas is rasterized in UV space, the triangle edges are expanded to cover extra gutter space.
+// The fragment shader traces rays against the original mesh (falling back to closest point on miss).
+// The results are shaded using a simplified version of the original material, and written to the output texture.
+// When painting vertex colors, we directly rasterize points for target vertex/triangles and trace rays/eval materials as above.
 import * as THREE from 'three';
 import { BVHShaderGLSL, MeshBVHUniformStruct, FloatVertexAttributeTexture, UIntVertexAttributeTexture } from 'three-mesh-bvh';
 
@@ -59,6 +62,82 @@ function expandGeometry(geometry, size, gutter) {
 	result.setAttribute('normal', new THREE.BufferAttribute(normals, 3));
 	result.setAttribute('uv', new THREE.BufferAttribute(uvs, 2));
 	return result;
+}
+
+function sampleGeometry(geometry, size) {
+	var position = geometry.attributes.position;
+	var normal = geometry.attributes.normal;
+	var indices = geometry.index.array;
+
+	var vertices = position.count;
+	var triangles = indices.length / 3;
+	var samples = vertices + triangles; // one sample per vertex plus one sample per triangle centroid
+
+	var positions = new Float32Array(samples * 3);
+	var normals = new Float32Array(samples * 3);
+	var uvs = new Float32Array(samples * 2);
+
+	for (var i = 0; i < vertices; ++i) {
+		for (var k = 0; k < 3; ++k) {
+			positions[i * 3 + k] = position.getComponent(i, k);
+			normals[i * 3 + k] = normal.getComponent(i, k);
+		}
+	}
+
+	for (var i = 0; i < triangles; ++i) {
+		var a = indices[i * 3 + 0],
+			b = indices[i * 3 + 1],
+			c = indices[i * 3 + 2];
+
+		// normals will be normalized in the shader
+		for (var k = 0; k < 3; ++k) {
+			positions[(vertices + i) * 3 + k] = (position.getComponent(a, k) + position.getComponent(b, k) + position.getComponent(c, k)) / 3;
+			normals[(vertices + i) * 3 + k] = normal.getComponent(a, k) + normal.getComponent(b, k) + normal.getComponent(c, k);
+		}
+	}
+
+	for (var i = 0; i < samples; ++i) {
+		uvs[i * 2 + 0] = ((i % size) + 0.5) / size;
+		uvs[i * 2 + 1] = (Math.floor(i / size) + 0.5) / size;
+	}
+
+	var result = new THREE.BufferGeometry();
+	result.setAttribute('position', new THREE.BufferAttribute(positions, 3));
+	result.setAttribute('normal', new THREE.BufferAttribute(normals, 3));
+	result.setAttribute('uv', new THREE.BufferAttribute(uvs, 2));
+	return result;
+}
+
+function extractColors(data, colors, indices) {
+	var vertices = colors.length / 4;
+	var triangles = indices.length / 3;
+
+	for (var i = 0; i < vertices; ++i) {
+		if (data[i * 4 + 3] == 0) continue;
+
+		for (var k = 0; k < 3; ++k) colors[i * 4 + k] = Math.pow(data[i * 4 + k] / 255, 2.2);
+		colors[i * 4 + 3] = 1;
+	}
+
+	for (var i = 0; i < triangles; ++i) {
+		var offset = (vertices + i) * 4;
+		if (data[offset + 3] == 0) continue;
+
+		for (var j = 0; j < 3; ++j) {
+			var v = indices[i * 3 + j];
+
+			for (var k = 0; k < 3; ++k) colors[v * 4 + k] += Math.pow(data[offset + k] / 255, 2.2);
+			colors[v * 4 + 3]++;
+		}
+	}
+
+	for (var i = 0; i < colors.length; i += 4) {
+		var weight = colors[i + 3];
+		if (weight == 0) continue;
+
+		for (var k = 0; k < 3; ++k) colors[i + k] /= weight;
+		colors[i + 3] = 1;
+	}
 }
 
 var MAP_SIZE = 1024;
@@ -174,6 +253,7 @@ void main() {
 	vNormal = normal;
 
 	gl_Position = vec4(uv * 2.0 - 1.0, 0.0, 1.0);
+	gl_PointSize = 1.0; // for vertex colors
 }
 `,
 	fragmentShader: `
@@ -268,9 +348,7 @@ void main() {
 	side: THREE.DoubleSide,
 });
 
-export function transferTexture(renderer, geometry, bvh, thickness, materials, size, gutter) {
-	var expanded = expandGeometry(geometry, size, gutter);
-
+function bindSource(bvh, thickness, materials) {
 	var bvhgpu = new MeshBVHUniformStruct();
 	bvhgpu.updateFrom(bvh);
 
@@ -297,9 +375,10 @@ export function transferTexture(renderer, geometry, bvh, thickness, materials, s
 	bakeMaterial.uniforms.textures.value = textures.array;
 	bakeMaterial.uniforms.thickness.value = thickness;
 
-	var mesh = new THREE.Mesh(expanded, bakeMaterial);
-	mesh.frustumCulled = false;
+	return [bvhgpu, attrNormal, attrUv, attrColor, attrMaterial, materialsgpu, textures.array];
+}
 
+function renderSamples(renderer, object, size) {
 	var target = new THREE.WebGLRenderTarget(size, size, {
 		minFilter: THREE.NearestFilter,
 		magFilter: THREE.NearestFilter,
@@ -309,28 +388,56 @@ export function transferTexture(renderer, geometry, bvh, thickness, materials, s
 
 	renderer.setClearColor(0x000000, 0);
 	renderer.setRenderTarget(target);
-	renderer.render(mesh, new THREE.OrthographicCamera());
+	renderer.render(object, new THREE.OrthographicCamera());
 
 	renderer.setRenderTarget(null);
 
-	// copy render target to DataTexture; this is redundant for display but we need this for GLB export to function
 	var data = new Uint8Array(size * size * 4);
 	renderer.readRenderTargetPixels(target, 0, 0, size, size, data);
 
-	expanded.dispose();
 	target.dispose();
-	bvhgpu.dispose();
-	attrNormal.dispose();
-	attrUv.dispose();
-	attrColor.dispose();
-	attrMaterial.dispose();
-	materialsgpu.dispose();
-	textures.array.dispose();
+	return data;
+}
 
+export function transferTexture(renderer, geometry, bvh, thickness, materials, size, gutter) {
+	var expanded = expandGeometry(geometry, size, gutter);
+	var resources = bindSource(bvh, thickness, materials);
+
+	var mesh = new THREE.Mesh(expanded, bakeMaterial);
+	mesh.frustumCulled = false;
+
+	var data = renderSamples(renderer, mesh, size);
+
+	expanded.dispose();
+	for (var i = 0; i < resources.length; ++i) resources[i].dispose();
+
+	// data comes from render texture, but we need it as DataTexture to be compatible with canvas/GLB export
 	var texture = new THREE.DataTexture(data, size, size, THREE.RGBAFormat);
 	texture.colorSpace = THREE.SRGBColorSpace;
 	texture.magFilter = THREE.LinearFilter;
 	texture.minFilter = THREE.LinearFilter;
 	texture.needsUpdate = true;
 	return texture;
+}
+
+export function transferColors(renderer, geometry, bvh, thickness, materials) {
+	var vertices = geometry.attributes.position.count;
+	var triangles = geometry.index.array.length / 3;
+	var size = Math.ceil(Math.sqrt(vertices + triangles));
+
+	var samples = sampleGeometry(geometry, size);
+	var resources = bindSource(bvh, thickness, materials);
+
+	var points = new THREE.Points(samples, bakeMaterial);
+	points.frustumCulled = false;
+
+	var data = renderSamples(renderer, points, size);
+
+	samples.dispose();
+	for (var i = 0; i < resources.length; ++i) resources[i].dispose();
+
+	var colors = new Float32Array(vertices * 4);
+	extractColors(data, colors, geometry.index.array);
+
+	geometry.setAttribute('color', new THREE.BufferAttribute(colors, 4));
 }

--- a/demo/repaint.js
+++ b/demo/repaint.js
@@ -348,34 +348,15 @@ void main() {
 	side: THREE.DoubleSide,
 });
 
-function bindSource(bvh, thickness, materials) {
-	var bvhgpu = new MeshBVHUniformStruct();
-	bvhgpu.updateFrom(bvh);
-
-	var attributes = bvh.geometry.attributes;
-	var attrNormal = new FloatVertexAttributeTexture();
-	var attrUv = new FloatVertexAttributeTexture();
-	var attrColor = new FloatVertexAttributeTexture();
-	var attrMaterial = new UIntVertexAttributeTexture();
-
-	attrNormal.updateFrom(attributes.normal);
-	attrUv.updateFrom(attributes.uv);
-	attrColor.updateFrom(attributes.color);
-	attrMaterial.updateFrom(attributes.material);
-
-	var textures = createTextureArray(materials);
-	var materialsgpu = createMaterialTexture(materials, textures.layers);
-
-	bakeMaterial.uniforms.bvh.value = bvhgpu;
-	bakeMaterial.uniforms.attrNormal.value = attrNormal;
-	bakeMaterial.uniforms.attrUv.value = attrUv;
-	bakeMaterial.uniforms.attrColor.value = attrColor;
-	bakeMaterial.uniforms.attrMaterial.value = attrMaterial;
-	bakeMaterial.uniforms.materials.value = materialsgpu;
-	bakeMaterial.uniforms.textures.value = textures.array;
+function bindCache(cache, thickness) {
+	bakeMaterial.uniforms.bvh.value = cache.bvh;
+	bakeMaterial.uniforms.attrNormal.value = cache.attributes.normal;
+	bakeMaterial.uniforms.attrUv.value = cache.attributes.uv;
+	bakeMaterial.uniforms.attrColor.value = cache.attributes.color;
+	bakeMaterial.uniforms.attrMaterial.value = cache.attributes.material;
+	bakeMaterial.uniforms.materials.value = cache.materials;
+	bakeMaterial.uniforms.textures.value = cache.textures;
 	bakeMaterial.uniforms.thickness.value = thickness;
-
-	return [bvhgpu, attrNormal, attrUv, attrColor, attrMaterial, materialsgpu, textures.array];
 }
 
 function renderSamples(renderer, object, size) {
@@ -399,17 +380,50 @@ function renderSamples(renderer, object, size) {
 	return data;
 }
 
-export function transferTexture(renderer, geometry, bvh, thickness, materials, size, gutter) {
-	var expanded = expandGeometry(geometry, size, gutter);
-	var resources = bindSource(bvh, thickness, materials);
+export function buildCache(bvh, materials) {
+	var bvhgpu = new MeshBVHUniformStruct();
+	var attrgpu = {
+		normal: new FloatVertexAttributeTexture(),
+		uv: new FloatVertexAttributeTexture(),
+		color: new FloatVertexAttributeTexture(),
+		material: new UIntVertexAttributeTexture(),
+	};
 
+	bvhgpu.updateFrom(bvh);
+	attrgpu.normal.updateFrom(bvh.geometry.attributes.normal);
+	attrgpu.uv.updateFrom(bvh.geometry.attributes.uv);
+	attrgpu.color.updateFrom(bvh.geometry.attributes.color);
+	attrgpu.material.updateFrom(bvh.geometry.attributes.material);
+
+	var textures = createTextureArray(materials);
+	var matgpu = createMaterialTexture(materials, textures.layers);
+
+	return {
+		bvh: bvhgpu,
+		attributes: attrgpu,
+		materials: matgpu,
+		textures: textures.array,
+
+		dispose: function () {
+			this.bvh.dispose();
+			this.materials.dispose();
+			this.textures.dispose();
+
+			for (var k in this.attributes) this.attributes[k].dispose();
+		},
+	};
+}
+
+export function transferTexture(renderer, geometry, cache, thickness, size, gutter) {
+	var expanded = expandGeometry(geometry, size, gutter);
 	var mesh = new THREE.Mesh(expanded, bakeMaterial);
 	mesh.frustumCulled = false;
+
+	bindCache(cache, thickness);
 
 	var data = renderSamples(renderer, mesh, size);
 
 	expanded.dispose();
-	for (var i = 0; i < resources.length; ++i) resources[i].dispose();
 
 	// data comes from render texture, but we need it as DataTexture to be compatible with canvas/GLB export
 	var texture = new THREE.DataTexture(data, size, size, THREE.RGBAFormat);
@@ -420,21 +434,20 @@ export function transferTexture(renderer, geometry, bvh, thickness, materials, s
 	return texture;
 }
 
-export function transferColors(renderer, geometry, bvh, thickness, materials) {
+export function transferColors(renderer, geometry, cache, thickness) {
 	var vertices = geometry.attributes.position.count;
 	var triangles = geometry.index.array.length / 3;
 	var size = Math.ceil(Math.sqrt(vertices + triangles));
 
 	var samples = sampleGeometry(geometry, size);
-	var resources = bindSource(bvh, thickness, materials);
-
 	var points = new THREE.Points(samples, bakeMaterial);
 	points.frustumCulled = false;
+
+	bindCache(cache, thickness);
 
 	var data = renderSamples(renderer, points, size);
 
 	samples.dispose();
-	for (var i = 0; i < resources.length; ++i) resources[i].dispose();
 
 	var colors = new Float32Array(vertices * 4);
 	extractColors(data, colors, geometry.index.array);

--- a/demo/repaint.js
+++ b/demo/repaint.js
@@ -6,7 +6,7 @@
 // Texels that were not rasterized are infilled afterwards using the mips of the resulting texture.
 // When painting vertex colors, we directly rasterize points for target vertex/triangles and trace rays/eval materials as above.
 import * as THREE from 'three';
-import { BVHShaderGLSL, MeshBVHUniformStruct, FloatVertexAttributeTexture, UIntVertexAttributeTexture } from 'three-mesh-bvh';
+import { MeshBVH, BVHShaderGLSL, MeshBVHUniformStruct, FloatVertexAttributeTexture, UIntVertexAttributeTexture } from 'three-mesh-bvh';
 
 function expandGeometry(geometry, size, gutter) {
 	var position = geometry.attributes.position;
@@ -499,7 +499,9 @@ function createTexture(data, size, srgb) {
 	return texture;
 }
 
-export function buildCache(bvh, materials) {
+export function buildCache(geometry, materials) {
+	var bvh = new MeshBVH(geometry, { indirect: true });
+
 	var bvhgpu = new MeshBVHUniformStruct();
 	var attrgpu = {
 		normal: new FloatVertexAttributeTexture(),
@@ -510,11 +512,11 @@ export function buildCache(bvh, materials) {
 	};
 
 	bvhgpu.updateFrom(bvh);
-	attrgpu.normal.updateFrom(bvh.geometry.attributes.normal);
-	attrgpu.uv.updateFrom(bvh.geometry.attributes.uv);
-	attrgpu.color.updateFrom(bvh.geometry.attributes.color);
-	attrgpu.tangent.updateFrom(bvh.geometry.attributes.tangent);
-	attrgpu.material.updateFrom(bvh.geometry.attributes.material);
+	attrgpu.normal.updateFrom(geometry.attributes.normal);
+	attrgpu.uv.updateFrom(geometry.attributes.uv);
+	attrgpu.color.updateFrom(geometry.attributes.color);
+	attrgpu.tangent.updateFrom(geometry.attributes.tangent);
+	attrgpu.material.updateFrom(geometry.attributes.material);
 
 	var textures = createTextureArray(materials);
 	var matgpu = createMaterialTexture(materials, textures.layers);

--- a/demo/repaint.js
+++ b/demo/repaint.js
@@ -3,6 +3,7 @@
 // Remeshed atlas is rasterized in UV space, the triangle edges are expanded to cover extra gutter space.
 // The fragment shader traces rays against the original mesh (falling back to closest point on miss).
 // The results are shaded using a simplified version of the original material, and written to the output texture.
+// Texels that were not rasterized are infilled afterwards using the mips of the resulting texture.
 // When painting vertex colors, we directly rasterize points for target vertex/triangles and trace rays/eval materials as above.
 import * as THREE from 'three';
 import { BVHShaderGLSL, MeshBVHUniformStruct, FloatVertexAttributeTexture, UIntVertexAttributeTexture } from 'three-mesh-bvh';
@@ -399,6 +400,37 @@ void main() {
 	side: THREE.DoubleSide,
 });
 
+var infillShader = new THREE.ShaderMaterial({
+	glslVersion: THREE.GLSL3,
+	uniforms: {
+		map: { value: null },
+	},
+	vertexShader: `
+void main() {
+	gl_Position = vec4(vec2(gl_VertexID & 1, gl_VertexID >> 1) * 4.0 - 1.0, 0.0, 1.0);
+}
+`,
+	fragmentShader: `
+uniform sampler2D map;
+
+layout(location = 0) out vec4 result;
+
+void main() {
+	ivec2 p = ivec2(gl_FragCoord.xy);
+	vec2 uv = (vec2(p) + 0.5) / vec2(textureSize(map, 0));
+
+	// use first texel with non-zero alpha as fallback
+	vec4 c = texelFetch(map, p, 0);
+	for (int l = 1; l <= 10 && c.a < 1e-4; ++l) c = textureLod(map, uv, float(l));
+
+	// filtering results in premultiplied value that we need to unpremultiply
+	result = vec4(c.rgb / max(c.a, 1e-4), 1.0);
+}
+`,
+	depthTest: false,
+	depthWrite: false,
+});
+
 function bindCache(cache, thickness, bakeNormals, bakeMaterial) {
 	bakeShader.uniforms.bvh.value = cache.bvh;
 	bakeShader.uniforms.attrNormal.value = cache.attributes.normal;
@@ -413,28 +445,47 @@ function bindCache(cache, thickness, bakeNormals, bakeMaterial) {
 	bakeShader.uniforms.bakeMaterial.value = bakeMaterial ? 1 : 0;
 }
 
-function renderSamples(renderer, object, size, count) {
+function renderSamples(renderer, object, size, count, infill) {
 	var target = new THREE.WebGLRenderTarget(size, size, {
 		count: count,
-		minFilter: THREE.NearestFilter,
-		magFilter: THREE.NearestFilter,
+		minFilter: THREE.LinearMipmapNearestFilter, // we use linear filtering with explicit lod for infill
 		depthBuffer: false,
-		generateMipmaps: false,
+		generateMipmaps: infill,
 	});
+
+	var infilled = [];
+	for (var i = 0; infill && i < count; ++i) {
+		infilled.push(new THREE.WebGLRenderTarget(size, size, { depthBuffer: false }));
+	}
 
 	renderer.setClearColor(0x000000, 0);
 	renderer.setRenderTarget(target);
 	renderer.render(object, new THREE.OrthographicCamera());
+
+	if (infill) {
+		var infillQuad = new THREE.Mesh(new THREE.BufferGeometry(), infillShader);
+		infillQuad.geometry.setDrawRange(0, 3);
+		infillQuad.frustumCulled = false;
+
+		for (var i = 0; i < count; ++i) {
+			infillShader.uniforms.map.value = target.textures[i];
+
+			renderer.setRenderTarget(infilled[i]);
+			renderer.render(infillQuad, new THREE.OrthographicCamera());
+		}
+	}
 
 	renderer.setRenderTarget(null);
 
 	var data = [];
 	for (var i = 0; i < count; ++i) {
 		data.push(new Uint8Array(size * size * 4));
-		renderer.readRenderTargetPixels(target, 0, 0, size, size, data[i], undefined, i);
+		renderer.readRenderTargetPixels(infill ? infilled[i] : target, 0, 0, size, size, data[i], undefined, infill ? 0 : i);
 	}
 
 	target.dispose();
+	for (var i = 0; i < infilled.length; ++i) infilled[i].dispose();
+
 	return data;
 }
 
@@ -484,7 +535,7 @@ export function buildCache(bvh, materials) {
 	};
 }
 
-export function transferTexture(renderer, geometry, cache, thickness, size, gutter, bakeNormals, bakeMaterial) {
+export function transferTexture(renderer, geometry, cache, thickness, size, gutter, infill, bakeNormals, bakeMaterial) {
 	var expanded = expandGeometry(geometry, size, gutter);
 	var mesh = new THREE.Mesh(expanded, bakeShader);
 	mesh.frustumCulled = false;
@@ -492,7 +543,7 @@ export function transferTexture(renderer, geometry, cache, thickness, size, gutt
 	bindCache(cache, thickness, bakeNormals, bakeMaterial);
 
 	var targets = bakeMaterial ? 3 : bakeNormals ? 2 : 1;
-	var data = renderSamples(renderer, mesh, size, targets);
+	var data = renderSamples(renderer, mesh, size, targets, infill);
 
 	expanded.dispose();
 

--- a/demo/repaint.js
+++ b/demo/repaint.js
@@ -10,12 +10,14 @@ import { BVHShaderGLSL, MeshBVHUniformStruct, FloatVertexAttributeTexture, UIntV
 function expandGeometry(geometry, size, gutter) {
 	var position = geometry.attributes.position;
 	var normal = geometry.attributes.normal;
+	var tangent = geometry.attributes.tangent;
 	var uv = geometry.attributes.uv;
 	var indices = geometry.index.array;
 
 	var count = indices.length;
 	var positions = new Float32Array(count * 3);
 	var normals = new Float32Array(count * 3);
+	var tangents = tangent ? new Float32Array(count * 4) : null;
 	var uvs = new Float32Array(count * 2);
 
 	for (var i = 0; i < count; i += 3) {
@@ -52,6 +54,14 @@ function expandGeometry(geometry, size, gutter) {
 			normals[v * 3 + 1] = normal.getY(a) * w0 + normal.getY(b) * w1 + normal.getY(c) * w2;
 			normals[v * 3 + 2] = normal.getZ(a) * w0 + normal.getZ(b) * w1 + normal.getZ(c) * w2;
 
+			if (tangent) {
+				// tangents are only used when normal maps are baked
+				tangents[v * 4 + 0] = tangent.getX(a) * w0 + tangent.getX(b) * w1 + tangent.getX(c) * w2;
+				tangents[v * 4 + 1] = tangent.getY(a) * w0 + tangent.getY(b) * w1 + tangent.getY(c) * w2;
+				tangents[v * 4 + 2] = tangent.getZ(a) * w0 + tangent.getZ(b) * w1 + tangent.getZ(c) * w2;
+				tangents[v * 4 + 3] = tangent.getW(a) * w0 + tangent.getW(b) * w1 + tangent.getW(c) * w2;
+			}
+
 			uvs[v * 2 + 0] = (x0 * w0 + x1 * w1 + x2 * w2) / size;
 			uvs[v * 2 + 1] = (y0 * w0 + y1 * w1 + y2 * w2) / size;
 		}
@@ -61,6 +71,7 @@ function expandGeometry(geometry, size, gutter) {
 	result.setAttribute('position', new THREE.BufferAttribute(positions, 3));
 	result.setAttribute('normal', new THREE.BufferAttribute(normals, 3));
 	result.setAttribute('uv', new THREE.BufferAttribute(uvs, 2));
+	if (tangent) result.setAttribute('tangent', new THREE.BufferAttribute(tangents, 4));
 	return result;
 }
 
@@ -142,7 +153,7 @@ function extractColors(data, colors, indices) {
 
 var MAP_SIZE = 1024;
 var MAP_BUDGET = 1 << 30;
-var MAP_SLOTS = ['map', 'aoMap', 'emissiveMap', 'roughnessMap', 'metalnessMap'];
+var MAP_SLOTS = ['map', 'aoMap', 'emissiveMap', 'roughnessMap', 'metalnessMap', 'normalMap'];
 
 function createTextureArray(materials) {
 	var textures = [];
@@ -234,23 +245,30 @@ function createMaterialTexture(materials, layers) {
 }
 
 var bakeMaterial = new THREE.ShaderMaterial({
+	glslVersion: THREE.GLSL3,
 	uniforms: {
 		bvh: { value: null },
 		attrNormal: { value: null },
 		attrUv: { value: null },
 		attrColor: { value: null },
+		attrTangent: { value: null },
 		attrMaterial: { value: null },
 		materials: { value: null },
 		textures: { value: null },
 		thickness: { value: 0 },
+		bakeNormal: { value: 0 },
 	},
 	vertexShader: `
+attribute vec4 tangent;
+
 varying vec3 vPosition;
 varying vec3 vNormal;
+varying vec4 vTangent;
 
 void main() {
 	vPosition = position;
 	vNormal = normal;
+	vTangent = tangent;
 
 	gl_Position = vec4(uv * 2.0 - 1.0, 0.0, 1.0);
 	gl_PointSize = 1.0; // for vertex colors
@@ -270,10 +288,12 @@ uniform BVH bvh;
 uniform sampler2D attrNormal;
 uniform sampler2D attrUv;
 uniform sampler2D attrColor;
+uniform sampler2D attrTangent;
 uniform usampler2D attrMaterial;
 uniform sampler2D materials;
 uniform sampler2DArray textures;
 uniform float thickness;
+uniform float bakeNormal;
 
 vec3 fromsrgb(vec3 c) {
 	return pow(c, vec3(2.2));
@@ -285,6 +305,10 @@ vec3 tosrgb(vec3 c) {
 
 varying vec3 vPosition;
 varying vec3 vNormal;
+varying vec4 vTangent;
+
+layout(location = 0) out vec4 outColor;
+layout(location = 1) out vec4 outNormal;
 
 void main() {
 	vec3 normal = normalize(vNormal);
@@ -313,7 +337,7 @@ void main() {
 	vec4 md4 = texelFetch(materials, ivec2(4, mati), 0);
 	vec4 md5 = texelFetch(materials, ivec2(5, mati), 0);
 
-	// md0: uv transform, md1.xyzw + md2.x: layer indices in MAP_SLOTS order,
+	// md0: uv transform, md1.xyzw + md2.xy: layer indices in MAP_SLOTS order,
 	// md3: base color + ao intensity, md4: emissive color + roughness, md5.x: metalness
 	vec2 point = uv * md0.xy + md0.zw;
 
@@ -340,7 +364,28 @@ void main() {
 	if (md1.z >= 0.0) emissive *= fromsrgb(texture(textures, vec3(point, md1.z)).rgb);
 	color += emissive;
 
-	gl_FragColor = vec4(tosrgb(color), 1.0);
+	outColor = vec4(tosrgb(color), 1.0);
+	outNormal = vec4(0.0);
+
+	if (bakeNormal > 0.5) {
+		vec3 snormal = textureSampleBarycoord(attrNormal, bary, face.xyz).xyz;
+
+		if (md2.y >= 0.0) {
+			vec4 stangent = textureSampleBarycoord(attrTangent, bary, face.xyz);
+			vec3 bitangent = cross(snormal, stangent.xyz) * (stangent.w < 0.0 ? -1.0 : 1.0);
+			vec3 nmap = texture(textures, vec3(point, md2.y)).xyz * 2.0 - 1.0;
+
+			// replace source (smooth) normal with perturbed normal
+			snormal = stangent.xyz * nmap.x + bitangent * nmap.y + snormal * nmap.z;
+		}
+
+		vec3 axisN = normal;
+		vec3 axisT = vTangent.xyz - axisN * dot(axisN, vTangent.xyz);
+		vec3 axisB = cross(axisN, axisT) * (vTangent.w < 0.0 ? -1.0 : 1.0);
+
+		vec3 tbn = vec3(dot(snormal, axisT), dot(snormal, axisB), dot(snormal, axisN));
+		outNormal = vec4(normalize(tbn) * 0.5 + 0.5, 1.0);
+	}
 }
 `,
 	depthTest: false,
@@ -348,19 +393,22 @@ void main() {
 	side: THREE.DoubleSide,
 });
 
-function bindCache(cache, thickness) {
+function bindCache(cache, thickness, normals) {
 	bakeMaterial.uniforms.bvh.value = cache.bvh;
 	bakeMaterial.uniforms.attrNormal.value = cache.attributes.normal;
 	bakeMaterial.uniforms.attrUv.value = cache.attributes.uv;
 	bakeMaterial.uniforms.attrColor.value = cache.attributes.color;
+	bakeMaterial.uniforms.attrTangent.value = cache.attributes.tangent;
 	bakeMaterial.uniforms.attrMaterial.value = cache.attributes.material;
 	bakeMaterial.uniforms.materials.value = cache.materials;
 	bakeMaterial.uniforms.textures.value = cache.textures;
 	bakeMaterial.uniforms.thickness.value = thickness;
+	bakeMaterial.uniforms.bakeNormal.value = normals ? 1 : 0;
 }
 
-function renderSamples(renderer, object, size) {
+function renderSamples(renderer, object, size, count) {
 	var target = new THREE.WebGLRenderTarget(size, size, {
+		count: count,
 		minFilter: THREE.NearestFilter,
 		magFilter: THREE.NearestFilter,
 		depthBuffer: false,
@@ -373,11 +421,24 @@ function renderSamples(renderer, object, size) {
 
 	renderer.setRenderTarget(null);
 
-	var data = new Uint8Array(size * size * 4);
-	renderer.readRenderTargetPixels(target, 0, 0, size, size, data);
+	var data = [];
+	for (var i = 0; i < count; ++i) {
+		data.push(new Uint8Array(size * size * 4));
+		renderer.readRenderTargetPixels(target, 0, 0, size, size, data[i], undefined, i);
+	}
 
 	target.dispose();
 	return data;
+}
+
+// data comes from render texture, but we need it as DataTexture to be compatible with canvas/GLB export
+function createTexture(data, size, srgb) {
+	var texture = new THREE.DataTexture(data, size, size, THREE.RGBAFormat);
+	if (srgb) texture.colorSpace = THREE.SRGBColorSpace;
+	texture.magFilter = THREE.LinearFilter;
+	texture.minFilter = THREE.LinearFilter;
+	texture.needsUpdate = true;
+	return texture;
 }
 
 export function buildCache(bvh, materials) {
@@ -386,6 +447,7 @@ export function buildCache(bvh, materials) {
 		normal: new FloatVertexAttributeTexture(),
 		uv: new FloatVertexAttributeTexture(),
 		color: new FloatVertexAttributeTexture(),
+		tangent: new FloatVertexAttributeTexture(),
 		material: new UIntVertexAttributeTexture(),
 	};
 
@@ -393,6 +455,7 @@ export function buildCache(bvh, materials) {
 	attrgpu.normal.updateFrom(bvh.geometry.attributes.normal);
 	attrgpu.uv.updateFrom(bvh.geometry.attributes.uv);
 	attrgpu.color.updateFrom(bvh.geometry.attributes.color);
+	attrgpu.tangent.updateFrom(bvh.geometry.attributes.tangent);
 	attrgpu.material.updateFrom(bvh.geometry.attributes.material);
 
 	var textures = createTextureArray(materials);
@@ -414,24 +477,21 @@ export function buildCache(bvh, materials) {
 	};
 }
 
-export function transferTexture(renderer, geometry, cache, thickness, size, gutter) {
+export function transferTexture(renderer, geometry, cache, thickness, size, gutter, normals) {
 	var expanded = expandGeometry(geometry, size, gutter);
 	var mesh = new THREE.Mesh(expanded, bakeMaterial);
 	mesh.frustumCulled = false;
 
-	bindCache(cache, thickness);
+	bindCache(cache, thickness, normals);
 
-	var data = renderSamples(renderer, mesh, size);
+	var data = renderSamples(renderer, mesh, size, normals ? 2 : 1);
 
 	expanded.dispose();
 
-	// data comes from render texture, but we need it as DataTexture to be compatible with canvas/GLB export
-	var texture = new THREE.DataTexture(data, size, size, THREE.RGBAFormat);
-	texture.colorSpace = THREE.SRGBColorSpace;
-	texture.magFilter = THREE.LinearFilter;
-	texture.minFilter = THREE.LinearFilter;
-	texture.needsUpdate = true;
-	return texture;
+	return {
+		map: createTexture(data[0], size, true),
+		normalMap: normals ? createTexture(data[1], size, false) : null,
+	};
 }
 
 export function transferColors(renderer, geometry, cache, thickness) {
@@ -443,9 +503,9 @@ export function transferColors(renderer, geometry, cache, thickness) {
 	var points = new THREE.Points(samples, bakeMaterial);
 	points.frustumCulled = false;
 
-	bindCache(cache, thickness);
+	bindCache(cache, thickness, false);
 
-	var data = renderSamples(renderer, points, size);
+	var data = renderSamples(renderer, points, size, 1)[0];
 
 	samples.dispose();
 

--- a/demo/repaint.js
+++ b/demo/repaint.js
@@ -31,18 +31,20 @@ function expandGeometry(geometry, size, gutter) {
 		var x2 = uv.getX(c) * size,
 			y2 = uv.getY(c) * size;
 
-		var denominator = (y1 - y2) * (x0 - x2) + (x2 - x1) * (y0 - y2);
-		var scale = Math.abs(denominator) < 1e-7 ? 0 : gutter / Math.abs(denominator);
-
-		var e0 = Math.hypot(x1 - x2, y1 - y2) * scale;
-		var e1 = Math.hypot(x2 - x0, y2 - y0) * scale;
-		var e2 = Math.hypot(x0 - x1, y0 - y1) * scale;
+		// shift corners away from the opposite edge center
+		var d0 = Math.hypot(x0 * 2 - x1 - x2, y0 * 2 - y1 - y2);
+		var d1 = Math.hypot(x1 * 2 - x0 - x2, y1 * 2 - y0 - y2);
+		var d2 = Math.hypot(x2 * 2 - x0 - x1, y2 * 2 - y0 - y1);
+		var e0 = d0 == 0 ? 0 : gutter / d0;
+		var e1 = d1 == 0 ? 0 : gutter / d1;
+		var e2 = d2 == 0 ? 0 : gutter / d2;
 
 		for (var j = 0; j < 3; ++j) {
-			// expand each triangle in barycentric space by e0/e1/e2 to accommodate extra gutter width
-			var w0 = j == 0 ? 1 + e1 + e2 : -e0;
-			var w1 = j == 1 ? 1 + e0 + e2 : -e1;
-			var w2 = j == 2 ? 1 + e0 + e1 : -e2;
+			// expand each triangle in barycentric space to accommodate extra gutter width
+			var ej = j == 0 ? e0 : j == 1 ? e1 : e2;
+			var w0 = j == 0 ? 1 + ej * 2 : -ej;
+			var w1 = j == 1 ? 1 + ej * 2 : -ej;
+			var w2 = j == 2 ? 1 + ej * 2 : -ej;
 
 			// interpolate all attributes; we will use UVs to rasterize and positions/normals to trace against the original mesh
 			var v = i + j;

--- a/demo/retexture.js
+++ b/demo/retexture.js
@@ -2,7 +2,7 @@
 //
 // Remeshed atlas is rasterized in UV space, the triangle edges are expanded to cover extra gutter space.
 import * as THREE from 'three';
-import { BVHShaderGLSL, MeshBVHUniformStruct } from 'three-mesh-bvh';
+import { BVHShaderGLSL, MeshBVHUniformStruct, FloatVertexAttributeTexture, UIntVertexAttributeTexture } from 'three-mesh-bvh';
 
 function expandGeometry(geometry, size, gutter) {
 	var position = geometry.attributes.position;
@@ -64,6 +64,10 @@ function expandGeometry(geometry, size, gutter) {
 var bakeMaterial = new THREE.ShaderMaterial({
 	uniforms: {
 		bvh: { value: null },
+		attrNormal: { value: null },
+		attrUv: { value: null },
+		attrColor: { value: null },
+		attrMaterial: { value: null },
 		thickness: { value: 0 },
 	},
 	vertexShader: `
@@ -87,6 +91,10 @@ ${BVHShaderGLSL.bvh_ray_functions}
 ${BVHShaderGLSL.bvh_distance_functions}
 
 uniform BVH bvh;
+uniform sampler2D attrNormal;
+uniform sampler2D attrUv;
+uniform sampler2D attrColor;
+uniform usampler2D attrMaterial;
 uniform float thickness;
 
 varying vec3 vPosition;
@@ -109,8 +117,9 @@ void main() {
 		discard;
 	}
 
-	uint hash = face.w * 2654435761u;
-	gl_FragColor = vec4(vec3(uvec3(hash >> 16u, hash >> 8u, hash) & 255u) / 255.0, 1.0);
+	vec2 uv = textureSampleBarycoord(attrUv, bary, face.xyz).xy;
+
+	gl_FragColor = vec4(uv, 0.0, 1.0);
 }
 `,
 	depthTest: false,
@@ -124,7 +133,22 @@ export function transferTexture(renderer, geometry, bvh, thickness, size, gutter
 	var bvhgpu = new MeshBVHUniformStruct();
 	bvhgpu.updateFrom(bvh);
 
+	var attributes = bvh.geometry.attributes;
+	var attrNormal = new FloatVertexAttributeTexture();
+	var attrUv = new FloatVertexAttributeTexture();
+	var attrColor = new FloatVertexAttributeTexture();
+	var attrMaterial = new UIntVertexAttributeTexture();
+
+	attrNormal.updateFrom(attributes.normal);
+	attrUv.updateFrom(attributes.uv);
+	attrColor.updateFrom(attributes.color);
+	attrMaterial.updateFrom(attributes.material);
+
 	bakeMaterial.uniforms.bvh.value = bvhgpu;
+	bakeMaterial.uniforms.attrNormal.value = attrNormal;
+	bakeMaterial.uniforms.attrUv.value = attrUv;
+	bakeMaterial.uniforms.attrColor.value = attrColor;
+	bakeMaterial.uniforms.attrMaterial.value = attrMaterial;
 	bakeMaterial.uniforms.thickness.value = thickness;
 
 	var mesh = new THREE.Mesh(expanded, bakeMaterial);
@@ -150,6 +174,10 @@ export function transferTexture(renderer, geometry, bvh, thickness, size, gutter
 	expanded.dispose();
 	target.dispose();
 	bvhgpu.dispose();
+	attrNormal.dispose();
+	attrUv.dispose();
+	attrColor.dispose();
+	attrMaterial.dispose();
 
 	var texture = new THREE.DataTexture(data, size, size, THREE.RGBAFormat);
 	texture.colorSpace = THREE.SRGBColorSpace;

--- a/demo/retexture.js
+++ b/demo/retexture.js
@@ -61,6 +61,93 @@ function expandGeometry(geometry, size, gutter) {
 	return result;
 }
 
+var MAP_SIZE = 1024;
+var MAP_BUDGET = 1 << 30;
+var MAP_SLOTS = ['map', 'metalnessMap', 'roughnessMap'];
+
+function createTextureArray(materials) {
+	var textures = [];
+	var layers = new Map();
+
+	for (var i = 0; i < materials.length; ++i) {
+		for (var j = 0; j < MAP_SLOTS.length; ++j) {
+			var texture = materials[i][MAP_SLOTS[j]];
+
+			// deduplicate images by source UUID to avoid wasting layers for reused images
+			if (texture && texture.image && !layers.has(texture.source)) {
+				layers.set(texture.source, textures.length);
+				textures.push(texture);
+			}
+		}
+	}
+
+	var depth = Math.max(textures.length, 1);
+	var size = MAP_SIZE;
+
+	// prevent accidental catastrophic memory use by downscaling texture array until it fits
+	while (size > 4 && depth * size * size * 4 > MAP_BUDGET) size /= 2;
+
+	// all images need to be resized to the same size because we need all of them in one texture array
+	var canvas = document.createElement('canvas');
+	canvas.width = canvas.height = size;
+	var context = canvas.getContext('2d', { willReadFrequently: true });
+
+	var data = new Uint8Array(size * size * 4 * depth);
+
+	for (var i = 0; i < textures.length; ++i) {
+		context.clearRect(0, 0, size, size);
+		context.drawImage(textures[i].image, 0, 0, size, size);
+		data.set(context.getImageData(0, 0, size, size).data, i * size * size * 4);
+	}
+
+	var result = new THREE.DataArrayTexture(data, size, size, depth);
+	result.wrapS = THREE.RepeatWrapping;
+	result.wrapT = THREE.RepeatWrapping;
+	result.minFilter = THREE.LinearFilter;
+	result.magFilter = THREE.LinearFilter;
+	result.needsUpdate = true;
+
+	return { array: result, layers: layers };
+}
+
+function createMaterialTexture(materials, layers) {
+	var stride = 12;
+	var count = Math.max(materials.length, 1);
+	var data = new Float32Array(count * stride);
+
+	function getLayer(material, slot) {
+		var texture = material[slot];
+		return texture && layers.has(texture.source) ? layers.get(texture.source) : -1;
+	}
+
+	for (var i = 0; i < materials.length; ++i) {
+		var material = materials[i];
+		var map = material.map;
+
+		// simplify UV transform by only taking repeat/offset from main texture
+		data[i * stride + 0] = map ? map.repeat.x : 1;
+		data[i * stride + 1] = map ? map.repeat.y : 1;
+		data[i * stride + 2] = map ? map.offset.x : 0;
+		data[i * stride + 3] = map ? map.offset.y : 0;
+
+		// layer indices for all maps
+		data[i * stride + 4] = getLayer(material, 'map');
+		data[i * stride + 5] = getLayer(material, 'metalnessMap');
+		data[i * stride + 6] = getLayer(material, 'roughnessMap');
+
+		// material parameters
+		data[i * stride + 7] = material.metalness !== undefined ? material.metalness : 0;
+		data[i * stride + 8] = material.color ? material.color.r : 1;
+		data[i * stride + 9] = material.color ? material.color.g : 1;
+		data[i * stride + 10] = material.color ? material.color.b : 1;
+		data[i * stride + 11] = material.roughness !== undefined ? material.roughness : 1;
+	}
+
+	var texture = new THREE.DataTexture(data, stride / 4, count, THREE.RGBAFormat, THREE.FloatType);
+	texture.needsUpdate = true;
+	return texture;
+}
+
 var bakeMaterial = new THREE.ShaderMaterial({
 	uniforms: {
 		bvh: { value: null },
@@ -68,6 +155,8 @@ var bakeMaterial = new THREE.ShaderMaterial({
 		attrUv: { value: null },
 		attrColor: { value: null },
 		attrMaterial: { value: null },
+		materials: { value: null },
+		textures: { value: null },
 		thickness: { value: 0 },
 	},
 	vertexShader: `
@@ -84,6 +173,7 @@ void main() {
 	fragmentShader: `
 precision highp isampler2D;
 precision highp usampler2D;
+precision highp sampler2DArray;
 
 ${BVHShaderGLSL.common_functions}
 ${BVHShaderGLSL.bvh_struct_definitions}
@@ -95,7 +185,17 @@ uniform sampler2D attrNormal;
 uniform sampler2D attrUv;
 uniform sampler2D attrColor;
 uniform usampler2D attrMaterial;
+uniform sampler2D materials;
+uniform sampler2DArray textures;
 uniform float thickness;
+
+vec3 fromsrgb(vec3 c) {
+	return pow(c, vec3(2.2));
+}
+
+vec3 tosrgb(vec3 c) {
+	return pow(c, vec3(1.0 / 2.2));
+}
 
 varying vec3 vPosition;
 varying vec3 vNormal;
@@ -118,8 +218,29 @@ void main() {
 	}
 
 	vec2 uv = textureSampleBarycoord(attrUv, bary, face.xyz).xy;
+	int mati = int(uTexelFetch1D(attrMaterial, face.x).r);
 
-	gl_FragColor = vec4(uv, 0.0, 1.0);
+	vec4 md0 = texelFetch(materials, ivec2(0, mati), 0);
+	vec4 md1 = texelFetch(materials, ivec2(1, mati), 0);
+	vec4 md2 = texelFetch(materials, ivec2(2, mati), 0);
+
+	vec2 point = uv * md0.xy + md0.zw;
+
+	vec3 color = md2.rgb;
+	if (md1.x >= 0.0) color *= fromsrgb(texture(textures, vec3(point, md1.x)).rgb);
+
+	// vertex colors are linear, and are white when the source mesh or material doesn't use them
+	color *= textureSampleBarycoord(attrColor, bary, face.xyz).rgb;
+
+	float metalness = md1.w;
+	float roughness = md2.w;
+	if (md1.y >= 0.0) metalness *= texture(textures, vec3(point, md1.y)).b;
+	if (md1.z >= 0.0) roughness *= texture(textures, vec3(point, md1.z)).g;
+
+	// for now, bake metalness/roughness into color as an approximation
+	color *= 1.0 - metalness * (1.0 - roughness * roughness * roughness);
+
+	gl_FragColor = vec4(tosrgb(color), 1.0);
 }
 `,
 	depthTest: false,
@@ -127,7 +248,7 @@ void main() {
 	side: THREE.DoubleSide,
 });
 
-export function transferTexture(renderer, geometry, bvh, thickness, size, gutter) {
+export function transferTexture(renderer, geometry, bvh, thickness, materials, size, gutter) {
 	var expanded = expandGeometry(geometry, size, gutter);
 
 	var bvhgpu = new MeshBVHUniformStruct();
@@ -144,11 +265,16 @@ export function transferTexture(renderer, geometry, bvh, thickness, size, gutter
 	attrColor.updateFrom(attributes.color);
 	attrMaterial.updateFrom(attributes.material);
 
+	var textures = createTextureArray(materials);
+	var materialsgpu = createMaterialTexture(materials, textures.layers);
+
 	bakeMaterial.uniforms.bvh.value = bvhgpu;
 	bakeMaterial.uniforms.attrNormal.value = attrNormal;
 	bakeMaterial.uniforms.attrUv.value = attrUv;
 	bakeMaterial.uniforms.attrColor.value = attrColor;
 	bakeMaterial.uniforms.attrMaterial.value = attrMaterial;
+	bakeMaterial.uniforms.materials.value = materialsgpu;
+	bakeMaterial.uniforms.textures.value = textures.array;
 	bakeMaterial.uniforms.thickness.value = thickness;
 
 	var mesh = new THREE.Mesh(expanded, bakeMaterial);
@@ -178,6 +304,8 @@ export function transferTexture(renderer, geometry, bvh, thickness, size, gutter
 	attrUv.dispose();
 	attrColor.dispose();
 	attrMaterial.dispose();
+	materialsgpu.dispose();
+	textures.array.dispose();
 
 	var texture = new THREE.DataTexture(data, size, size, THREE.RGBAFormat);
 	texture.colorSpace = THREE.SRGBColorSpace;

--- a/demo/retexture.js
+++ b/demo/retexture.js
@@ -2,6 +2,7 @@
 //
 // Remeshed atlas is rasterized in UV space, the triangle edges are expanded to cover extra gutter space.
 import * as THREE from 'three';
+import { BVHShaderGLSL, MeshBVHUniformStruct } from 'three-mesh-bvh';
 
 function expandGeometry(geometry, size, gutter) {
 	var position = geometry.attributes.position;
@@ -61,14 +62,55 @@ function expandGeometry(geometry, size, gutter) {
 }
 
 var bakeMaterial = new THREE.ShaderMaterial({
+	uniforms: {
+		bvh: { value: null },
+		thickness: { value: 0 },
+	},
 	vertexShader: `
+varying vec3 vPosition;
+varying vec3 vNormal;
+
 void main() {
+	vPosition = position;
+	vNormal = normal;
+
 	gl_Position = vec4(uv * 2.0 - 1.0, 0.0, 1.0);
 }
 `,
 	fragmentShader: `
+precision highp isampler2D;
+precision highp usampler2D;
+
+${BVHShaderGLSL.common_functions}
+${BVHShaderGLSL.bvh_struct_definitions}
+${BVHShaderGLSL.bvh_ray_functions}
+${BVHShaderGLSL.bvh_distance_functions}
+
+uniform BVH bvh;
+uniform float thickness;
+
+varying vec3 vPosition;
+varying vec3 vNormal;
+
 void main() {
-	gl_FragColor = vec4(1.0);
+	vec3 normal = normalize(vNormal);
+
+	uvec4 face = uvec4(0u);
+	vec3 faceNormal = vec3(0.0), bary = vec3(0.0), closest = vec3(0.0);
+	float side = 1.0, dist = 0.0;
+	float maxClosest = thickness * 10.0;
+
+	if (bvhIntersectFirstHit(bvh, vPosition + normal * thickness, -normal, face, faceNormal, bary, side, dist) && dist < thickness * 2.0) {
+		// ray hit
+	} else if (bvhClosestPointToPoint(bvh, vPosition, maxClosest, face, faceNormal, bary, side, closest) < maxClosest) {
+		// closest point found; note, bary is ordered incorrectly in three-mesh-bvh for closest point so we need to swizzle it
+		bary = bary.zxy;
+	} else {
+		discard;
+	}
+
+	uint hash = face.w * 2654435761u;
+	gl_FragColor = vec4(vec3(uvec3(hash >> 16u, hash >> 8u, hash) & 255u) / 255.0, 1.0);
 }
 `,
 	depthTest: false,
@@ -76,8 +118,14 @@ void main() {
 	side: THREE.DoubleSide,
 });
 
-export function transferTexture(renderer, geometry, size, gutter) {
+export function transferTexture(renderer, geometry, bvh, thickness, size, gutter) {
 	var expanded = expandGeometry(geometry, size, gutter);
+
+	var bvhgpu = new MeshBVHUniformStruct();
+	bvhgpu.updateFrom(bvh);
+
+	bakeMaterial.uniforms.bvh.value = bvhgpu;
+	bakeMaterial.uniforms.thickness.value = thickness;
 
 	var mesh = new THREE.Mesh(expanded, bakeMaterial);
 	mesh.frustumCulled = false;
@@ -101,6 +149,7 @@ export function transferTexture(renderer, geometry, size, gutter) {
 
 	expanded.dispose();
 	target.dispose();
+	bvhgpu.dispose();
 
 	var texture = new THREE.DataTexture(data, size, size, THREE.RGBAFormat);
 	texture.colorSpace = THREE.SRGBColorSpace;

--- a/demo/retexture.js
+++ b/demo/retexture.js
@@ -1,0 +1,111 @@
+// GPU texture transfer for remeshing demo
+//
+// Remeshed atlas is rasterized in UV space, the triangle edges are expanded to cover extra gutter space.
+import * as THREE from 'three';
+
+function expandGeometry(geometry, size, gutter) {
+	var position = geometry.attributes.position;
+	var normal = geometry.attributes.normal;
+	var uv = geometry.attributes.uv;
+	var indices = geometry.index.array;
+
+	var count = indices.length;
+	var positions = new Float32Array(count * 3);
+	var normals = new Float32Array(count * 3);
+	var uvs = new Float32Array(count * 2);
+
+	for (var i = 0; i < count; i += 3) {
+		var a = indices[i],
+			b = indices[i + 1],
+			c = indices[i + 2];
+		var x0 = uv.getX(a) * size,
+			y0 = uv.getY(a) * size;
+		var x1 = uv.getX(b) * size,
+			y1 = uv.getY(b) * size;
+		var x2 = uv.getX(c) * size,
+			y2 = uv.getY(c) * size;
+
+		var denominator = (y1 - y2) * (x0 - x2) + (x2 - x1) * (y0 - y2);
+		var scale = Math.abs(denominator) < 1e-7 ? 0 : gutter / Math.abs(denominator);
+
+		var e0 = Math.hypot(x1 - x2, y1 - y2) * scale;
+		var e1 = Math.hypot(x2 - x0, y2 - y0) * scale;
+		var e2 = Math.hypot(x0 - x1, y0 - y1) * scale;
+
+		for (var j = 0; j < 3; ++j) {
+			// expand each triangle in barycentric space by e0/e1/e2 to accommodate extra gutter width
+			var w0 = j == 0 ? 1 + e1 + e2 : -e0;
+			var w1 = j == 1 ? 1 + e0 + e2 : -e1;
+			var w2 = j == 2 ? 1 + e0 + e1 : -e2;
+
+			// interpolate all attributes; we will use UVs to rasterize and positions/normals to trace against the original mesh
+			var v = i + j;
+			positions[v * 3 + 0] = position.getX(a) * w0 + position.getX(b) * w1 + position.getX(c) * w2;
+			positions[v * 3 + 1] = position.getY(a) * w0 + position.getY(b) * w1 + position.getY(c) * w2;
+			positions[v * 3 + 2] = position.getZ(a) * w0 + position.getZ(b) * w1 + position.getZ(c) * w2;
+
+			normals[v * 3 + 0] = normal.getX(a) * w0 + normal.getX(b) * w1 + normal.getX(c) * w2;
+			normals[v * 3 + 1] = normal.getY(a) * w0 + normal.getY(b) * w1 + normal.getY(c) * w2;
+			normals[v * 3 + 2] = normal.getZ(a) * w0 + normal.getZ(b) * w1 + normal.getZ(c) * w2;
+
+			uvs[v * 2 + 0] = (x0 * w0 + x1 * w1 + x2 * w2) / size;
+			uvs[v * 2 + 1] = (y0 * w0 + y1 * w1 + y2 * w2) / size;
+		}
+	}
+
+	var result = new THREE.BufferGeometry();
+	result.setAttribute('position', new THREE.BufferAttribute(positions, 3));
+	result.setAttribute('normal', new THREE.BufferAttribute(normals, 3));
+	result.setAttribute('uv', new THREE.BufferAttribute(uvs, 2));
+	return result;
+}
+
+var bakeMaterial = new THREE.ShaderMaterial({
+	vertexShader: `
+void main() {
+	gl_Position = vec4(uv * 2.0 - 1.0, 0.0, 1.0);
+}
+`,
+	fragmentShader: `
+void main() {
+	gl_FragColor = vec4(1.0);
+}
+`,
+	depthTest: false,
+	depthWrite: false,
+	side: THREE.DoubleSide,
+});
+
+export function transferTexture(renderer, geometry, size, gutter) {
+	var expanded = expandGeometry(geometry, size, gutter);
+
+	var mesh = new THREE.Mesh(expanded, bakeMaterial);
+	mesh.frustumCulled = false;
+
+	var target = new THREE.WebGLRenderTarget(size, size, {
+		minFilter: THREE.NearestFilter,
+		magFilter: THREE.NearestFilter,
+		depthBuffer: false,
+		generateMipmaps: false,
+	});
+
+	renderer.setClearColor(0x000000, 0);
+	renderer.setRenderTarget(target);
+	renderer.render(mesh, new THREE.OrthographicCamera());
+
+	renderer.setRenderTarget(null);
+
+	// copy render target to DataTexture; this is redundant for display but we need this for GLB export to function
+	var data = new Uint8Array(size * size * 4);
+	renderer.readRenderTargetPixels(target, 0, 0, size, size, data);
+
+	expanded.dispose();
+	target.dispose();
+
+	var texture = new THREE.DataTexture(data, size, size, THREE.RGBAFormat);
+	texture.colorSpace = THREE.SRGBColorSpace;
+	texture.magFilter = THREE.LinearFilter;
+	texture.minFilter = THREE.LinearFilter;
+	texture.needsUpdate = true;
+	return texture;
+}

--- a/demo/retexture.js
+++ b/demo/retexture.js
@@ -63,7 +63,7 @@ function expandGeometry(geometry, size, gutter) {
 
 var MAP_SIZE = 1024;
 var MAP_BUDGET = 1 << 30;
-var MAP_SLOTS = ['map', 'metalnessMap', 'roughnessMap'];
+var MAP_SLOTS = ['map', 'aoMap', 'emissiveMap', 'roughnessMap', 'metalnessMap'];
 
 function createTextureArray(materials) {
 	var textures = [];
@@ -111,7 +111,7 @@ function createTextureArray(materials) {
 }
 
 function createMaterialTexture(materials, layers) {
-	var stride = 12;
+	var stride = 24;
 	var count = Math.max(materials.length, 1);
 	var data = new Float32Array(count * stride);
 
@@ -130,17 +130,23 @@ function createMaterialTexture(materials, layers) {
 		data[i * stride + 2] = map ? map.offset.x : 0;
 		data[i * stride + 3] = map ? map.offset.y : 0;
 
-		// layer indices for all maps
-		data[i * stride + 4] = getLayer(material, 'map');
-		data[i * stride + 5] = getLayer(material, 'metalnessMap');
-		data[i * stride + 6] = getLayer(material, 'roughnessMap');
+		// layer indices
+		for (var j = 0; j < MAP_SLOTS.length; ++j) {
+			data[i * stride + 4 + j] = getLayer(material, MAP_SLOTS[j]);
+		}
 
 		// material parameters
-		data[i * stride + 7] = material.metalness !== undefined ? material.metalness : 0;
-		data[i * stride + 8] = material.color ? material.color.r : 1;
-		data[i * stride + 9] = material.color ? material.color.g : 1;
-		data[i * stride + 10] = material.color ? material.color.b : 1;
-		data[i * stride + 11] = material.roughness !== undefined ? material.roughness : 1;
+		data[i * stride + 12] = material.color ? material.color.r : 1;
+		data[i * stride + 13] = material.color ? material.color.g : 1;
+		data[i * stride + 14] = material.color ? material.color.b : 1;
+		data[i * stride + 15] = material.aoMapIntensity !== undefined ? material.aoMapIntensity : 1;
+
+		data[i * stride + 16] = material.emissive ? material.emissive.r * material.emissiveIntensity : 0;
+		data[i * stride + 17] = material.emissive ? material.emissive.g * material.emissiveIntensity : 0;
+		data[i * stride + 18] = material.emissive ? material.emissive.b * material.emissiveIntensity : 0;
+		data[i * stride + 19] = material.roughness !== undefined ? material.roughness : 1;
+
+		data[i * stride + 20] = material.metalness !== undefined ? material.metalness : 0;
 	}
 
 	var texture = new THREE.DataTexture(data, stride / 4, count, THREE.RGBAFormat, THREE.FloatType);
@@ -223,22 +229,36 @@ void main() {
 	vec4 md0 = texelFetch(materials, ivec2(0, mati), 0);
 	vec4 md1 = texelFetch(materials, ivec2(1, mati), 0);
 	vec4 md2 = texelFetch(materials, ivec2(2, mati), 0);
+	vec4 md3 = texelFetch(materials, ivec2(3, mati), 0);
+	vec4 md4 = texelFetch(materials, ivec2(4, mati), 0);
+	vec4 md5 = texelFetch(materials, ivec2(5, mati), 0);
 
+	// md0: uv transform, md1.xyzw + md2.x: layer indices in MAP_SLOTS order,
+	// md3: base color + ao intensity, md4: emissive color + roughness, md5.x: metalness
 	vec2 point = uv * md0.xy + md0.zw;
 
-	vec3 color = md2.rgb;
+	vec3 color = md3.rgb;
 	if (md1.x >= 0.0) color *= fromsrgb(texture(textures, vec3(point, md1.x)).rgb);
 
 	// vertex colors are linear, and are white when the source mesh or material doesn't use them
 	color *= textureSampleBarycoord(attrColor, bary, face.xyz).rgb;
 
-	float metalness = md1.w;
-	float roughness = md2.w;
-	if (md1.y >= 0.0) metalness *= texture(textures, vec3(point, md1.y)).b;
-	if (md1.z >= 0.0) roughness *= texture(textures, vec3(point, md1.z)).g;
+	if (md1.y >= 0.0) {
+		float occlusion = texture(textures, vec3(point, md1.y)).r;
+		color *= 1.0 + md3.w * (occlusion - 1.0);
+	}
+
+	float roughness = md4.w;
+	float metalness = md5.x;
+	if (md1.w >= 0.0) roughness *= texture(textures, vec3(point, md1.w)).g;
+	if (md2.x >= 0.0) metalness *= texture(textures, vec3(point, md2.x)).b;
 
 	// for now, bake metalness/roughness into color as an approximation
 	color *= 1.0 - metalness * (1.0 - roughness * roughness * roughness);
+
+	vec3 emissive = md4.rgb;
+	if (md1.z >= 0.0) emissive *= fromsrgb(texture(textures, vec3(point, md1.z)).rgb);
+	color += emissive;
 
 	gl_FragColor = vec4(tosrgb(color), 1.0);
 }


### PR DESCRIPTION
This is pretty much a complete rewrite of the repainting portion of the remeshing demo :) I got a little carried away...

The original demo was quite slow when generating high resolution textures. Most of the cost was in JS raycasts; I tried a few different options for how to accelerate these (rewrite casting function to iterative traversal; tweak three-mesh-bvh construction; replace three-mesh-bvh with tinybvh compiled to JS; use WebWorkers). Ultimately it was all pretty cumbersome, and the only option that got reasonable tracing times involved tinybvh compiled to JS and used from WebWorkers, which required someone to maintain tinybvh.js and that wasn't going to be me. Plus even once tracing cost was removed, material evaluation was not free and computing normal maps added even more time.

So I decided to bite the bullet and move repainting *entirely* to WebGL. Thankfully three-mesh-bvh was a huge help here, as it already provided full support and shader code for tracing the BVH, including closest-point sampling, and also had helpful utilities for exposing vertex data as textures.

To be able to do material sampling, not just ray casts, materials need to get bound into the shader in a "bindless" manner. Neither WebGPU nor WebGL support bindless, so all textures referenced by all materials need to get rescaled to the same size and copied into a texture array. We limit the size of the resulting array to 1024x1024 layers (and 1 GB total); this limits the quality a little bit for some assets but makes this practical. If WebGPU gains true bindless support in the future this could get ported to WebGPU instead, but for now WebGL is enough.

With all that, ray casting and sampling becomes very fast and is practical to run at high resolutions like 2048. Which then made it fairly easy to integrate normal map and material (metallic-roughness) map baking too. For normal map baking, we need source and destination tangents, and we use MeshoptTangents module to generate these now.

Vertex color repaint works using the same approach, with an intermediate texture that is copied to vertex color stream on the CPU.

The results are quite faithful with the right settings; e.g. this is a remesh of a backpack mesh with normal/material map baking, voxel resolution 128, thickening, simplification enabled and regularization disabled:

before | after | wireframe
----|----|----
<img width="1312" height="762" alt="image" src="https://github.com/user-attachments/assets/7cc1f01a-7f11-47a2-835e-170e0355b5ab" /> | <img width="1312" height="762" alt="image" src="https://github.com/user-attachments/assets/600b8498-4078-461a-9dab-0c3d5ee8222f" /> | <img width="1312" height="762" alt="image" src="https://github.com/user-attachments/assets/bd3e2916-3105-44ea-85c2-de83e3d457c1" />

The demo now also has an 'exportFile' button which produces a GLB file with all textures bundled, courtesy of three.js GLTFExporter.

The JS code used averaging of pixels along triangle edges; to keep this PR a little smaller we don't do that (it requires a separate intermediate texture with RGBA16F format and a separate resolve shader). There might also be occasional issues with the ray casting code as the thickness needs to be tuned better for some meshes to work well, and I'm not sure if casting is watertight either.