### PR TITLE
 gltfpack: Expose position/attribute solve during simplification

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -202,6 +202,7 @@ jobs:
           ./gltfpack -test glTF-Sample-Assets/Models/ABeautifulGame/glTF/ABeautifulGame.gltf -mi -c
           ./gltfpack -test glTF-Sample-Assets/Models/ABeautifulGame/glTF/ABeautifulGame.gltf -kn -km -ke
           ./gltfpack -test glTF-Sample-Assets/Models/ABeautifulGame/glTF/ABeautifulGame.gltf -si 0.1 -sp
+          ./gltfpack -test glTF-Sample-Assets/Models/ABeautifulGame/glTF/ABeautifulGame.gltf -si 0.1 -sv
           ./gltfpack -test glTF-Sample-Assets/Models/BoxTextured/glTF/BoxTextured.gltf -vpf -vtf -c
           ./gltfpack -test glTF-Sample-Assets/Models/BoxTextured/glTF/BoxTextured.gltf -vpf -vtf -cc
           ./gltfpack -test glTF-Sample-Assets/Models/BoxTextured/glTF/BoxTextured.gltf -tc

--- a/gltf/gltfpack.cpp
+++ b/gltf/gltfpack.cpp
@@ -1461,16 +1461,6 @@ int main(int argc, char** argv)
 		{
 			fprintf(stderr, "Warning: attribute aware simplification is enabled by default; option -sv is only provided for compatibility and may be removed in the future\n");
 		}
