### PR TITLE
 gltfpack: Implement normal generation when requested via -gn

### DIFF
--- a/gltf/gltfpack.cpp
+++ b/gltf/gltfpack.cpp
@@ -437,6 +437,9 @@ static size_t process(cgltf_data* data, const char* input_path, const char* outp
 		if (!settings.keep_attributes)
 			filterStreams(mesh, mi);
 
+		if (settings.mesh_normals && (!mi.unlit || settings.keep_attributes))
+			generateNormals(mesh, settings.normals_crease);
+
 		if (settings.mesh_tangents && (mi.needs_tangents || settings.keep_attributes))
 			generateTangents(mesh);
 	}
@@ -1384,6 +1387,11 @@ int main(int argc, char** argv)
 		{
 			settings.mesh_tangents = true;
 		}
+		else if (strcmp(arg, "-gn") == 0 && i + 1 < argc && isdigit(argv[i + 1][0]))
+		{
+			settings.mesh_normals = true;
+			settings.normals_crease = clamp(float(atof(argv[++i])), 0.f, 180.f);
+		}
 		else if (strcmp(arg, "-at") == 0 && i + 1 < argc && isdigit(argv[i + 1][0]))
 		{
 			settings.trn_bits = clamp(atoi(argv[++i]), 1, 24);
@@ -1706,6 +1714,7 @@ int main(int argc, char** argv)
 			fprintf(stderr, "\t-vnf: use floating point attributes for normals\n");
 			fprintf(stderr, "\t-vi: use interleaved vertex attributes (reduces compression efficiency)\n");
 			fprintf(stderr, "\t-gt: generate tangent frames when needed, replacing existing tangents\n");
+			fprintf(stderr, "\t-gn A: generate normals when absent, using crease angle A (degrees)\n");
 			fprintf(stderr, "\t-kv: keep source vertex attributes even if they aren't used\n");
 			fprintf(stderr, "\nAnimations:\n");
 			fprintf(stderr, "\t-at N: use N-bit quantization for translations (default: 16; N should be between 1 and 24)\n");
@@ -1771,6 +1780,12 @@ int main(int argc, char** argv)
 	if (settings.mesh_tangents)
 	{
 		fprintf(stderr, "Option -gt is not available in this build\n");
+		return 1;
+	}
+
+	if (settings.mesh_normals)
+	{
+		fprintf(stderr, "Option -gn is not available in this build\n");
 		return 1;
 	}
 #endif

--- a/gltf/gltfpack.h
+++ b/gltf/gltfpack.h
@@ -146,6 +146,9 @@ struct Settings
 	bool mesh_instancing;
 	bool mesh_interleaved;
 	bool mesh_tangents;
+	bool mesh_normals;
+
+	float normals_crease;
 
 	float simplify_ratio;
 	float simplify_error;
@@ -336,6 +339,7 @@ void mergeMeshes(std::vector<Mesh>& meshes, const Settings& settings);
 void filterEmptyMeshes(std::vector<Mesh>& meshes);
 void filterStreams(Mesh& mesh, const MaterialInfo& mi);
 void generateTangents(Mesh& mesh);
+void generateNormals(Mesh& mesh, float crease_angle);
 
 void mergeMeshMaterials(cgltf_data* data, std::vector<Mesh>& meshes, const Settings& settings);
 void markNeededMaterials(cgltf_data* data, std::vector<MaterialInfo>& materials, const std::vector<Mesh>& meshes, const Settings& settings);

--- a/gltf/mesh.cpp
+++ b/gltf/mesh.cpp
@@ -670,6 +670,44 @@ static Stream& prepareTangentStream(Mesh& mesh, size_t vertex_count)
 
 	return tangent;
 }
+
+static void splitVertices(Mesh& mesh, Stream& target, const Attr* data)
+{
+	size_t vertex_count = target.data.size();
+
+	// seed each vertex with one of its corner values; the loop below fixes any mismatches
+	for (size_t i = 0; i < mesh.indices.size(); ++i)
+		target.data[mesh.indices[i]] = data[i];
+
+	std::vector<unsigned int> splits(vertex_count, ~0u);
+
+	for (size_t i = 0; i < mesh.indices.size(); ++i)
+	{
+		const Attr& a = data[i];
+		unsigned int v = mesh.indices[i];
+		unsigned int sv = v;
+
+		// walk the chain of split copies looking for a vertex whose attribute matches
+		while (sv != ~0u && !(target.data[sv].f[0] == a.f[0] && target.data[sv].f[1] == a.f[1] && target.data[sv].f[2] == a.f[2] && target.data[sv].f[3] == a.f[3]))
+			sv = splits[sv];
+
+		// no match in chain: append a new split copy with the target attribute and chain it
+		if (sv == ~0u)
+		{
+			sv = unsigned(target.data.size());
+
+			for (Stream& stream : mesh.streams)
+				stream.data.push_back(stream.data[v]);
+
+			target.data[sv] = a;
+
+			splits.push_back(splits[v]);
+			splits[v] = sv;
+		}
+
+		mesh.indices[i] = sv;
+	}
+}
 #endif
 
 void generateTangents(Mesh& mesh)
@@ -698,38 +736,7 @@ void generateTangents(Mesh& mesh)
 	// note: potentially invalidates positions/normals/uvs but we no longer use these
 	Stream& tangent = prepareTangentStream(mesh, vertex_count);
 
-	// seed each vertex with one of its corner tangents; the loop below fixes any mismatches
-	for (size_t i = 0; i < mesh.indices.size(); ++i)
-		tangent.data[mesh.indices[i]] = tangents[i];
-
-	std::vector<unsigned int> splits(vertex_count, ~0u);
-
-	for (size_t i = 0; i < mesh.indices.size(); ++i)
-	{
-		const Attr& t = tangents[i];
-		unsigned int v = mesh.indices[i];
-		unsigned int sv = v;
-
-		// walk the chain of split copies looking for a vertex whose tangent matches
-		while (sv != ~0u && !(tangent.data[sv].f[0] == t.f[0] && tangent.data[sv].f[1] == t.f[1] && tangent.data[sv].f[2] == t.f[2] && tangent.data[sv].f[3] == t.f[3]))
-			sv = splits[sv];
-
-		// no match in chain: append a new split copy with the target tangent and chain it
-		if (sv == ~0u)
-		{
-			sv = unsigned(tangent.data.size());
-
-			for (Stream& stream : mesh.streams)
-				stream.data.push_back(stream.data[v]);
-
-			tangent.data[sv] = t;
-
-			splits.push_back(splits[v]);
-			splits[v] = sv;
-		}
-
-		mesh.indices[i] = sv;
-	}
+	splitVertices(mesh, tangent, tangents.data());
 #endif
 }
 

--- a/gltf/mesh.cpp
+++ b/gltf/mesh.cpp
@@ -671,19 +671,22 @@ static Stream& prepareTangentStream(Mesh& mesh, size_t vertex_count)
 	return tangent;
 }
 