-		else if (strcmp(arg, "-svd") == 0)
-		{
-			fprintf(stderr, "Warning: option -svd disables attribute aware simplification and is temporary; avoid production usage\n");
-			settings.simplify_attributes = false;
-		}
-		else if (strcmp(arg, "-ssd") == 0)
-		{
-			fprintf(stderr, "Warning: option -ssd disables scaled simplification error and is temporary; avoid production usage\n");
-			settings.simplify_scaled = false;
-		}
 		else if (strcmp(arg, "-sp") == 0)
 		{
 			settings.simplify_permissive = true;

--- a/gltf/gltfpack.cpp
+++ b/gltf/gltfpack.cpp
@@ -450,7 +450,7 @@ static size_t process(cgltf_data* data, const char* input_path, const char* outp
 	markNeededNodes(data, nodes, meshes, animations, settings);
 	markNeededMaterials(data, materials, meshes, settings);
 
-	if (settings.simplify_scaled && settings.simplify_ratio < 1)
+	if (settings.simplify_ratio < 1)
 		computeMeshQuality(meshes);
 
 	for (size_t i = 0; i < meshes.size(); ++i)
@@ -1265,8 +1265,6 @@ Settings defaults()
 	settings.mesh_dedup = true;
 	settings.simplify_ratio = 1.f;
 	settings.simplify_error = 1e-2f;
-	settings.simplify_attributes = true;
-	settings.simplify_scaled = true;
 
 	for (int kind = 0; kind < TextureKind__Count; ++kind)
 	{

--- a/gltf/gltfpack.cpp
+++ b/gltf/gltfpack.cpp
@@ -1459,7 +1459,7 @@ int main(int argc, char** argv)
 		}
 		else if (strcmp(arg, "-sv") == 0)
 		{
-			fprintf(stderr, "Warning: attribute aware simplification is enabled by default; option -sv is only provided for compatibility and may be removed in the future\n");
+			settings.simplify_update = true;
 		}
 		else if (strcmp(arg, "-sp") == 0)
 		{
@@ -1687,6 +1687,7 @@ int main(int argc, char** argv)
 			fprintf(stderr, "\nSimplification:\n");
 			fprintf(stderr, "\t-si R: simplify meshes targeting triangle/point count ratio R (default: 1; R should be between 0 and 1)\n");
 			fprintf(stderr, "\t-se E: limit simplification error to E (default: 0.01 = 1%% deviation; E should be between 0 and 1)\n");
+			fprintf(stderr, "\t-sv: simplify with vertex position and attribute optimization\n");
 			fprintf(stderr, "\t-sp: use permissive simplification mode to allow simplification across attribute discontinuities\n");
 			fprintf(stderr, "\t-sa: aggressively simplify to the target ratio disregarding quality\n");
 			fprintf(stderr, "\t-slb: lock border vertices during simplification to avoid gaps on connected meshes\n");

--- a/gltf/gltfpack.h
+++ b/gltf/gltfpack.h
@@ -154,8 +154,6 @@ struct Settings
 	float simplify_error;
 	bool simplify_aggressive;
 	bool simplify_lock_borders;
-	bool simplify_attributes;
-	bool simplify_scaled;
 	bool simplify_permissive;
 	bool simplify_update;
 

--- a/gltf/gltfpack.h
+++ b/gltf/gltfpack.h
@@ -157,6 +157,7 @@ struct Settings
 	bool simplify_attributes;
 	bool simplify_scaled;
 	bool simplify_permissive;
+	bool simplify_update;
 
 	bool texture_ktx2;
 	bool texture_webp;

--- a/gltf/mesh.cpp
+++ b/gltf/mesh.cpp
@@ -1112,7 +1112,8 @@ static void simplifyMesh(Mesh& mesh, float threshold, float error, bool aggressi
 	if (permissive)
 		simplifyProtect(locks, mesh, presplit_vertices);
 
-	if (update && !mesh.targets)
+	// for now we disable simplify-with-update if the mesh has a second texture coordinate since we don't currently update it and moving vertices may create UV distortion
+	if (update && !mesh.targets && !getStream(mesh, cgltf_attribute_type_texcoord, 1))
 	{
 		indices = mesh.indices;
 		indices.resize(meshopt_simplifyWithUpdate(&indices[0], indices.size(), positions->data[0].f, vertex_count, sizeof(Attr),

--- a/gltf/mesh.cpp
+++ b/gltf/mesh.cpp
@@ -1068,7 +1068,7 @@ static void simplifyUvSplit(Mesh& mesh, std::vector<unsigned int>& remap)
 	}
 }
 
-static void simplifyMesh(Mesh& mesh, float threshold, float error, bool attributes, bool aggressive, bool lock_borders, bool permissive, bool update)
+static void simplifyMesh(Mesh& mesh, float threshold, float error, bool aggressive, bool lock_borders, bool permissive, bool update)
 {
 	assert(mesh.type == cgltf_primitive_type_triangles);
 
@@ -1082,8 +1082,7 @@ static void simplifyMesh(Mesh& mesh, float threshold, float error, bool attribut
 	size_t presplit_vertices = positions->data.size();
 
 	std::vector<unsigned int> uvremap;
-	if (attributes)
-		simplifyUvSplit(mesh, uvremap);
+	simplifyUvSplit(mesh, uvremap);
 
 	size_t vertex_count = positions->data.size();
 
@@ -1107,25 +1106,22 @@ static void simplifyMesh(Mesh& mesh, float threshold, float error, bool attribut
 
 	float attrw[8] = {};
 	std::vector<float> attrs;
-	if (attributes)
-		simplifyAttributes(attrs, attrw, sizeof(attrw) / sizeof(attrw[0]), mesh, update ? 1.f : 0.f);
+	simplifyAttributes(attrs, attrw, sizeof(attrw) / sizeof(attrw[0]), mesh, update ? 1.f : 0.f);
 
 	std::vector<unsigned char> locks;
-	if (attributes && permissive)
+	if (permissive)
 		simplifyProtect(locks, mesh, presplit_vertices);
 
-	if (attributes && update && !mesh.targets)
+	if (update && !mesh.targets)
 	{
 		indices = mesh.indices;
 		indices.resize(meshopt_simplifyWithUpdate(&indices[0], indices.size(), positions->data[0].f, vertex_count, sizeof(Attr),
 		    attrs.data(), sizeof(attrw), attrw, sizeof(attrw) / sizeof(attrw[0]), permissive ? locks.data() : NULL, target_index_count, target_error, options));
 		simplifyUpdate(attrs, sizeof(attrw) / sizeof(attrw[0]), mesh);
 	}
-	else if (attributes)
+	else
 		indices.resize(meshopt_simplifyWithAttributes(&indices[0], &mesh.indices[0], mesh.indices.size(), positions->data[0].f, vertex_count, sizeof(Attr),
 		    attrs.data(), sizeof(attrw), attrw, sizeof(attrw) / sizeof(attrw[0]), permissive ? locks.data() : NULL, target_index_count, target_error, options));
-	else
-		indices.resize(meshopt_simplify(&indices[0], &mesh.indices[0], mesh.indices.size(), positions->data[0].f, vertex_count, sizeof(Attr), target_index_count, target_error, options));
 
 	mesh.indices.swap(indices);
 
@@ -1351,8 +1347,7 @@ void processMesh(Mesh& mesh, const Settings& settings)
 
 		if (settings.simplify_ratio < 1)
 		{
-			float error = settings.simplify_scaled ? settings.simplify_error / mesh.quality : settings.simplify_error;
-			simplifyMesh(mesh, settings.simplify_ratio, error, settings.simplify_attributes, settings.simplify_aggressive, settings.simplify_lock_borders, settings.simplify_permissive, settings.simplify_update);
+			simplifyMesh(mesh, settings.simplify_ratio, settings.simplify_error / mesh.quality, settings.simplify_aggressive, settings.simplify_lock_borders, settings.simplify_permissive, settings.simplify_update);
 		}
 
 		optimizeMesh(mesh, settings.compressmore);

--- a/gltf/mesh.cpp
+++ b/gltf/mesh.cpp
@@ -871,9 +871,9 @@ static void filterTriangles(Mesh& mesh)
 	mesh.indices.resize(write);
 }
 
-static void simplifyAttributes(std::vector<float>& attrs, float* attrw, size_t stride, Mesh& mesh)
+static void simplifyAttributes(std::vector<float>& attrs, float* attrw, size_t stride, Mesh& mesh, float uv_weight)
 {
-	assert(stride >= 6); // normal + color
+	assert(stride >= 8); // normal + color + UV
 
 	size_t vertex_count = mesh.streams[0].data.size();
 
@@ -906,6 +906,62 @@ static void simplifyAttributes(std::vector<float>& attrs, float* attrw, size_t s
 		}
 
 		attrw[3] = attrw[4] = attrw[5] = 1.0f;
+	}
+
+	if (const Stream* attr = getStream(mesh, cgltf_attribute_type_texcoord))
+	{
+		const Attr* a = attr->data.data();
+		for (size_t i = 0; i < vertex_count; ++i)
+		{
+			data[i * stride + 6] = a[i].f[0];
+			data[i * stride + 7] = a[i].f[1];
+		}
+		attrw[6] = attrw[7] = uv_weight;
+	}
+}
+
+static void simplifyUpdate(const std::vector<float>& attrs, size_t stride, Mesh& mesh)
+{
+	size_t vertex_count = mesh.streams[0].data.size();
+	const float* data = attrs.data();
+
+	if (Stream* attr = getStream(mesh, cgltf_attribute_type_normal))
+	{
+		Attr* a = attr->data.data();
+
+		for (size_t i = 0; i < vertex_count; ++i)
+		{
+			float nx = data[i * stride + 0], ny = data[i * stride + 1], nz = data[i * stride + 2];
+			float nl = sqrtf(nx * nx + ny * ny + nz * nz);
+			float ns = nl > 0.f ? 1.f / nl : 0.f;
+			a[i].f[0] = nx * ns;
+			a[i].f[1] = ny * ns;
+			a[i].f[2] = nz * ns;
+		}
+	}
+
+	if (Stream* attr = getStream(mesh, cgltf_attribute_type_color))
+	{
+		Attr* a = attr->data.data();
+
+		for (size_t i = 0; i < vertex_count; ++i)
+		{
+			float cs = a[i].f[3] > 0.f ? 1.f / a[i].f[3] : 0.f;
+			a[i].f[0] = std::max(0.f, std::min(1.f, data[i * stride + 3] * cs));
+			a[i].f[1] = std::max(0.f, std::min(1.f, data[i * stride + 4] * cs));
+			a[i].f[2] = std::max(0.f, std::min(1.f, data[i * stride + 5] * cs));
+		}
+	}
+
+	if (Stream* attr = getStream(mesh, cgltf_attribute_type_texcoord))
+	{
+		Attr* a = attr->data.data();
+
+		for (size_t i = 0; i < vertex_count; ++i)
+		{
+			a[i].f[0] = data[i * stride + 6];
+			a[i].f[1] = data[i * stride + 7];
+		}
 	}
 }
 
@@ -1012,14 +1068,14 @@ static void simplifyUvSplit(Mesh& mesh, std::vector<unsigned int>& remap)
 	}
 }
 
-static void simplifyMesh(Mesh& mesh, float threshold, float error, bool attributes, bool aggressive, bool lock_borders, bool permissive)
+static void simplifyMesh(Mesh& mesh, float threshold, float error, bool attributes, bool aggressive, bool lock_borders, bool permissive, bool update)
 {
 	assert(mesh.type == cgltf_primitive_type_triangles);
 
 	if (mesh.indices.empty())
 		return;
 
-	const Stream* positions = getStream(mesh, cgltf_attribute_type_position);
+	Stream* positions = getStream(mesh, cgltf_attribute_type_position);
 	if (!positions)
 		return;
 
@@ -1049,16 +1105,23 @@ static void simplifyMesh(Mesh& mesh, float threshold, float error, bool attribut
 
 	std::vector<unsigned int> indices(mesh.indices.size());
 
-	float attrw[6] = {};
+	float attrw[8] = {};
 	std::vector<float> attrs;
 	if (attributes)
-		simplifyAttributes(attrs, attrw, sizeof(attrw) / sizeof(attrw[0]), mesh);
+		simplifyAttributes(attrs, attrw, sizeof(attrw) / sizeof(attrw[0]), mesh, update ? 1.f : 0.f);
 
 	std::vector<unsigned char> locks;
 	if (attributes && permissive)
 		simplifyProtect(locks, mesh, presplit_vertices);
 
-	if (attributes)
+	if (attributes && update && !mesh.targets)
+	{
+		indices = mesh.indices;
+		indices.resize(meshopt_simplifyWithUpdate(&indices[0], indices.size(), positions->data[0].f, vertex_count, sizeof(Attr),
+		    attrs.data(), sizeof(attrw), attrw, sizeof(attrw) / sizeof(attrw[0]), permissive ? locks.data() : NULL, target_index_count, target_error, options));
+		simplifyUpdate(attrs, sizeof(attrw) / sizeof(attrw[0]), mesh);
+	}
+	else if (attributes)
 		indices.resize(meshopt_simplifyWithAttributes(&indices[0], &mesh.indices[0], mesh.indices.size(), positions->data[0].f, vertex_count, sizeof(Attr),
 		    attrs.data(), sizeof(attrw), attrw, sizeof(attrw) / sizeof(attrw[0]), permissive ? locks.data() : NULL, target_index_count, target_error, options));
 	else
@@ -1289,7 +1352,7 @@ void processMesh(Mesh& mesh, const Settings& settings)
 		if (settings.simplify_ratio < 1)
 		{
 			float error = settings.simplify_scaled ? settings.simplify_error / mesh.quality : settings.simplify_error;
-			simplifyMesh(mesh, settings.simplify_ratio, error, settings.simplify_attributes, settings.simplify_aggressive, settings.simplify_lock_borders, settings.simplify_permissive);
+			simplifyMesh(mesh, settings.simplify_ratio, error, settings.simplify_attributes, settings.simplify_aggressive, settings.simplify_lock_borders, settings.simplify_permissive, settings.simplify_update);
 		}
 
 		optimizeMesh(mesh, settings.compressmore);


### PR DESCRIPTION
When the option `-sv` is specified, we run position/attribute solve
(simplifyWithUpdate) which results in an improved appearance of the
mesh.

This is repurposing the old "simplify-with-attributes" switch that has
become defunct; the meaning is pretty adjacent - this improves appearance
by, in this case, updating the vertex data - so this probably works
better than a new option name.

For now we just apply this to normals, colors and UV0; meshes with multiple
UV sets or morph targets simplify as before (for multiple UV sets, position
update would need to update them too and it's easier to skip those for now;
for morph targets, a morph delta may or may not apply cleanly on the updated
position).

Note that for now we also use a one-shot simplification to the target count, instead
of following the recommended iterative simplification recipe. This might change in
the future; this does not matter much on reasonable simplification ratios (up to 0.1
perhaps), but does result in cleaner results for significant factors like 0.01 so might
be adjusted at some point under the existing option.

As part of this, legacy `-ssd` and `-svd` options were removed to keep code simpler.