-static void splitVertices(Mesh& mesh, Stream& target, const Attr* data)
+template <int N>
+static void splitVertices(Mesh& mesh, Stream& target, const float* data)
 {
 	size_t vertex_count = target.data.size();
 
 	// seed each vertex with one of its corner values; the loop below fixes any mismatches
 	for (size_t i = 0; i < mesh.indices.size(); ++i)
-		target.data[mesh.indices[i]] = data[i];
+		memcpy(target.data[mesh.indices[i]].f, &data[i * N], N * sizeof(float));
 
 	std::vector<unsigned int> splits(vertex_count, ~0u);
 
 	for (size_t i = 0; i < mesh.indices.size(); ++i)
 	{
-		const Attr& a = data[i];
+		Attr a = {};
+		memcpy(a.f, &data[i * N], N * sizeof(float));
+
 		unsigned int v = mesh.indices[i];
 		unsigned int sv = v;
 
@@ -730,13 +733,13 @@ void generateTangents(Mesh& mesh)
 	size_t vertex_count = positions->data.size();
 	assert(normals->data.size() == vertex_count && uvs->data.size() == vertex_count);
 
-	std::vector<Attr> tangents(mesh.indices.size());
-	meshopt_generateTangents(tangents[0].f, mesh.indices.data(), mesh.indices.size(), positions->data[0].f, vertex_count, sizeof(Attr), normals->data[0].f, sizeof(Attr), uvs->data[0].f, sizeof(Attr), 0);
+	std::vector<float> tangents(mesh.indices.size() * 4);
+	meshopt_generateTangents(tangents.data(), mesh.indices.data(), mesh.indices.size(), positions->data[0].f, vertex_count, sizeof(Attr), normals->data[0].f, sizeof(Attr), uvs->data[0].f, sizeof(Attr), 0);
 
 	// note: potentially invalidates positions/normals/uvs but we no longer use these
 	Stream& tangent = prepareTangentStream(mesh, vertex_count);
 
-	splitVertices(mesh, tangent, tangents.data());
+	splitVertices<4>(mesh, tangent, tangents.data());
 #endif
 }
 
@@ -759,14 +762,6 @@ void generateNormals(Mesh& mesh, float crease_angle)
 	std::vector<float> normals(mesh.indices.size() * 3);
 	meshopt_generateNormals(normals.data(), mesh.indices.data(), mesh.indices.size(), positions->data[0].f, vertex_count, sizeof(Attr), crease_angle * (3.14159265f / 180.f), 1.5f);
 
-	std::vector<Attr> data(mesh.indices.size());
-	for (size_t i = 0; i < mesh.indices.size(); ++i)
-	{
-		data[i].f[0] = normals[i * 3 + 0];
-		data[i].f[1] = normals[i * 3 + 1];
-		data[i].f[2] = normals[i * 3 + 2];
-	}
-
 	// note: potentially invalidates positions but we no longer use these
 	mesh.streams.push_back(Stream());
 
@@ -774,7 +769,7 @@ void generateNormals(Mesh& mesh, float crease_angle)
 	normal.type = cgltf_attribute_type_normal;
 	normal.data.resize(vertex_count);
 
-	splitVertices(mesh, normal, data.data());
+	splitVertices<3>(mesh, normal, normals.data());
 #endif
 }
 

--- a/gltf/mesh.cpp
+++ b/gltf/mesh.cpp
@@ -740,6 +740,44 @@ void generateTangents(Mesh& mesh)
 #endif
 }
 
+void generateNormals(Mesh& mesh, float crease_angle)
+{
+#ifdef GLTFPACK_NO_EXPERIMENTAL
+	// disabled until meshopt_generateNormals becomes stable
+	(void)mesh;
+	(void)crease_angle;
+#else
+	if (mesh.type != cgltf_primitive_type_triangles || mesh.indices.empty() || mesh.targets || getStream(mesh, cgltf_attribute_type_normal))
+		return;
+
+	Stream* positions = getStream(mesh, cgltf_attribute_type_position);
+	if (!positions)
+		return;
+
+	size_t vertex_count = positions->data.size();
+
+	std::vector<float> normals(mesh.indices.size() * 3);
+	meshopt_generateNormals(normals.data(), mesh.indices.data(), mesh.indices.size(), positions->data[0].f, vertex_count, sizeof(Attr), crease_angle * (3.14159265f / 180.f), 1.5f);
+
+	std::vector<Attr> data(mesh.indices.size());
+	for (size_t i = 0; i < mesh.indices.size(); ++i)
+	{
+		data[i].f[0] = normals[i * 3 + 0];
+		data[i].f[1] = normals[i * 3 + 1];
+		data[i].f[2] = normals[i * 3 + 2];
+	}
+
+	// note: potentially invalidates positions but we no longer use these
+	mesh.streams.push_back(Stream());
+
+	Stream& normal = mesh.streams.back();
+	normal.type = cgltf_attribute_type_normal;
+	normal.data.resize(vertex_count);
+
+	splitVertices(mesh, normal, data.data());
+#endif
+}
+
 struct QuantizedTBN
 {
 	int8_t nx, ny, nz, nw;


### PR DESCRIPTION
Unlike tangent generation, we keep existing normal stream if present,
and only override it if necessary. Broken normals are much more rare,
and glTF specification does not recommend any particular method of
generating normals, so it would in general not be correct to replace
existing normals.

For now, smoothing is hard coded and left at a moderate strength that
works fairly well across many different meshes.